### PR TITLE
NetworkParametersCreator: Create .ihmc config directory if it does not exist

### DIFF
--- a/IHMCCommunication/src/us/ihmc/communication/configuration/NetworkParametersCreator.java
+++ b/IHMCCommunication/src/us/ihmc/communication/configuration/NetworkParametersCreator.java
@@ -189,6 +189,8 @@ public class NetworkParametersCreator
    {
       try
       {
+         file.getParentFile().mkdirs();
+
          FileOutputStream out = new FileOutputStream(file);
          Properties properties = new Properties();
          for (NetworkParameterKeys key : NetworkParameterKeys.values())


### PR DESCRIPTION
Currently upon a fresh install on a new machine, one needs to manually run ``mkdir ~/.ihmc`` in order for the NetworkParametersCreator to succeed. This automatically creates the directory if it does not exist without showing a generic error message to the user.