### PR TITLE
Don't claim all sliders if not in tuning mode

### DIFF
--- a/DarpaRoboticsChallenge/src/us/ihmc/darpaRoboticsChallenge/visualization/WalkControllerSliderBoard.java
+++ b/DarpaRoboticsChallenge/src/us/ihmc/darpaRoboticsChallenge/visualization/WalkControllerSliderBoard.java
@@ -29,23 +29,30 @@ public class WalkControllerSliderBoard
       final EnumYoVariable<SliderBoardMode> sliderBoardMode = new EnumYoVariable<SliderBoardMode>("sliderBoardMode", registry, SliderBoardMode.class);
       final SliderBoardConfigurationManager sliderBoardConfigurationManager = new SliderBoardConfigurationManager(scs);
 
-      sliderBoardConfigurationManager.setSlider(1, "captureKpParallel", registry, 0.0, 2.0);
-      sliderBoardConfigurationManager.setKnob(1, "captureKpOrthogonal", registry, 0.0, 2.0);
-
-      sliderBoardConfigurationManager.setSlider(2, "kp_comHeight", registry, 0.0, 40.0);
-      sliderBoardConfigurationManager.setKnob(2, "kd_comHeight", registry, 0.0, 13.0);
-
-      sliderBoardConfigurationManager.setSlider(3, "kpPelvisOrientation", registry, 0.0, 100.0);
-      sliderBoardConfigurationManager.setKnob(3, "zetaPelvisOrientation", registry, 0.0, 1.0);
-
-      sliderBoardConfigurationManager.setSlider(4, "kpUpperBody", registry, 0.0, 200.0);
-      sliderBoardConfigurationManager.setKnob(4, "zetaUpperBody", registry, 0.0, 1.0);
-
-      sliderBoardConfigurationManager.setSlider(5, "kpAllArmJointsL", registry, 0.0, 120.0);
-      sliderBoardConfigurationManager.setKnob(5, "zetaAllArmJointsL", registry, 0.0, 1.0);
-
-      sliderBoardConfigurationManager.setSlider(6, "kpAllArmJointsR", registry, 0.0, 120.0);
-      sliderBoardConfigurationManager.setKnob(6, "zetaAllArmJointsR", registry, 0.0, 1.0);
+      // TODO: FIXME: This is a super rough, temporary fix for 
+      // https://github.com/ihmcrobotics/ihmc-open-robotics-software/issues/26 
+      boolean DEBUG_WITH_SLIDERBOARD = false;
+      if (DEBUG_WITH_SLIDERBOARD) {
+	      sliderBoardConfigurationManager.setSlider(1, "captureKpParallel", registry, 0.0, 2.0);
+	      sliderBoardConfigurationManager.setKnob(1, "captureKpOrthogonal", registry, 0.0, 2.0);
+	
+	      sliderBoardConfigurationManager.setSlider(2, "kp_comHeight", registry, 0.0, 40.0);
+	      sliderBoardConfigurationManager.setKnob(2, "kd_comHeight", registry, 0.0, 13.0);
+	
+	      sliderBoardConfigurationManager.setSlider(3, "kpPelvisOrientation", registry, 0.0, 100.0);
+	      sliderBoardConfigurationManager.setKnob(3, "zetaPelvisOrientation", registry, 0.0, 1.0);
+	
+	      sliderBoardConfigurationManager.setSlider(4, "kpUpperBody", registry, 0.0, 200.0);
+	      sliderBoardConfigurationManager.setKnob(4, "zetaUpperBody", registry, 0.0, 1.0);
+	
+	      sliderBoardConfigurationManager.setSlider(5, "kpAllArmJointsL", registry, 0.0, 120.0);
+	      sliderBoardConfigurationManager.setKnob(5, "zetaAllArmJointsL", registry, 0.0, 1.0);
+	
+	      sliderBoardConfigurationManager.setSlider(6, "kpAllArmJointsR", registry, 0.0, 120.0);
+	      sliderBoardConfigurationManager.setKnob(6, "zetaAllArmJointsR", registry, 0.0, 1.0);
+      } else {
+    	  System.out.println("Only claiming sliders 7 and 8 (for tuning change DEBUG_WITH_SLIDERBOARD to true in WalkControllerSliderBoard.java");
+      }
 
       sliderBoardConfigurationManager.setSlider(7, CommonNames.doIHMCControlRatio.toString(), registry, 0.0, 1.0);
 


### PR DESCRIPTION
This is a first temporary go at it - is there a global variable for tuning? The debug message should give a hint to the user to change the variable if tuning is desired and the sliders are mystically not claimed.

I've seen in other places that sliders might be claimed (e.g. ValkyrieSliderBoard) - is the code there active?

Addresses https://github.com/ihmcrobotics/ihmc-open-robotics-software/issues/26

cc: @dljsjr @SylvainBertrand 