### PR TITLE
Added missing message packet checking

### DIFF
--- a/IHMCHumanoidRobotics/src/us/ihmc/humanoidRobotics/communication/packets/walking/FootTrajectoryMessage.java
+++ b/IHMCHumanoidRobotics/src/us/ihmc/humanoidRobotics/communication/packets/walking/FootTrajectoryMessage.java
@@ -9,6 +9,7 @@ import us.ihmc.communication.ros.generators.RosExportedField;
 import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.packets.VisualizablePacket;
 import us.ihmc.humanoidRobotics.communication.packets.AbstractSE3TrajectoryMessage;
+import us.ihmc.humanoidRobotics.communication.packets.PacketValidityChecker;
 import us.ihmc.robotics.geometry.RigidBodyTransform;
 import us.ihmc.robotics.random.RandomTools;
 import us.ihmc.robotics.robotSide.RobotSide;
@@ -117,5 +118,12 @@ public class FootTrajectoryMessage extends AbstractSE3TrajectoryMessage<FootTraj
          ret = "Foot SE3 trajectory: no SE3 trajectory points";
 
       return ret + ", robotSide = " + robotSide + ".";
+   }
+   
+   /** {@inheritDoc} */
+   @Override
+   public String validateMessage()
+   {
+      return PacketValidityChecker.validateFootTrajectoryMessage(this);
    }
 }

--- a/IHMCHumanoidRobotics/src/us/ihmc/humanoidRobotics/communication/packets/walking/GoHomeMessage.java
+++ b/IHMCHumanoidRobotics/src/us/ihmc/humanoidRobotics/communication/packets/walking/GoHomeMessage.java
@@ -2,6 +2,7 @@ package us.ihmc.humanoidRobotics.communication.packets.walking;
 
 import us.ihmc.communication.ros.generators.RosEnumValueDocumentation;
 import us.ihmc.communication.ros.generators.RosMessagePacket;
+import us.ihmc.humanoidRobotics.communication.packets.PacketValidityChecker;
 import us.ihmc.communication.ros.generators.RosExportedField;
 import us.ihmc.communication.packets.Packet;
 import us.ihmc.robotics.random.RandomTools;
@@ -108,5 +109,12 @@ public class GoHomeMessage extends Packet<GoHomeMessage>
       if (robotSide != other.robotSide)
          return false;
       return true;
+   }
+   
+   /** {@inheritDoc} */
+   @Override
+   public String validateMessage()
+   {
+      return PacketValidityChecker.validateGoHomeMessage(this);
    }
 }

--- a/IHMCHumanoidRobotics/src/us/ihmc/humanoidRobotics/communication/packets/walking/PelvisOrientationTrajectoryMessage.java
+++ b/IHMCHumanoidRobotics/src/us/ihmc/humanoidRobotics/communication/packets/walking/PelvisOrientationTrajectoryMessage.java
@@ -7,6 +7,7 @@ import us.ihmc.communication.ros.generators.RosMessagePacket;
 import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.packets.VisualizablePacket;
 import us.ihmc.humanoidRobotics.communication.packets.AbstractSO3TrajectoryMessage;
+import us.ihmc.humanoidRobotics.communication.packets.PacketValidityChecker;
 import us.ihmc.robotics.geometry.RigidBodyTransform;
 
 import java.util.Random;
@@ -99,5 +100,12 @@ public class PelvisOrientationTrajectoryMessage extends AbstractSO3TrajectoryMes
          return "Pelvis SO3 trajectory: number of SO3 trajectory points = " + getNumberOfTrajectoryPoints();
       else
          return "Pelvis SO3 trajectory: no SO3 trajectory points";
+   }
+   
+   /** {@inheritDoc} */
+   @Override
+   public String validateMessage()
+   {
+      return PacketValidityChecker.validatePelvisOrientationTrajectoryMessage(this);
    }
 }

--- a/IHMCHumanoidRobotics/src/us/ihmc/humanoidRobotics/communication/packets/walking/PelvisTrajectoryMessage.java
+++ b/IHMCHumanoidRobotics/src/us/ihmc/humanoidRobotics/communication/packets/walking/PelvisTrajectoryMessage.java
@@ -8,6 +8,7 @@ import us.ihmc.communication.ros.generators.RosMessagePacket;
 import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.packets.VisualizablePacket;
 import us.ihmc.humanoidRobotics.communication.packets.AbstractSE3TrajectoryMessage;
+import us.ihmc.humanoidRobotics.communication.packets.PacketValidityChecker;
 import us.ihmc.robotics.geometry.RigidBodyTransform;
 
 import java.util.Random;
@@ -95,5 +96,12 @@ public class PelvisTrajectoryMessage extends AbstractSE3TrajectoryMessage<Pelvis
          return "Pelvis SE3 trajectory: number of SE3 trajectory points = " + getNumberOfTrajectoryPoints();
       else
          return "Pelvis SE3 trajectory: no SE3 trajectory points";
+   }
+   
+   /** {@inheritDoc} */
+   @Override
+   public String validateMessage()
+   {
+      return PacketValidityChecker.validatePelvisTrajectoryMessage(this);
    }
 }


### PR DESCRIPTION
FootTrajectoryMessage, GoHomeMessage, PelvisOrientationTrajectoryMessage and PelvisTrajectoryMessage don't check the packet validity although the packet checking routine exist for these messages.

In the case of PelvisTrajectoryMessage, NaN values get passed into the trajectory generator and crash the controller with an exception during execution.

This PR adds the checking routine into the respective message classes.