### PR TITLE
localization yaw correction bug fix

### DIFF
--- a/IHMCStateEstimation/src/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/ClippedSpeedOffsetErrorInterpolator.java
+++ b/IHMCStateEstimation/src/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/ClippedSpeedOffsetErrorInterpolator.java
@@ -386,9 +386,9 @@ public class ClippedSpeedOffsetErrorInterpolator
       
       offsetBetweenStartAndGoal_Rotation.setOrientationFromOneToTwo(updatedGoalOffset_Rotation, updatedStartOffset_Rotation);
       offsetBetweenStartAndGoal_Rotation.getYawPitchRoll(temporaryYawPitchRoll);
-      goalYawRaw.set(temporaryYawPitchRoll[0]);
+      goalYawRaw.set(updatedGoalOffset_Rotation_YawPitchRoll[0]);
       goalYawWithDeadZone.update();
-      RotationTools.convertYawPitchRollToQuaternion(updatedGoalOffset_Rotation_YawPitchRoll[0], temporaryYawPitchRoll[1], temporaryYawPitchRoll[2], updatedGoalOffsetWithDeadZone_Rotation_quat);
+      RotationTools.convertYawPitchRollToQuaternion(goalYawWithDeadZone.getDoubleValue(), temporaryYawPitchRoll[1], temporaryYawPitchRoll[2], updatedGoalOffsetWithDeadZone_Rotation_quat);
       updatedGoalOffsetWithDeadZone_Rotation.set(updatedGoalOffsetWithDeadZone_Rotation_quat);
       
       goalOffsetTransform_Rotation.setRotationAndZeroTranslation(updatedGoalOffsetWithDeadZone_Rotation_quat);

--- a/IHMCStateEstimation/src/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/ClippedSpeedOffsetErrorInterpolator.java
+++ b/IHMCStateEstimation/src/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/ClippedSpeedOffsetErrorInterpolator.java
@@ -125,6 +125,7 @@ public class ClippedSpeedOffsetErrorInterpolator
    
    double[] stateEstimatorYawPitchRoll = new double[3];
    double[] temporaryYawPitchRoll = new double[3];
+   double[] updatedGoalOffset_Rotation_YawPitchRoll = new double[3];
    private final DoubleYoVariable startYaw;
    private final DoubleYoVariable goalYaw;
    private final DoubleYoVariable interpolatedYaw;
@@ -381,12 +382,13 @@ public class ClippedSpeedOffsetErrorInterpolator
       goalOffsetErrorPose.getOrientationIncludingFrame(updatedGoalOffset_Rotation);
       
       startOffsetTransform_Rotation.setRotationAndZeroTranslation(updatedStartOffset_Rotation_quat);
+      updatedGoalOffset_Rotation.getYawPitchRoll(updatedGoalOffset_Rotation_YawPitchRoll);
       
       offsetBetweenStartAndGoal_Rotation.setOrientationFromOneToTwo(updatedGoalOffset_Rotation, updatedStartOffset_Rotation);
       offsetBetweenStartAndGoal_Rotation.getYawPitchRoll(temporaryYawPitchRoll);
       goalYawRaw.set(temporaryYawPitchRoll[0]);
       goalYawWithDeadZone.update();
-      RotationTools.convertYawPitchRollToQuaternion(goalYawWithDeadZone.getDoubleValue(), temporaryYawPitchRoll[1], temporaryYawPitchRoll[2], updatedGoalOffsetWithDeadZone_Rotation_quat);
+      RotationTools.convertYawPitchRollToQuaternion(updatedGoalOffset_Rotation_YawPitchRoll[0], temporaryYawPitchRoll[1], temporaryYawPitchRoll[2], updatedGoalOffsetWithDeadZone_Rotation_quat);
       updatedGoalOffsetWithDeadZone_Rotation.set(updatedGoalOffsetWithDeadZone_Rotation_quat);
       
       goalOffsetTransform_Rotation.setRotationAndZeroTranslation(updatedGoalOffsetWithDeadZone_Rotation_quat);

--- a/IHMCStateEstimation/src/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/NewPelvisPoseHistoryCorrection.java
+++ b/IHMCStateEstimation/src/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/NewPelvisPoseHistoryCorrection.java
@@ -32,7 +32,7 @@ public class NewPelvisPoseHistoryCorrection implements PelvisPoseHistoryCorrecti
    private static final boolean ENABLE_GRAPHICS = true;
    
    private static final ReferenceFrame worldFrame = ReferenceFrame.getWorldFrame();
-   private static final boolean ENABLE_ROTATION_CORRECTION = false;  
+   private static final boolean ENABLE_ROTATION_CORRECTION = true;
    
    private static final double DEFAULT_BREAK_FREQUENCY = 0.6;
 


### PR DESCRIPTION
@SylvainBertrand , @dljsjr  :  I think this fixes https://github.com/ihmcrobotics/ihmc-open-robotics-software/issues/67

After quite a lot of testing I saw that the corrected rotation being created in 
updateStartAndGoalOffsetErrorRotation was incorrect. It should have been the error correction the user wanted but it wasn't.

I made a python ROS script for ease of testing. Its really simple. It creates a correction in yaw (and x) and sends a ROS message to the IHMC controller:
[send_fake_pose_correction_ros.py.txt](https://github.com/ihmcrobotics/ihmc-open-robotics-software/files/478797/send_fake_pose_correction_ros.py.txt)

Here is me using it to "correct" the Pelvis pose a bunch of times.
https://www.dropbox.com/s/v327lqvvmgobjc5/2016-09-ihmc_localization_correction_script.m4v?dl=0

I recommend setting the deadzone values to zero (X_DEADZONE_SIZE, YAW_DEADZONE_SIZE etc) for testing.

To explain the video:
- We transmit a ROS message which becomes yoIterativeClosestPointPoseInWorldFrameGraphic.
  - yoIterativeClosestPointPoseInWorldFrameGraphic is a red frame with a red tip
- The class ClippedSpeedOffsetErrorInterpolator corrects the robot pose's (yoCorrectedPelvisPoseInWorldFrame) to that frame
  - yoCorrectedPelvisPoseInWorldFrame is a red frame with a yellow tip
- The ClippedSpeedOffsetErrorInterpolator should move the latter to be the position of the former

In addition:
- The first correction message doesn't do anything. I think it gets dropped by your ROS I/O system somewhere.
- there is a bug in DeadzoneYoVariable which I haven't look at. (that's why I disabled it with zeros)

FYI: @simalpha
