### PR TITLE
Support transparency values defined in SDF files

### DIFF
--- a/ModelFileLoader/src/us/ihmc/modelFileLoaders/SdfLoader/SDFGraphics3DObject.java
+++ b/ModelFileLoader/src/us/ihmc/modelFileLoaders/SdfLoader/SDFGraphics3DObject.java
@@ -14,6 +14,7 @@ import javax.vecmath.Vector3d;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
+import us.ihmc.graphicsDescription.appearance.YoAppearanceRGBColor;
 import us.ihmc.modelFileLoaders.ModelFileLoaderConversionsHelper;
 import us.ihmc.modelFileLoaders.SdfLoader.xmlDescription.AbstractSDFMesh;
 import us.ihmc.modelFileLoaders.SdfLoader.xmlDescription.SDFGeometry;
@@ -107,6 +108,16 @@ public class SDFGraphics3DObject extends LinkGraphicsDescription
 
                   appearance = mat;
                }
+            }
+
+            if (sdfVisual.getTransparency() != null)
+            {
+               // An appearance must exist in order to set a transparency value, whether a material was defined above or not.
+               if (appearance == null)
+               {
+                  appearance = new YoAppearanceRGBColor(DEFAULT_APPEARANCE.getColor(), 0.0);
+               }
+               appearance.setTransparency(Double.parseDouble(sdfVisual.getTransparency()));
             }
 
             SDFGeometry geometry = sdfVisual.getGeometry();

--- a/ModelFileLoader/src/us/ihmc/modelFileLoaders/SdfLoader/xmlDescription/AbstractSDFMesh.java
+++ b/ModelFileLoader/src/us/ihmc/modelFileLoaders/SdfLoader/xmlDescription/AbstractSDFMesh.java
@@ -8,4 +8,5 @@ public interface AbstractSDFMesh
    public SDFGeometry getGeometry();
    public String getPose();
    public SDFMaterial getMaterial();
+   public String getTransparency();
 }

--- a/ModelFileLoader/src/us/ihmc/modelFileLoaders/SdfLoader/xmlDescription/Collision.java
+++ b/ModelFileLoader/src/us/ihmc/modelFileLoaders/SdfLoader/xmlDescription/Collision.java
@@ -132,6 +132,10 @@ public class Collision implements AbstractSDFMesh
    {
       return null;
    }
-   
 
+   @Override
+   public String getTransparency()
+   {
+      return null;
+   }
 }


### PR DESCRIPTION
This PR adds support for `transparency` tags in SDF visual elements.

There is one potential issue with this implementation. If a transparency is defined in an SDF but a material is not, then an appearance must be assigned to the graphic object in order to set its transparency. This implementation then sets the appearance to the `DEFAULT_APPEARANCE` defined in SDFGraphics3DObject. This has the downside of turning any visual elements defining a transparency but not a material orange. I think this is consistent with the default behavior for handling STL files, which do not define appearances.