### PR TITLE
detuned gains using the joystick branch  parameters.

### DIFF
--- a/valkyrie/src/main/java/us/ihmc/valkyrie/parameters/ValkyrieMomentumOptimizationSettings.java
+++ b/valkyrie/src/main/java/us/ihmc/valkyrie/parameters/ValkyrieMomentumOptimizationSettings.java
@@ -36,7 +36,7 @@ public class ValkyrieMomentumOptimizationSettings extends MomentumOptimizationSe
    private final double jointJerkWeight = 1.6E-6;
    private final double rhoWeight = 0.00001;
    private final double rhoMin = 4.0;
-   private final double rhoRateDefaultWeight = 5E-8;
+   private final double rhoRateDefaultWeight = 3.2E-8; //5E-8;
    private final double rhoRateHighWeight = 8.0E-7;
    private final Vector2D copWeight = new Vector2D(0.001, 0.002);
    private final Vector2D copRateDefaultWeight = new Vector2D(0.0000032, 0.0000032);

--- a/valkyrie/src/main/java/us/ihmc/valkyrie/parameters/ValkyrieStateEstimatorParameters.java
+++ b/valkyrie/src/main/java/us/ihmc/valkyrie/parameters/ValkyrieStateEstimatorParameters.java
@@ -90,24 +90,24 @@ public class ValkyrieStateEstimatorParameters extends StateEstimatorParameters
       armJointPositionFilterFrequencyHz = Double.POSITIVE_INFINITY;
       jointOutputEncoderVelocityFilterFrequencyHz = runningOnRealRobot ? 20.0 : Double.POSITIVE_INFINITY;
       lowerBodyJointPositionFilterFrequencyHz = Double.POSITIVE_INFINITY;
-      lowerBodyJointVelocityFilterFrequencyHz = runningOnRealRobot ? 50.0 : Double.POSITIVE_INFINITY;
+      lowerBodyJointVelocityFilterFrequencyHz = runningOnRealRobot ? 25.0 : Double.POSITIVE_INFINITY;
       fingerPositionFilterFrequencyHz = runningOnRealRobot ? 2.5 : Double.POSITIVE_INFINITY;
 
       // Somehow it's less shaky when these are low especially when pitching the chest forward. I still don't quite get it. Sylvain
       // Update (2018-09-12): Tried 50Hz for IMU filters, it looks like 25Hz reduces shakies in single support while using 50Hz for joint filters.
-      orientationFilterFrequencyHz = runningOnRealRobot ? Double.POSITIVE_INFINITY : Double.POSITIVE_INFINITY;
-      angularVelocityFilterFrequencyHz = runningOnRealRobot ? 40.0 : Double.POSITIVE_INFINITY;
-      linearAccelerationFilterFrequencyHz = runningOnRealRobot ? 40.0 : Double.POSITIVE_INFINITY;
-
-      lowerBodyJointVelocityBacklashSlopTime = 0.0;
-      armJointVelocityBacklashSlopTime = 0.0;
+      orientationFilterFrequencyHz = runningOnRealRobot ? 25.0 : Double.POSITIVE_INFINITY;
+      angularVelocityFilterFrequencyHz = runningOnRealRobot ? 25.0 : Double.POSITIVE_INFINITY;
+      linearAccelerationFilterFrequencyHz = runningOnRealRobot ? 10.0 : Double.POSITIVE_INFINITY;
+      
+      lowerBodyJointVelocityBacklashSlopTime = 0.03;
+      armJointVelocityBacklashSlopTime = 0.03;
 
       doElasticityCompensation = runningOnRealRobot;
       jointElasticityFilterFrequencyHz = 20.0;
       maximumDeflection = 0.10;
       defaultJointStiffness = 10000.0;
       for (RobotSide robotSide : RobotSide.values)
-         jointSpecificStiffness.put(jointMap.getLegJointName(robotSide, LegJointName.HIP_ROLL), 9500.0);
+         jointSpecificStiffness.put(jointMap.getLegJointName(robotSide, LegJointName.HIP_ROLL), 8000.0);
 
       kinematicsPelvisPositionFilterFreqInHertz = Double.POSITIVE_INFINITY;
    }
@@ -300,7 +300,8 @@ public class ValkyrieStateEstimatorParameters extends StateEstimatorParameters
    @Override
    public double getIMUJointVelocityEstimationBacklashSlopTime()
    {
-      return 0.0;
+	   //return 0.0;
+	   return lowerBodyJointVelocityBacklashSlopTime;
    }
 
    @Override

--- a/valkyrie/src/main/java/us/ihmc/valkyrie/parameters/ValkyrieWalkingControllerParameters.java
+++ b/valkyrie/src/main/java/us/ihmc/valkyrie/parameters/ValkyrieWalkingControllerParameters.java
@@ -314,12 +314,12 @@ public class ValkyrieWalkingControllerParameters extends WalkingControllerParame
    {
       boolean runningOnRealRobot = target == RobotTarget.REAL_ROBOT;
 
-      double kpXY = runningOnRealRobot ? 120.0 : 100.0; // Was 100.0 before tuneup of sep 2018
-      double kpZ = runningOnRealRobot ? 120.0 : 100.0; // Was 80.0 before tuneup of sep 2018
-      double zetaXY = runningOnRealRobot ? 1.0 : 0.8; // Was 0.9 before tuneup of sep 2018
-      double zetaZ = runningOnRealRobot ? 1.0 : 0.8;
-      double maxAccel = runningOnRealRobot ? 100.0 : 18.0; // Was 18.0 before tuneup of sep 2018
-      double maxJerk = runningOnRealRobot ? 1500.0 : 270.0; // Was 270.0 before tuneup of sep 2018
+      double kpXY = runningOnRealRobot ? 90.0 : 100.0; // Was 100.0 before tuneup of sep 2018
+      double kpZ = runningOnRealRobot ? 80.0 : 100.0; // Was 80.0 before tuneup of sep 2018
+      double zetaXY = runningOnRealRobot ? 0.8 : 0.8; // Was 0.9 before tuneup of sep 2018
+      double zetaZ = runningOnRealRobot ? 0.8 : 0.8;
+      double maxAccel = runningOnRealRobot ? 18.0 : 18.0; // Was 18.0 before tuneup of sep 2018
+      double maxJerk = runningOnRealRobot ? 270.0 : 270.0; // Was 270.0 before tuneup of sep 2018
 
       DefaultPID3DGains gains = new DefaultPID3DGains();
       gains.setProportionalGains(kpXY, kpXY, kpZ);
@@ -351,10 +351,10 @@ public class ValkyrieWalkingControllerParameters extends WalkingControllerParame
    {
       boolean runningOnRealRobot = target == RobotTarget.REAL_ROBOT;
 
-      double kpXY = runningOnRealRobot ? 100.0 : 100.0; // Was 80.0 before tuneup of sep 2018
-      double kpZ = runningOnRealRobot ? 100.0 : 100.0; // Was 60.0 before tuneup of sep 2018
-      double zetaXY = runningOnRealRobot ? 1.0 : 0.8; // Was 0.8 before tuneup of sep 2018
-      double zetaZ = runningOnRealRobot ? 1.0 : 0.8; // Was 0.8 before tuneup of sep 2018
+      double kpXY = runningOnRealRobot ? 80.0 : 100.0; // Was 80.0 before tuneup of sep 2018
+      double kpZ = runningOnRealRobot ? 60.0 : 100.0; // Was 60.0 before tuneup of sep 2018
+      double zetaXY = runningOnRealRobot ? 0.8 : 0.8; // Was 0.8 before tuneup of sep 2018
+      double zetaZ = runningOnRealRobot ? 0.8 : 0.8; // Was 0.8 before tuneup of sep 2018
       double maxAccel = runningOnRealRobot ? 12.0 : 18.0;
       double maxJerk = runningOnRealRobot ? 360.0 : 270.0;
 
@@ -473,19 +473,19 @@ public class ValkyrieWalkingControllerParameters extends WalkingControllerParame
       boolean runningOnRealRobot = target == RobotTarget.REAL_ROBOT;
 
       double kpX = 120.0; // Was 150.0 before tuneup of sep 2018
-      double kpY = 120.0; // Was 100.0 before tuneup of sep 2018
-      double kpZ = runningOnRealRobot ? 250.0 : 200.0;  // Was 200.0 before tuneup of sep 2018
+      double kpY = 100.0; // Was 100.0 before tuneup of sep 2018
+      double kpZ = runningOnRealRobot ? 200.0 : 200.0;  // Was 200.0 before tuneup of sep 2018
       // zeta was [0.8, 0.5, 0.8] before tuneup of sep 2018
       double zetaXY = runningOnRealRobot ? 0.8 : 0.7;
-      double zetaZ = runningOnRealRobot ? 1.0 : 0.7;
+      double zetaZ = runningOnRealRobot ? 0.8 : 0.7;
       double kpXYOrientation = runningOnRealRobot ? 300.0 : 300.0;
       double kpZOrientation = runningOnRealRobot ? 150.0 : 200.0; // 160
-      double zetaOrientationXY = runningOnRealRobot ? 0.8 : 0.7; // Was 0.7 before tuneup of sep 2018
-      double zetaOrientationZ = runningOnRealRobot ? 0.8 : 0.7; // Was 0.5 before tuneup of sep 2018
+      double zetaOrientationXY = runningOnRealRobot ? 0.7 : 0.7; // Was 0.7 before tuneup of sep 2018
+      double zetaOrientationZ = runningOnRealRobot ? 0.5 : 0.7; // Was 0.5 before tuneup of sep 2018
       double maxLinearAcceleration = runningOnRealRobot ? 10.0 : Double.POSITIVE_INFINITY;
       double maxLinearJerk = runningOnRealRobot ? 250.0 : Double.POSITIVE_INFINITY;
-      double maxAngularAcceleration = runningOnRealRobot ? 200.0 : Double.POSITIVE_INFINITY;
-      double maxAngularJerk = runningOnRealRobot ? 3000.0 : Double.POSITIVE_INFINITY;
+      double maxAngularAcceleration = runningOnRealRobot ? 100.0 : Double.POSITIVE_INFINITY;
+      double maxAngularJerk = runningOnRealRobot ? 1500.0 : Double.POSITIVE_INFINITY;
 
       DefaultPIDSE3Gains gains = new DefaultPIDSE3Gains();
       gains.setPositionProportionalGains(kpX, kpY, kpZ);


### PR DESCRIPTION
Using the controller branch parameters with the commit hash `30076df711f472ef79bcdac72a642884ad063677` , we detuned gains on Unit A which reduced robot shaking and enabled robot walking. Unit A is also much more stable during double support after external disturbances.

However, we still have issues with entering right leg single support form double support, but entering left leg single support is just fine.