### PR TITLE
Make Scene Graph Node IDs Thread Safe

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/SceneGraph.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/SceneGraph.java
@@ -4,7 +4,6 @@ import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.TLongObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.map.hash.TLongObjectHashMap;
-import org.apache.commons.lang3.mutable.MutableLong;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.perception.filters.DetectionFilterCollection;
 import us.ihmc.perception.sceneGraph.arUco.ArUcoMarkerNode;
@@ -24,6 +23,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.SortedSet;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
@@ -42,7 +42,7 @@ public class SceneGraph
    public static long ROOT_NODE_ID = 0;
    public static String ROOT_NODE_NAME = "SceneGraphRoot";
 
-   private final MutableLong nextID = new MutableLong(1); // Starts at 1 because root node is passed in
+   private final AtomicLong nextID = new AtomicLong(1); // Starts at 1 because root node is passed in
    private final SceneNode rootNode;
    private final Queue<SceneGraphTreeModification> queuedModifications = new LinkedList<>();
    private final DetectionFilterCollection detectionFilterCollection = new DetectionFilterCollection();
@@ -164,7 +164,7 @@ public class SceneGraph
       return rootNode;
    }
 
-   public MutableLong getNextID()
+   public AtomicLong getNextID()
    {
       return nextID;
    }

--- a/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/ros2/ROS2SceneGraphSubscription.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/ros2/ROS2SceneGraphSubscription.java
@@ -108,7 +108,7 @@ public class ROS2SceneGraphSubscription
             checkTreeModified(sceneGraph.getRootNode());
 
             if (!localTreeFrozen)
-               sceneGraph.getNextID().setValue(sceneGraphMessage.getNextId());
+               sceneGraph.getNextID().set(sceneGraphMessage.getNextId());
 
             sceneGraph.modifyTree(modificationQueue ->
             {

--- a/ihmc-perception/src/test/java/us/ihmc/perception/sceneGraph/SceneGraphTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/sceneGraph/SceneGraphTest.java
@@ -17,7 +17,7 @@ public class SceneGraphTest
 
       Assertions.assertEquals(0, sceneGraph.getRootNode().getChildren().size());
 
-      Assertions.assertEquals(1, sceneGraph.getNextID().getValue());
+      Assertions.assertEquals(1, sceneGraph.getNextID().get());
       Assertions.assertEquals(1, sceneGraph.getIDToNodeMap().size());
       Assertions.assertEquals(1, sceneGraph.getNodeNameList().size());
       Assertions.assertEquals(1, sceneGraph.getNamesToNodesMap().size());
@@ -31,7 +31,7 @@ public class SceneGraphTest
 
       Assertions.assertEquals(1, sceneGraph.getRootNode().getChildren().size());
 
-      Assertions.assertEquals(2, sceneGraph.getNextID().getValue());
+      Assertions.assertEquals(2, sceneGraph.getNextID().get());
       Assertions.assertEquals(2, sceneGraph.getIDToNodeMap().size());
       Assertions.assertEquals(2, sceneGraph.getNodeNameList().size());
       Assertions.assertEquals(2, sceneGraph.getNamesToNodesMap().size());
@@ -48,7 +48,7 @@ public class SceneGraphTest
       Assertions.assertEquals(2, sceneGraph.getRootNode().getChildren().size());
       Assertions.assertEquals(1, child1.getChildren().size());
 
-      Assertions.assertEquals(4, sceneGraph.getNextID().getValue());
+      Assertions.assertEquals(4, sceneGraph.getNextID().get());
       Assertions.assertEquals(4, sceneGraph.getIDToNodeMap().size());
       Assertions.assertEquals(4, sceneGraph.getNodeNameList().size());
       Assertions.assertEquals(4, sceneGraph.getNamesToNodesMap().size());

--- a/ihmc-perception/src/test/java/us/ihmc/perception/sceneGraph/ros2/ROS2SceneGraphTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/sceneGraph/ros2/ROS2SceneGraphTest.java
@@ -58,7 +58,7 @@ public class ROS2SceneGraphTest
       Assertions.assertEquals("Child1Child0", subscriptionChild1Child0.getName());
       Assertions.assertEquals(0, subscriptionChild1Child0.getChildren().size());
 
-      Assertions.assertEquals(4, subscriptionSceneGraph.getNextID().getValue());
+      Assertions.assertEquals(4, subscriptionSceneGraph.getNextID().get());
       Assertions.assertEquals(4, subscriptionSceneGraph.getIDToNodeMap().size());
       Assertions.assertEquals(4, subscriptionSceneGraph.getNodeNameList().size());
       Assertions.assertEquals(4, subscriptionSceneGraph.getNamesToNodesMap().size());


### PR DESCRIPTION
I plan on creating YOLO nodes in one thread, then adding them to the scene graph in the scene graph update loop. This requires getting new node IDs outside the scene graph update thread, so I thought it'd be good to make the node IDs thread safe. What do we think? 