### PR TITLE
Feature/turn walk turn

### DIFF
--- a/ihmc-footstep-planning/src/main/java/us/ihmc/footstepPlanning/simplePlanners/FlatGroundPlanningUtils.java
+++ b/ihmc-footstep-planning/src/main/java/us/ihmc/footstepPlanning/simplePlanners/FlatGroundPlanningUtils.java
@@ -5,10 +5,11 @@ import java.util.List;
 
 import us.ihmc.euclid.referenceFrame.FramePose2D;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
+import us.ihmc.euclid.referenceFrame.interfaces.FramePose2DReadOnly;
 
 public class FlatGroundPlanningUtils
 {
-   public static FramePose3D poseFormPose2d(FramePose2D pose2d)
+   public static FramePose3D poseFormPose2d(FramePose2DReadOnly pose2d)
    {
       FramePose3D pose = new FramePose3D(pose2d.getReferenceFrame());
       pose.getOrientation().setYawPitchRoll(pose2d.getYaw(), 0.0, 0.0);
@@ -17,7 +18,7 @@ public class FlatGroundPlanningUtils
       return pose;
    }
 
-   public static FramePose3D poseFormPose2d(FramePose2D pose2d, double z)
+   public static FramePose3D poseFormPose2d(FramePose2DReadOnly pose2d, double z)
    {
       FramePose3D pose = poseFormPose2d(pose2d);
       pose.setZ(z);

--- a/ihmc-footstep-planning/src/main/java/us/ihmc/footstepPlanning/simplePlanners/FlatGroundPlanningUtils.java
+++ b/ihmc-footstep-planning/src/main/java/us/ihmc/footstepPlanning/simplePlanners/FlatGroundPlanningUtils.java
@@ -6,15 +6,14 @@ import java.util.List;
 import us.ihmc.euclid.referenceFrame.FramePose2D;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.interfaces.FramePose2DReadOnly;
+import us.ihmc.euclid.referenceFrame.interfaces.FramePose3DReadOnly;
 
 public class FlatGroundPlanningUtils
 {
    public static FramePose3D poseFormPose2d(FramePose2DReadOnly pose2d)
    {
-      FramePose3D pose = new FramePose3D(pose2d.getReferenceFrame());
-      pose.getOrientation().setYawPitchRoll(pose2d.getYaw(), 0.0, 0.0);
-      pose.setX(pose2d.getX());
-      pose.setY(pose2d.getY());
+      FramePose3D pose = new FramePose3D();
+      pose.setIncludingFrame(pose2d);
       return pose;
    }
 
@@ -23,15 +22,6 @@ public class FlatGroundPlanningUtils
       FramePose3D pose = poseFormPose2d(pose2d);
       pose.setZ(z);
       return pose;
-   }
-
-   public static FramePose2D pose2dFormPose(FramePose3D pose)
-   {
-      FramePose2D pose2d = new FramePose2D(pose.getReferenceFrame());
-      pose2d.setYaw(pose.getYaw());
-      pose2d.setX(pose.getX());
-      pose2d.setY(pose.getY());
-      return pose2d;
    }
 
    public static List<FramePose3D> poseListFromPoseList2d(List<FramePose2D> pose2dList)
@@ -54,7 +44,7 @@ public class FlatGroundPlanningUtils
    {
       ArrayList<FramePose2D> pose2dList = new ArrayList<>();
       for (FramePose3D pose : poseList)
-         pose2dList.add(pose2dFormPose(pose));
+         pose2dList.add(new FramePose2D(pose));
       return pose2dList;
    }
 }

--- a/ihmc-footstep-planning/src/main/java/us/ihmc/footstepPlanning/simplePlanners/PlanThenSnapPlanner.java
+++ b/ihmc-footstep-planning/src/main/java/us/ihmc/footstepPlanning/simplePlanners/PlanThenSnapPlanner.java
@@ -58,7 +58,7 @@ public class PlanThenSnapPlanner
       FootstepPlanningResult result = turnWalkTurnPlanner.plan();
       footstepPlan = turnWalkTurnPlanner.getPlan();
 
-      if (internalEnvironmentHandler.hasHeightMap())
+      if (!internalEnvironmentHandler.hasHeightMap())
          return result;
 
       int numberOfFootsteps = footstepPlan.getNumberOfSteps();

--- a/ihmc-footstep-planning/src/main/java/us/ihmc/footstepPlanning/simplePlanners/TurnWalkTurnPlanner.java
+++ b/ihmc-footstep-planning/src/main/java/us/ihmc/footstepPlanning/simplePlanners/TurnWalkTurnPlanner.java
@@ -141,15 +141,15 @@ public class TurnWalkTurnPlanner
       return FootstepPlanningResult.FOUND_SOLUTION;
    }
 
-   private void addSquareUp(List<FramePose2DReadOnly> footstepListToPack, FramePoint2D robotPosition)
+   private void addSquareUp(List<FramePose2DReadOnly> footstepListToPack, FramePoint2DReadOnly robotPosition)
    {
-      robotPosition.changeFrame(planStanceFootFrame);
-      if (Math.abs(robotPosition.getX()) > 0.001)
+      FramePoint2D positionInStance = new FramePoint2D(robotPosition);
+      positionInStance.changeFrame(planStanceFootFrame);
+      if (Math.abs(positionInStance.getX()) > 0.001)
          throw new RuntimeException("Can not square up for given position.");
 
-      robotPosition.changeFrame(planStanceFootFrame);
       FramePose2D footstepPose = new FramePose2D(planStanceFootFrame);
-      footstepPose.setY(2.0 * robotPosition.getY());
+      footstepPose.setY(2.0 * positionInStance.getY());
 
       if (lastStepSide.equals(RobotSide.LEFT) && footstepPose.getY() > 0)
          throw new RuntimeException("Left foot can not be placed on right side of right foot");

--- a/ihmc-footstep-planning/src/test/java/us/ihmc/footstepPlanning/simplePlanners/TurnWalkTurnPlannerTest.java
+++ b/ihmc-footstep-planning/src/test/java/us/ihmc/footstepPlanning/simplePlanners/TurnWalkTurnPlannerTest.java
@@ -1,0 +1,161 @@
+package us.ihmc.footstepPlanning.simplePlanners;
+
+import org.junit.jupiter.api.Test;
+import us.ihmc.euclid.referenceFrame.FramePose3D;
+import us.ihmc.footstepPlanning.FootstepPlan;
+import us.ihmc.footstepPlanning.graphSearch.parameters.DefaultFootstepPlannerParameters;
+import us.ihmc.footstepPlanning.graphSearch.parameters.DefaultFootstepPlannerParametersReadOnly;
+import us.ihmc.robotics.geometry.AngleTools;
+import us.ihmc.robotics.robotSide.RobotSide;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class TurnWalkTurnPlannerTest
+{
+   @Test
+   public void testWalking45Degrees()
+   {
+      DefaultFootstepPlannerParametersReadOnly parameters = new DefaultFootstepPlannerParameters();
+      TurnWalkTurnPlanner planner = new TurnWalkTurnPlanner(parameters);
+
+      FramePose3D startPoseRight = new FramePose3D();
+      FramePose3D startPoseLeft = new FramePose3D();
+      startPoseRight.setY(-parameters.getIdealFootstepWidth() / 2.0);
+      startPoseLeft.setY(parameters.getIdealFootstepWidth() / 2.0);
+
+      {
+         planner.setInitialStanceFoot(startPoseRight, RobotSide.RIGHT);
+
+         FramePose3D goalPose = new FramePose3D();
+         goalPose.getPosition().set(1.5, 1.5, 0.0);
+
+         planner.setGoal(goalPose);
+
+         planner.plan();
+
+         FootstepPlan plan = planner.getPlan();
+
+         // first step is the left side
+         RobotSide expectedStepSide = RobotSide.LEFT;
+         int stepIdx = 0;
+         // we know the heading is 45 degrees. We're turning to that position now
+         while (true)
+         {
+            assertEquals(expectedStepSide, plan.getFootstep(stepIdx).getRobotSide());
+
+            // make sure we've turned CCW
+            assertTrue(plan.getFootstep(stepIdx).getFootstepPose().getYaw() > 0.0);
+            // make sure each step is turning more CCW
+            if (stepIdx > 0)
+            {
+               assertTrue(plan.getFootstep(stepIdx).getFootstepPose().getYaw() > plan.getFootstep(stepIdx - 1).getFootstepPose().getYaw());
+            }
+
+            // once we've achieved the desired angle, stop turning
+            if (plan.getFootstep(stepIdx).getFootstepPose().getYaw() > Math.toRadians(45.0) - 1e-5)
+               break;
+
+            expectedStepSide = expectedStepSide.getOppositeSide();
+            stepIdx++;
+         }
+
+         // do the steps walking straight
+         int forwardSteps = (int) Math.ceil(goalPose.getPosition().distanceFromOrigin() / parameters.getIdealFootstepLength());
+         for (; stepIdx <= forwardSteps + 1; stepIdx++)
+         {
+            assertEquals(expectedStepSide, plan.getFootstep(stepIdx).getRobotSide());
+            assertEquals(plan.getFootstep(stepIdx).getFootstepPose().getYaw(), Math.toRadians(45.0), 1e-5);
+            expectedStepSide = expectedStepSide.getOppositeSide();
+         }
+
+         // we know the heading is 45 degrees. We're turning back from that position now
+         while (true)
+         {
+            assertEquals(expectedStepSide, plan.getFootstep(stepIdx).getRobotSide());
+
+            // make sure we've turned CCW
+            assertTrue(plan.getFootstep(stepIdx).getFootstepPose().getYaw() < Math.toRadians(45.0));
+            // make sure each step is turning more CCW
+            if (stepIdx > 0)
+            {
+               assertTrue(plan.getFootstep(stepIdx).getFootstepPose().getYaw() < plan.getFootstep(stepIdx - 1).getFootstepPose().getYaw());
+            }
+
+            // once we've achieved the zero angle, stop turning
+            if (plan.getFootstep(stepIdx).getFootstepPose().getYaw() < 1e-5)
+               break;
+
+            stepIdx++;
+            expectedStepSide = expectedStepSide.getOppositeSide();
+         }
+      }
+
+      {
+         planner.setInitialStanceFoot(startPoseLeft, RobotSide.LEFT);
+
+         FramePose3D goalPose = new FramePose3D();
+         goalPose.getPosition().set(1.5, 1.5, 0.0);
+
+         planner.setGoal(goalPose);
+
+         planner.plan();
+
+         FootstepPlan plan = planner.getPlan();
+
+         // first step is the left side
+         RobotSide expectedStepSide = RobotSide.RIGHT;
+         int stepIdx = 0;
+         // we know the heading is 45 degrees. We're turning to that position now
+         while (true)
+         {
+            assertEquals(expectedStepSide, plan.getFootstep(stepIdx).getRobotSide());
+
+            // make sure we've turned CCW
+            assertTrue(plan.getFootstep(stepIdx).getFootstepPose().getYaw() > 0.0);
+            // make sure each step is turning more CCW
+            if (stepIdx > 0)
+            {
+               assertTrue(plan.getFootstep(stepIdx).getFootstepPose().getYaw() > plan.getFootstep(stepIdx - 1).getFootstepPose().getYaw());
+            }
+
+            // once we've achieved the desired angle, stop turning
+            if (plan.getFootstep(stepIdx).getFootstepPose().getYaw() > Math.toRadians(45.0) - 1e-5)
+               break;
+
+            expectedStepSide = expectedStepSide.getOppositeSide();
+            stepIdx++;
+         }
+
+         // do the steps walking straight
+         int forwardSteps = (int) Math.ceil(goalPose.getPosition().distanceFromOrigin() / parameters.getIdealFootstepLength());
+         for (; stepIdx <= forwardSteps + 1; stepIdx++)
+         {
+            assertEquals(expectedStepSide, plan.getFootstep(stepIdx).getRobotSide());
+            assertEquals(plan.getFootstep(stepIdx).getFootstepPose().getYaw(), Math.toRadians(45.0), 1e-5);
+            expectedStepSide = expectedStepSide.getOppositeSide();
+         }
+
+         // we know the heading is 45 degrees. We're turning back from that position now
+         while (true)
+         {
+            assertEquals(expectedStepSide, plan.getFootstep(stepIdx).getRobotSide());
+
+            // make sure we've turned CCW
+            assertTrue(plan.getFootstep(stepIdx).getFootstepPose().getYaw() < Math.toRadians(45.0));
+            // make sure each step is turning more CCW
+            if (stepIdx > 0)
+            {
+               assertTrue(plan.getFootstep(stepIdx).getFootstepPose().getYaw() < plan.getFootstep(stepIdx - 1).getFootstepPose().getYaw());
+            }
+
+            // once we've achieved the zero angle, stop turning
+            if (plan.getFootstep(stepIdx).getFootstepPose().getYaw() < 1e-5)
+               break;
+
+            stepIdx++;
+            expectedStepSide = expectedStepSide.getOppositeSide();
+         }
+      }
+   }
+
+}

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/ImGuiStoredPropertySetDoubleWidget.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/ImGuiStoredPropertySetDoubleWidget.java
@@ -49,6 +49,26 @@ public class ImGuiStoredPropertySetDoubleWidget implements ImGuiStoredPropertySe
       imDoubleWrapper = new ImDoubleWrapper(storedPropertySet, key, this::renderSliderWithMinMax);
    }
 
+
+   public ImGuiStoredPropertySetDoubleWidget(StoredPropertySetBasics storedPropertySet,
+                                             DoubleStoredPropertyKey key,
+                                             String format,
+                                             String unitString,
+                                             double min,
+                                             double max,
+                                             Runnable onParametersUpdatedCallback)
+   {
+      this.key = key;
+      this.min = min;
+      this.max = max;
+      this.onParametersUpdatedCallback = onParametersUpdatedCallback;
+      this.format = format;
+      this.unitString = unitString;
+      label = labels.get(unitString, key.getTitleCasedName());
+      fancyPrefixLabel = key.getTitleCasedName() + ":";
+      imDoubleWrapper = new ImDoubleWrapper(storedPropertySet, key, this::renderSliderWithMinMaxAndFormatFancy);
+   }
+
    public ImGuiStoredPropertySetDoubleWidget(StoredPropertySetBasics storedPropertySet,
                                              DoubleStoredPropertyKey key,
                                              double step,

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/RDXStoredPropertySetTuner.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/RDXStoredPropertySetTuner.java
@@ -173,6 +173,11 @@ public class RDXStoredPropertySetTuner extends RDXPanel
       return new ImGuiStoredPropertySetDoubleWidget(storedPropertySet, key, min, max, onParametersUpdatedCallback);
    }
 
+   public ImGuiStoredPropertySetDoubleWidget createDoubleSlider(DoubleStoredPropertyKey key, String unitString, double min, double max, String format)
+   {
+      return new ImGuiStoredPropertySetDoubleWidget(storedPropertySet, key, format, unitString, min, max, onParametersUpdatedCallback);
+   }
+
    public ImGuiStoredPropertySetBooleanWidget createBooleanCheckbox(BooleanStoredPropertyKey key)
    {
       return new ImGuiStoredPropertySetBooleanWidget(storedPropertySet, key, onParametersUpdatedCallback);

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
@@ -123,7 +123,8 @@ public class RDXLocomotionManager
       footstepPlanning = new RDXFootstepPlanning(robotModel,
                                                  syncedRobot,
                                                  controllerStatusTracker,
-                                                 locomotionParameters, footstepPlannerParametersToUse,
+                                                 locomotionParameters,
+                                                 footstepPlannerParametersToUse,
                                                  bodyPathPlannerParameters,
                                                  swingFootPlannerParameters);
       interactableFootstepPlan = new RDXInteractableFootstepPlan(controllerStatusTracker);

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
@@ -20,6 +20,7 @@ import us.ihmc.footstepPlanning.graphSearch.parameters.FootstepPlannerParameters
 import us.ihmc.footstepPlanning.graphSearch.parameters.DefaultFootstepPlannerParametersBasics;
 import us.ihmc.footstepPlanning.graphSearch.parameters.InitialStanceSide;
 import us.ihmc.footstepPlanning.swing.SwingPlannerParametersBasics;
+import us.ihmc.rdx.imgui.ImGuiSliderDouble;
 import us.ihmc.rdx.imgui.ImGuiTools;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
 import us.ihmc.rdx.imgui.RDXPanel;
@@ -69,8 +70,8 @@ public class RDXLocomotionManager
    private ImGuiStoredPropertySetBooleanWidget replanSwingTrajectoriesOnChangeCheckbox;
    private ImGuiStoredPropertySetDoubleWidget swingTimeSlider;
    private ImGuiStoredPropertySetDoubleWidget transferTimeSlider;
-   private ImGuiStoredPropertySetDoubleWidget stepLengthSlider;
-   private ImGuiStoredPropertySetDoubleWidget turnAggressivenessSlider;
+   private ImGuiSliderDouble stepAggressivenessSlider;
+   private ImGuiSliderDouble turnAggressivenessSlider;
    private ImGuiStoredPropertySetEnumWidget initialStanceSideRadioButtons;
 
    private final RDXFootstepPlanGraphic controllerFootstepQueueGraphic;
@@ -158,8 +159,8 @@ public class RDXLocomotionManager
       replanSwingTrajectoriesOnChangeCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.replanSwingTrajectoriesOnChange);
       swingTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.swingTime, 0.3, 1.5);
       transferTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.transferTime, 0.1, 1.5);
-//      stepLengthSlider = turnWalkTurnFootstepPlanningParametersTuner.createDoubleSlider(DefaultFootstepPlannerParameters.maxStepReach, 0.2, 0.5);
-//      turnAggressivenessSlider = turnWalkTurnFootstepPlanningParametersTuner.createDoubleSlider(DefaultFootstepPlannerParameters.maxStepYaw, 0.0, 1.0);
+      stepAggressivenessSlider = new ImGuiSliderDouble("Step Aggressiveness", "", 0.5);
+      turnAggressivenessSlider = new ImGuiSliderDouble("Turn Aggressiveness", "", 0.5);
       initialStanceSideRadioButtons = locomotionParametersTuner.createEnumRadioButtons(RDXLocomotionParameters.initialStanceSide, InitialStanceSide.values());
 
       ballAndArrowMidFeetPosePlacement.create(Color.YELLOW, syncedRobot);
@@ -300,8 +301,14 @@ public class RDXLocomotionManager
 
       swingTimeSlider.renderImGuiWidget();
       transferTimeSlider.renderImGuiWidget();
-//      stepLengthSlider.renderImGuiWidget();
-//      turnAggressivenessSlider.renderImGuiWidget();
+      stepAggressivenessSlider.render(0.0, 1.0);
+      turnAggressivenessSlider.render(0.0, 2.0);
+
+      turnWalkTurnFootstepPlannerParameters.setIdealFootstepLength(stepAggressivenessSlider.getDoubleValue() * aStarFootstepPlannerParameters.getMaxStepReach());
+      turnWalkTurnFootstepPlannerParameters.setIdealBackStepLength(stepAggressivenessSlider.getDoubleValue() * -aStarFootstepPlannerParameters.getMinStepLength());
+      turnWalkTurnFootstepPlannerParameters.setIdealSideStepWidth(stepAggressivenessSlider.getDoubleValue() * aStarFootstepPlannerParameters.getMaxStepWidth());
+      turnWalkTurnFootstepPlannerParameters.setMaxStepYaw(turnAggressivenessSlider.getDoubleValue() * aStarFootstepPlannerParameters.getMaxStepYaw());
+      turnWalkTurnFootstepPlannerParameters.setMinStepYaw(turnAggressivenessSlider.getDoubleValue() * aStarFootstepPlannerParameters.getMinStepYaw());
 
       ImGui.separator();
       ImGui.text("Walking Options:");

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
@@ -54,7 +54,8 @@ public class RDXLocomotionManager
    private final SwingPlannerParametersBasics swingFootPlannerParameters;
    private final Notification locomotionParametersChanged = new Notification();
    private final Notification footstepPlanningParametersChanged = new Notification();
-   private final Notification usedFootstepParametersChanged = new Notification();
+   private final Notification turnAggressivenessChanged = new Notification();
+   private final Notification stepAggressivenessChanged = new Notification();
    private final RDXStoredPropertySetTuner locomotionParametersTuner = new RDXStoredPropertySetTuner("Locomotion Parameters");
    private final RDXStoredPropertySetTuner aStartFootstepPlanningParametersTuner
          = new RDXStoredPropertySetTuner("Footstep Planner Parameters (Teleoperation A*)");
@@ -140,7 +141,6 @@ public class RDXLocomotionManager
       controllerStatusTracker.getFootstepTracker().registerFootstepQueuedMessageListener(footstepQueueNotification);
       locomotionParameters.addAnyPropertyChangedListener(locomotionParametersChanged);
       aStarFootstepPlannerParameters.addAnyPropertyChangedListener(footstepPlanningParametersChanged);
-      footstepPlannerParametersToUse.addAnyPropertyChangedListener(usedFootstepParametersChanged);
 
       locomotionParametersTuner.create(locomotionParameters);
       aStartFootstepPlanningParametersTuner.create(aStarFootstepPlannerParameters, false);
@@ -212,7 +212,8 @@ public class RDXLocomotionManager
 
       boolean parametersChanged = locomotionParametersChanged.poll();
       parametersChanged |= footstepPlanningParametersChanged.poll();
-      parametersChanged |= usedFootstepParametersChanged.poll();
+      parametersChanged |= turnAggressivenessChanged.poll();
+      parametersChanged |= stepAggressivenessChanged.poll();
 
       if (parametersChanged)
       {
@@ -304,8 +305,10 @@ public class RDXLocomotionManager
 
       swingTimeSlider.renderImGuiWidget();
       transferTimeSlider.renderImGuiWidget();
-      stepAggressivenessSlider.render(0.0, 1.5);
-      turnAggressivenessSlider.render(0.0, 2.0);
+      if (stepAggressivenessSlider.render(0.0, 1.5))
+         stepAggressivenessChanged.set();
+      if (turnAggressivenessSlider.render(0.0, 2.0))
+         turnAggressivenessChanged.set();
 
       ImGui.separator();
       ImGui.text("Walking Options:");

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
@@ -64,6 +64,7 @@ public class RDXLocomotionManager
    private final RDXStoredPropertySetTuner swingFootPlanningParametersTuner = new RDXStoredPropertySetTuner("Swing Foot Planning Parameters (Teleoperation)");
    private ImGuiStoredPropertySetBooleanWidget areFootstepsAdjustableCheckbox;
    private ImGuiStoredPropertySetBooleanWidget assumeFlatGroundCheckbox;
+   private ImGuiStoredPropertySetBooleanWidget performAStarSearchCheckbox;
    private ImGuiStoredPropertySetBooleanWidget planSwingTrajectoriesCheckbox;
    private ImGuiStoredPropertySetBooleanWidget replanSwingTrajectoriesOnChangeCheckbox;
    private ImGuiStoredPropertySetDoubleWidget swingTimeSlider;
@@ -147,6 +148,7 @@ public class RDXLocomotionManager
       swingFootPlanningParametersTuner.create(swingFootPlannerParameters, false);
 
       assumeFlatGroundCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.assumeFlatGround);
+      performAStarSearchCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.performAStarSearch);
       areFootstepsAdjustableCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.areFootstepsAdjustable);
       planSwingTrajectoriesCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.planSwingTrajectories);
       replanSwingTrajectoriesOnChangeCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.replanSwingTrajectoriesOnChange);
@@ -356,6 +358,7 @@ public class RDXLocomotionManager
       {
          ImGui.indent();
          assumeFlatGroundCheckbox.renderImGuiWidget();
+         performAStarSearchCheckbox.renderImGuiWidget();
          areFootstepsAdjustableCheckbox.renderImGuiWidget();
          planSwingTrajectoriesCheckbox.renderImGuiWidget();
          replanSwingTrajectoriesOnChangeCheckbox.renderImGuiWidget();

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
@@ -15,7 +15,7 @@ import us.ihmc.commons.thread.Notification;
 import us.ihmc.communication.subscribers.FilteredNotification;
 import us.ihmc.footstepPlanning.AStarBodyPathPlannerParametersBasics;
 import us.ihmc.footstepPlanning.FootstepPlannerOutput;
-import us.ihmc.footstepPlanning.graphSearch.parameters.FootstepPlannerParameterKeys;
+import us.ihmc.footstepPlanning.graphSearch.parameters.DefaultFootstepPlannerParameters;
 import us.ihmc.footstepPlanning.graphSearch.parameters.FootstepPlannerParametersDelegate;
 import us.ihmc.footstepPlanning.graphSearch.parameters.DefaultFootstepPlannerParametersBasics;
 import us.ihmc.footstepPlanning.graphSearch.parameters.InitialStanceSide;
@@ -158,8 +158,8 @@ public class RDXLocomotionManager
       replanSwingTrajectoriesOnChangeCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.replanSwingTrajectoriesOnChange);
       swingTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.swingTime, 0.3, 1.5);
       transferTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.transferTime, 0.1, 1.5);
-      stepLengthSlider = turnWalkTurnFootstepPlanningParametersTuner.createDoubleSlider(FootstepPlannerParameterKeys.maxStepReach, 0.2, 0.5);
-      turnAggressivenessSlider = turnWalkTurnFootstepPlanningParametersTuner.createDoubleSlider(FootstepPlannerParameterKeys.maxStepYaw, 0.0, 1.0);
+//      stepLengthSlider = turnWalkTurnFootstepPlanningParametersTuner.createDoubleSlider(DefaultFootstepPlannerParameters.maxStepReach, 0.2, 0.5);
+//      turnAggressivenessSlider = turnWalkTurnFootstepPlanningParametersTuner.createDoubleSlider(DefaultFootstepPlannerParameters.maxStepYaw, 0.0, 1.0);
       initialStanceSideRadioButtons = locomotionParametersTuner.createEnumRadioButtons(RDXLocomotionParameters.initialStanceSide, InitialStanceSide.values());
 
       ballAndArrowMidFeetPosePlacement.create(Color.YELLOW, syncedRobot);
@@ -300,8 +300,8 @@ public class RDXLocomotionManager
 
       swingTimeSlider.renderImGuiWidget();
       transferTimeSlider.renderImGuiWidget();
-      stepLengthSlider.renderImGuiWidget();
-      turnAggressivenessSlider.renderImGuiWidget();
+//      stepLengthSlider.renderImGuiWidget();
+//      turnAggressivenessSlider.renderImGuiWidget();
 
       ImGui.separator();
       ImGui.text("Walking Options:");

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
@@ -15,6 +15,7 @@ import us.ihmc.commons.thread.Notification;
 import us.ihmc.communication.subscribers.FilteredNotification;
 import us.ihmc.footstepPlanning.AStarBodyPathPlannerParametersBasics;
 import us.ihmc.footstepPlanning.FootstepPlannerOutput;
+import us.ihmc.footstepPlanning.graphSearch.parameters.FootstepPlannerParameterKeys;
 import us.ihmc.footstepPlanning.graphSearch.parameters.FootstepPlannerParametersDelegate;
 import us.ihmc.footstepPlanning.graphSearch.parameters.DefaultFootstepPlannerParametersBasics;
 import us.ihmc.footstepPlanning.graphSearch.parameters.InitialStanceSide;
@@ -68,6 +69,8 @@ public class RDXLocomotionManager
    private ImGuiStoredPropertySetBooleanWidget replanSwingTrajectoriesOnChangeCheckbox;
    private ImGuiStoredPropertySetDoubleWidget swingTimeSlider;
    private ImGuiStoredPropertySetDoubleWidget transferTimeSlider;
+   private ImGuiStoredPropertySetDoubleWidget stepLengthSlider;
+   private ImGuiStoredPropertySetDoubleWidget turnAggressivenessSlider;
    private ImGuiStoredPropertySetEnumWidget initialStanceSideRadioButtons;
 
    private final RDXFootstepPlanGraphic controllerFootstepQueueGraphic;
@@ -155,6 +158,8 @@ public class RDXLocomotionManager
       replanSwingTrajectoriesOnChangeCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.replanSwingTrajectoriesOnChange);
       swingTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.swingTime, 0.3, 1.5);
       transferTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.transferTime, 0.1, 1.5);
+      stepLengthSlider = turnWalkTurnFootstepPlanningParametersTuner.createDoubleSlider(FootstepPlannerParameterKeys.maxStepReach, 0.2, 0.5);
+      turnAggressivenessSlider = turnWalkTurnFootstepPlanningParametersTuner.createDoubleSlider(FootstepPlannerParameterKeys.maxStepYaw, 0.0, 1.0);
       initialStanceSideRadioButtons = locomotionParametersTuner.createEnumRadioButtons(RDXLocomotionParameters.initialStanceSide, InitialStanceSide.values());
 
       ballAndArrowMidFeetPosePlacement.create(Color.YELLOW, syncedRobot);
@@ -295,6 +300,8 @@ public class RDXLocomotionManager
 
       swingTimeSlider.renderImGuiWidget();
       transferTimeSlider.renderImGuiWidget();
+      stepLengthSlider.renderImGuiWidget();
+      turnAggressivenessSlider.renderImGuiWidget();
 
       ImGui.separator();
       ImGui.text("Walking Options:");

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/locomotion/RDXLocomotionManager.java
@@ -150,10 +150,11 @@ public class RDXLocomotionManager
       areFootstepsAdjustableCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.areFootstepsAdjustable);
       planSwingTrajectoriesCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.planSwingTrajectories);
       replanSwingTrajectoriesOnChangeCheckbox = locomotionParametersTuner.createBooleanCheckbox(RDXLocomotionParameters.replanSwingTrajectoriesOnChange);
-      swingTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.swingTime, 0.3, 1.5);
-      transferTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.transferTime, 0.1, 1.5);
-      stepAggressivenessSlider = new ImGuiSliderDouble("Step Aggressiveness", "", aStarFootstepPlannerParameters.getIdealFootstepLength() / aStarFootstepPlannerParameters.getMaxStepReach());
-      turnAggressivenessSlider = new ImGuiSliderDouble("Turn Aggressiveness", "", 0.5);
+      swingTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.swingTime, "s", 0.3, 1.5, "%.2f");
+      transferTimeSlider = locomotionParametersTuner.createDoubleSlider(RDXLocomotionParameters.transferTime, "s", 0.1, 1.5, "%.2f");
+      stepAggressivenessSlider = new ImGuiSliderDouble("Step Aggressiveness", "%.2f",aStarFootstepPlannerParameters.getIdealFootstepLength()
+                                                                                     / aStarFootstepPlannerParameters.getMaxStepReach());
+      turnAggressivenessSlider = new ImGuiSliderDouble("Turn Aggressiveness", "%.2f", 0.5);
       initialStanceSideRadioButtons = locomotionParametersTuner.createEnumRadioButtons(RDXLocomotionParameters.initialStanceSide, InitialStanceSide.values());
 
       ballAndArrowMidFeetPosePlacement.create(Color.YELLOW, syncedRobot);

--- a/ihmc-robotics-toolkit/src/main/java/us/ihmc/robotics/geometry/AngleTools.java
+++ b/ihmc-robotics-toolkit/src/main/java/us/ihmc/robotics/geometry/AngleTools.java
@@ -7,7 +7,9 @@ import us.ihmc.euclid.referenceFrame.FramePoint2D;
 import us.ihmc.euclid.referenceFrame.FramePose2D;
 import us.ihmc.euclid.referenceFrame.interfaces.FramePoint2DReadOnly;
 import us.ihmc.euclid.referenceFrame.interfaces.FramePoint3DReadOnly;
+import us.ihmc.euclid.referenceFrame.interfaces.FramePose2DReadOnly;
 import us.ihmc.euclid.tuple2D.Point2D32;
+import us.ihmc.euclid.tuple2D.interfaces.Point2DReadOnly;
 import us.ihmc.euclid.tuple2D.interfaces.Vector2DReadOnly;
 import us.ihmc.euclid.tuple3D.Vector3D;
 import us.ihmc.euclid.tuple3D.interfaces.Tuple3DBasics;
@@ -38,7 +40,7 @@ public class AngleTools
 
    public static double angleMinusPiToPi(Vector2DReadOnly startVector, Vector2DReadOnly endVector)
    {
-      double absoluteAngle = Math.acos(startVector.dot(endVector) / startVector.length() / endVector.length());
+      double absoluteAngle = Math.acos(startVector.dot(endVector) / startVector.norm() / endVector.norm());
 
       Vector3D start3d = new Vector3D(startVector.getX(), startVector.getY(), 0.0);
       Vector3D end3d = new Vector3D(endVector.getX(), endVector.getY(), 0.0);
@@ -308,7 +310,7 @@ public class AngleTools
     * @param noTranslationTolerance tolerance for determining if path angle should be determined
     * @return number between -PI and PI
     */
-   public static double calculateHeading(FramePose2D startPose, FramePoint2D endPoint, double headingOffset, double noTranslationTolerance)
+   public static double calculateHeading(FramePose2DReadOnly startPose, FramePoint2DReadOnly endPoint, double headingOffset, double noTranslationTolerance)
    {
       double deltaX = endPoint.getX() - startPose.getX();
       double deltaY = endPoint.getY() - startPose.getY();
@@ -349,7 +351,7 @@ public class AngleTools
     * @param endPoint  end position
     * @return number between -PI and PI
     */
-   public static double calculateHeading(Point2D32 startPose, Point2D32 endPoint)
+   public static double calculateHeading(Point2DReadOnly startPose, Point2DReadOnly endPoint)
    {
       double deltaX = endPoint.getX() - startPose.getX();
       double deltaY = endPoint.getY() - startPose.getY();


### PR DESCRIPTION
This gets the turn walk turn planner fixed up a little bit. To enable, you have to turn off "use A* planner" in the Locomotion parameters panel. 
- fixes a few bugs related to the planner that manifest based on signs
- updates the planner to use the post-2018 Euclid syntax
- introduces some functionality for close plans so that it just steps directly to that point
- sets up the slider for step and turn aggressiveness.