### PR TITLE
Fix Concurrent Modification in PersistentDetection

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/detections/PersistentDetection.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/detections/PersistentDetection.java
@@ -12,20 +12,18 @@ import us.ihmc.robotics.time.TimeTools;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.SortedSet;
-import java.util.TreeSet;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 public class PersistentDetection
 {
    public static final UUID NULL_DETECTION_ID = new UUID(0L, 0L);
 
    // The first element of this set is the oldest detection, and the last element is the most recent detection
-   private final SortedSet<InstantDetection> detectionHistory
-         = Collections.synchronizedSortedSet(new TreeSet<>(Comparator.comparing(InstantDetection::getDetectionTime)));
+   private final SortedSet<InstantDetection> detectionHistory = new ConcurrentSkipListSet<>(Comparator.comparing(InstantDetection::getDetectionTime));
    private final InstantDetection firstDetection;
    private Duration historyDuration;
    private final UUID id = UUID.randomUUID();


### PR DESCRIPTION
Didn't realize using synchronized `TreeSet` can still lead to concurrent modification. 
Using a `ConcurrentSkipListSet` fixes that. 