### PR TITLE
Show disabled properties when property set waiting for upated values from remote

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/ImGuiRemoteROS2StoredPropertySet.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/ImGuiRemoteROS2StoredPropertySet.java
@@ -6,9 +6,9 @@ import us.ihmc.communication.property.StoredPropertySetMessageTools;
 import us.ihmc.communication.property.StoredPropertySetROS2Input;
 import us.ihmc.communication.property.StoredPropertySetROS2TopicPair;
 import us.ihmc.communication.ros2.ROS2PublishSubscribeAPI;
-import us.ihmc.rdx.imgui.RDXPanel;
 import us.ihmc.rdx.imgui.ImGuiTools;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
+import us.ihmc.rdx.imgui.RDXPanel;
 import us.ihmc.tools.property.StoredPropertySetBasics;
 
 public class ImGuiRemoteROS2StoredPropertySet
@@ -64,6 +64,10 @@ public class ImGuiRemoteROS2StoredPropertySet
             storedPropertySetROS2Input.setToAcceptUpdate();
          }
       }
+      else if (storedPropertySetROS2Input.getWaitingForUpdate())
+      {
+         ImGuiTools.textColored(YELLOW, "[!] Waiting for updated values from remote.");
+      }
       else if (storedPropertySetROS2Input.getIsExpired())
       {
          ImGuiTools.textColored(DARK_RED, "[!] Parameters have expired.");
@@ -80,16 +84,10 @@ public class ImGuiRemoteROS2StoredPropertySet
    {
       storedPropertySetROS2Input.update();
 
-      if (storedPropertySetROS2Input.getWaitingForUpdate())
-      {
-         ImGui.text(storedPropertySet.getTitle());
-         ImGui.text("Waiting for updated values from remote...");
-      }
-      else
-      {
-         imGuiStoredPropertySetTuner.renderImGuiWidgets();
-         publishIfNecessary();
-      }
+      ImGui.beginDisabled(storedPropertySetROS2Input.getWaitingForUpdate());
+      imGuiStoredPropertySetTuner.renderImGuiWidgets();
+      publishIfNecessary();
+      ImGui.endDisabled();
    }
 
    private void publishIfNecessary()


### PR DESCRIPTION
I think it's nice to see the adjustable parameters, even if the values may be incorrect and they cannot be adjusted immediately. 
![Screenshot from 2024-07-19 17-24-30](https://github.com/user-attachments/assets/330e61d8-dd8b-4470-a135-23c51b69adc0)
vs
![Screenshot from 2024-07-19 17-28-01](https://github.com/user-attachments/assets/701d68f8-5f4b-41e3-81c1-95eb9f655789)
