### PR TITLE
Dynamically calculate point cloud point sprite size for the simulated sensor the same as how we do on the real robot.

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/simulation/sensors/RDXHighLevelDepthSensorSimulator.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/simulation/sensors/RDXHighLevelDepthSensorSimulator.java
@@ -170,7 +170,7 @@ public class RDXHighLevelDepthSensorSimulator extends RDXPanel
    private final ImBoolean useSensorColor = new ImBoolean(false);
    private final ImBoolean colorBasedOnWorldZ = new ImBoolean(true);
    private final Color pointColorFromPicker = new Color();
-   private final ImFloat pointSize = new ImFloat(0.01f);
+   private final ImFloat pointSizeScale = new ImFloat(1.0f);
    private final float[] color = new float[] {1.0f, 1.0f, 1.0f, 1.0f};
    private final ImInt segmentationDivisor = new ImInt(8);
    private final List<Point3D> pointCloud = new ArrayList<>();
@@ -368,7 +368,7 @@ public class RDXHighLevelDepthSensorSimulator extends RDXPanel
             {
                LibGDXTools.toLibGDX(color, pointColorFromPicker);
                Color pointColor = useSensorColor.get() ? null : pointColorFromPicker;
-               depthSensorSimulator.render(scene, colorBasedOnWorldZ.get(), pointColor, pointSize.get());
+               depthSensorSimulator.render(scene, colorBasedOnWorldZ.get(), pointColor, pointSizeScale.get());
                pointCloudRenderer.updateMeshFastest(imageWidth * imageHeight);
             }
             else
@@ -582,7 +582,7 @@ public class RDXHighLevelDepthSensorSimulator extends RDXPanel
       ImGui.checkbox("Use Sensor Color", useSensorColor);
       ImGui.sameLine();
       ImGui.checkbox("Color based on world Z", colorBasedOnWorldZ);
-      ImGui.sliderFloat("Point size", pointSize.getData(), 0.0001f, 0.10f);
+      ImGui.sliderFloat("Point scale", pointSizeScale.getData(), 0.0f, 2.0f);
       if (ImGui.collapsingHeader(labels.get("Color tuner")))
       {
          ImGui.colorPicker4("Color", color);
@@ -853,9 +853,9 @@ public class RDXHighLevelDepthSensorSimulator extends RDXPanel
       this.renderPointCloudDirectly.set(renderPointCloudDirectly);
    }
 
-   public void setPointSize(double size)
+   public void setPointSizeScale(double size)
    {
-      pointSize.set((float) size);
+      pointSizeScale.set((float) size);
    }
 
    public void setRenderDepthVideoDirectly(boolean renderDepthVideoDirectly)

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/simulation/sensors/RDXLowLevelDepthSensorSimulator.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/simulation/sensors/RDXLowLevelDepthSensorSimulator.java
@@ -179,10 +179,10 @@ public class RDXLowLevelDepthSensorSimulator
 
    public void render(RDX3DScene scene)
    {
-      render(scene, true, null, 0.01f);
+      render(scene, true, null, 1.0f);
    }
 
-   public void render(RDX3DScene scene, boolean colorBasedOnWorldZ, Color userPointColor, float pointSize)
+   public void render(RDX3DScene scene, boolean colorBasedOnWorldZ, Color userPointColor, float pointSizeScale)
    {
       boolean updateThisTick = throttleTimer.isExpired(updatePeriod);
       if (updateThisTick)
@@ -249,6 +249,7 @@ public class RDXLowLevelDepthSensorSimulator
       parametersBuffer.getBytedecoFloatBufferPointer().put(5, calculatePointCloud);
       parametersBuffer.getBytedecoFloatBufferPointer().put(6, imageWidth);
       parametersBuffer.getBytedecoFloatBufferPointer().put(7, imageHeight);
+      float pointSize = pointSizeScale / focalLengthPixels.get();
       parametersBuffer.getBytedecoFloatBufferPointer().put(8, pointSize);
       parametersBuffer.getBytedecoFloatBufferPointer().put(9, colorBasedOnWorldZ ? 1.0f : 0.0f);
       parametersBuffer.getBytedecoFloatBufferPointer().put(10, userPointColor == null ? -1.0f : userPointColor.r);

--- a/ihmc-high-level-behaviors/src/libgdx/resources/openCL/LowLevelDepthSensorSimulator.cl
+++ b/ihmc-high-level-behaviors/src/libgdx/resources/openCL/LowLevelDepthSensorSimulator.cl
@@ -146,6 +146,6 @@ kernel void lowLevelDepthSensorSimulator(read_only image2d_t normalizedDeviceCoo
       pointCloudRenderingBuffer[pointStartIndex + 4] = pointColorG;
       pointCloudRenderingBuffer[pointStartIndex + 5] = pointColorB;
       pointCloudRenderingBuffer[pointStartIndex + 6] = pointColorA;
-      pointCloudRenderingBuffer[pointStartIndex + 7] = pointSize;
+      pointCloudRenderingBuffer[pointStartIndex + 7] = pointSize * eyeDepth;
    }
 }

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/RDXDepthSensorDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/RDXDepthSensorDemo.java
@@ -48,7 +48,7 @@ public class RDXDepthSensorDemo
          @Override
          public void render()
          {
-            depthSensorSimulator.render(baseUI.getPrimaryScene(), false, Color.WHITE, 0.01f);
+            depthSensorSimulator.render(baseUI.getPrimaryScene(), false, Color.WHITE, 1.0f);
             pointCloudRenderer.updateMeshFastest(depthSensorSimulator.getNumberOfPoints());
 
             baseUI.renderBeforeOnScreenUI();

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/RDXVRDepthSensorDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/RDXVRDepthSensorDemo.java
@@ -33,7 +33,7 @@ public class RDXVRDepthSensorDemo
    private final ImBoolean useSensorColor = new ImBoolean(false);
    private final ImBoolean colorBasedOnWorldZ = new ImBoolean(true);
    private final ImBoolean useGizmoToPoseSensor = new ImBoolean(false);
-   private final ImFloat pointSize = new ImFloat(0.01f);
+   private final ImFloat pointSizeScale = new ImFloat(1.0f);
    private final float[] color = new float[] {0.0f, 0.0f, 0.0f, 1.0f};
    private final RDXPose3DGizmo gizmo = new RDXPose3DGizmo();
    private final Color pointColorFromPicker = new Color();
@@ -145,7 +145,7 @@ public class RDXVRDepthSensorDemo
             {
                pointColorFromPicker.set(color[0], color[1], color[2], color[3]);
                Color pointColor = useSensorColor.get() ? null : pointColorFromPicker;
-               depthSensorSimulator.render(baseUI.getPrimaryScene(), colorBasedOnWorldZ.get(), pointColor, pointSize.get());
+               depthSensorSimulator.render(baseUI.getPrimaryScene(), colorBasedOnWorldZ.get(), pointColor, pointSizeScale.get());
                pointCloudRenderer.updateMeshFastest(depthSensorSimulator.getNumberOfPoints());
             }
 
@@ -159,7 +159,7 @@ public class RDXVRDepthSensorDemo
             ImGui.checkbox("Use Gizmo to pose sensor", useGizmoToPoseSensor);
             ImGui.checkbox("Use Sensor Color", useSensorColor);
             ImGui.checkbox("Color based on world Z", colorBasedOnWorldZ);
-            ImGui.sliderFloat("Point size", pointSize.getData(), 0.0001f, 0.02f);
+            ImGui.sliderFloat("Point scale", pointSizeScale.getData(), 0.0f, 2.0f);
             ImGui.colorPicker4("Color", color);
          }
 


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/8facb19f-4d0b-4ada-a129-5b0ea5c32459)
After:
![20240729_153845](https://github.com/user-attachments/assets/10d757ad-fea0-4811-a3f3-9a8eca001619)
![20240729_153653](https://github.com/user-attachments/assets/babdd445-6aaf-48f9-9f11-ba6b04e41e4c)
