### PR TITLE
Replace RealSense demand graph node with BooleanSupplier

### DIFF
--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/PerceptionAndAutonomyProcess.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/PerceptionAndAutonomyProcess.java
@@ -230,7 +230,7 @@ public class PerceptionAndAutonomyProcess
       realsenseImageRetriever = new RealsenseColorDepthImageRetriever(new RealsenseDeviceManager(),
                                                                       REALSENSE_SERIAL_NUMBER,
                                                                       RealsenseConfiguration.D455_COLOR_720P_DEPTH_720P_30HZ,
-                                                                      realsenseFrameSupplier, realsenseDemandNode);
+                                                                      realsenseFrameSupplier, realsenseDemandNode::isDemanded);
       realsenseImagePublisher = new RealsenseColorDepthImagePublisher(REALSENSE_DEPTH_TOPIC, REALSENSE_COLOR_TOPIC);
       realsenseProcessAndPublishThread = new RestartableThread("RealsenseProcessAndPublish", this::processAndPublishRealsense);
       realsenseProcessAndPublishThread.start();

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/RealsenseColorDepthImageRetriever.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/RealsenseColorDepthImageRetriever.java
@@ -3,7 +3,6 @@ package us.ihmc.sensors;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.opencv_core.Mat;
 import us.ihmc.commons.thread.ThreadTools;
-import us.ihmc.communication.ros2.ROS2DemandGraphNode;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.log.LogTools;
@@ -17,6 +16,7 @@ import java.time.Instant;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 
 public class RealsenseColorDepthImageRetriever
@@ -39,7 +39,7 @@ public class RealsenseColorDepthImageRetriever
    private final FramePose3D depthPose = new FramePose3D();
    private final FramePose3D colorPose = new FramePose3D();
    private final Supplier<ReferenceFrame> sensorFrameSupplier;
-   private final ROS2DemandGraphNode demandGraphNode;
+   private final BooleanSupplier demandSupplier;
    private final RestartableThrottledThread realsenseGrabThread;
 
    private final Lock newDepthImageLock = new ReentrantLock();
@@ -56,13 +56,13 @@ public class RealsenseColorDepthImageRetriever
                                             String realsenseSerialNumber,
                                             RealsenseConfiguration realsenseConfiguration,
                                             Supplier<ReferenceFrame> sensorFrameSupplier,
-                                            ROS2DemandGraphNode realsenseDemandNode)
+                                            BooleanSupplier realsenseDemandSupplier)
    {
       this.sensorFrameSupplier = sensorFrameSupplier;
       this.realsenseManager = realsenseManager;
       this.realsenseSerialNumber = realsenseSerialNumber;
       this.realsenseConfiguration = realsenseConfiguration;
-      this.demandGraphNode = realsenseDemandNode;
+      this.demandSupplier = realsenseDemandSupplier;
 
       realsenseGrabThread = new RestartableThrottledThread("RealsenseImageGrabber", OUTPUT_FREQUENCY, this::updateImages);
       realsenseGrabThread.start();
@@ -70,7 +70,7 @@ public class RealsenseColorDepthImageRetriever
 
    private void updateImages()
    {
-      if (demandGraphNode.isDemanded())
+      if (demandSupplier.getAsBoolean())
       {
          if (realsense == null || realsense.getDevice() == null || numberOfFailedReads > 30)
          {


### PR DESCRIPTION
Tiny PR to replace the demand graph node with a `BooleanSupplier`, like in the ZED retriever. 