### PR TITLE
Remove standalone realtime ros2node from pointcloud viz

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXCenterposeObjectDetectionDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXCenterposeObjectDetectionDemo.java
@@ -71,7 +71,7 @@ public class RDXCenterposeObjectDetectionDemo
             perceptionVisualizerPanel.addVisualizer(zed2DepthImageVisualizer);
 
             RDXROS2ColoredPointCloudVisualizer zed2ColoredPointCloudVisualizer = new RDXROS2ColoredPointCloudVisualizer("ZED 2 Colored Point Cloud",
-                                                                                                                        PubSubImplementation.FAST_RTPS,
+                                                                                                                        ros2Node,
                                                                                                                         PerceptionAPI.ZED2_DEPTH,
                                                                                                                         PerceptionAPI.ZED2_COLOR_IMAGES.get(
                                                                                                                               RobotSide.LEFT));

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXZED2DisplayDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXZED2DisplayDemo.java
@@ -44,7 +44,7 @@ public class RDXZED2DisplayDemo
             perceptionVisualizerPanel.addVisualizer(zed2DepthImageVisualizer);
 
             RDXROS2ColoredPointCloudVisualizer zed2ColoredPointCloudVisualizer = new RDXROS2ColoredPointCloudVisualizer("ZED 2 Colored Point Cloud",
-                                                                                                                        PubSubImplementation.FAST_RTPS,
+                                                                                                                        ros2Node,
                                                                                                                         PerceptionAPI.ZED2_DEPTH,
                                                                                                                         PerceptionAPI.ZED2_COLOR_IMAGES.get(
                                                                                                                               RobotSide.LEFT));

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXZEDSVORecordingDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXZEDSVORecordingDemo.java
@@ -119,7 +119,7 @@ public class RDXZEDSVORecordingDemo
       // ZED2 colored point cloud visualizer
       {
          RDXROS2ColoredPointCloudVisualizer zed2ColoredPointCloudVisualizer = new RDXROS2ColoredPointCloudVisualizer("ZED 2 Colored Point Cloud",
-                                                                                                                     PubSubImplementation.FAST_RTPS,
+                                                                                                                     ros2Node,
                                                                                                                      PerceptionAPI.ZED2_DEPTH,
                                                                                                                      PerceptionAPI.ZED2_COLOR_IMAGES.get(
                                                                                                                            RobotSide.LEFT))

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
@@ -339,7 +339,7 @@ public class RDXSceneGraphDemo
       // ZED2 colored point cloud visualizer
       {
          RDXROS2ColoredPointCloudVisualizer zed2ColoredPointCloudVisualizer = new RDXROS2ColoredPointCloudVisualizer("ZED 2 Colored Point Cloud",
-                                                                                                                     PubSubImplementation.FAST_RTPS,
+                                                                                                                     ros2Node,
                                                                                                                      PerceptionAPI.ZED2_DEPTH,
                                                                                                                      PerceptionAPI.ZED2_COLOR_IMAGES.get(
                                                                                                                            RobotSide.LEFT));

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/graphics/ros2/pointCloud/RDXROS2ColoredPointCloudVisualizer.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/graphics/ros2/pointCloud/RDXROS2ColoredPointCloudVisualizer.java
@@ -8,13 +8,11 @@ import imgui.type.ImBoolean;
 import imgui.type.ImFloat;
 import imgui.type.ImInt;
 import perception_msgs.msg.dds.ImageMessage;
-import us.ihmc.communication.ROS2Tools;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.log.LogTools;
 import us.ihmc.perception.CameraModel;
 import us.ihmc.perception.opencl.OpenCLFloatBuffer;
 import us.ihmc.perception.opencl.OpenCLManager;
-import us.ihmc.pubsub.DomainFactory.PubSubImplementation;
 import us.ihmc.rdx.RDXPointCloudRenderer;
 import us.ihmc.rdx.imgui.ImGuiAveragedFrequencyText;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
@@ -23,10 +21,9 @@ import us.ihmc.rdx.ui.graphics.RDXColorGradientMode;
 import us.ihmc.rdx.ui.graphics.RDXOusterFisheyeColoredPointCloudKernel;
 import us.ihmc.rdx.ui.graphics.ros2.RDXROS2MultiTopicVisualizer;
 import us.ihmc.robotics.referenceFrames.MutableReferenceFrame;
+import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Topic;
-import us.ihmc.ros2.RealtimeROS2Node;
 import us.ihmc.tools.Timer;
-import us.ihmc.tools.string.StringTools;
 
 import java.util.List;
 import java.util.Set;
@@ -49,12 +46,12 @@ public class RDXROS2ColoredPointCloudVisualizer extends RDXROS2MultiTopicVisuali
    private final ImInt levelOfColorDetail = new ImInt(0);
    private boolean subscribed = false;
 
+   private final ROS2Node ros2Node;
+
    private final RDXROS2ColoredPointCloudVisualizerDepthChannel depthChannel;
    private final RDXROS2ColoredPointCloudVisualizerColorChannel colorChannel;
    private final Timer colorReceptionTimer = new Timer();
 
-   private final PubSubImplementation pubSubImplementation;
-   private RealtimeROS2Node realtimeROS2Node;
    private final Object imageMessagesSyncObject = new Object();
 
    private RDXPointCloudRenderer pointCloudRenderer;
@@ -70,21 +67,21 @@ public class RDXROS2ColoredPointCloudVisualizer extends RDXROS2MultiTopicVisuali
 
 
    public RDXROS2ColoredPointCloudVisualizer(String title,
-                                             PubSubImplementation pubSubImplementation,
+                                             ROS2Node ros2Node,
                                              ROS2Topic<ImageMessage> depthTopic,
                                              ROS2Topic<ImageMessage> colorTopic)
    {
       super(title);
       titleBeforeAdditions = title;
-      this.pubSubImplementation = pubSubImplementation;
+      this.ros2Node = ros2Node;
       depthChannel = new RDXROS2ColoredPointCloudVisualizerDepthChannel(depthTopic);
       colorChannel = new RDXROS2ColoredPointCloudVisualizerColorChannel(colorTopic);
 
       setActivenessChangeCallback(isActive ->
       {
-         if (isActive && realtimeROS2Node == null)
+         if (isActive)
             subscribe();
-         else if (!isActive && realtimeROS2Node != null)
+         else
             unsubscribe();
       });
    }
@@ -92,10 +89,8 @@ public class RDXROS2ColoredPointCloudVisualizer extends RDXROS2MultiTopicVisuali
    private void subscribe()
    {
       subscribed = true;
-      realtimeROS2Node = ROS2Tools.createRealtimeROS2Node(pubSubImplementation, StringTools.titleToSnakeCase(titleBeforeAdditions));
-      depthChannel.subscribe(realtimeROS2Node, imageMessagesSyncObject);
-      colorChannel.subscribe(realtimeROS2Node, imageMessagesSyncObject);
-      realtimeROS2Node.spin();
+      depthChannel.subscribe(ros2Node, imageMessagesSyncObject);
+      colorChannel.subscribe(ros2Node, imageMessagesSyncObject);
    }
 
    @Override
@@ -266,11 +261,6 @@ public class RDXROS2ColoredPointCloudVisualizer extends RDXROS2MultiTopicVisuali
    private void unsubscribe()
    {
       subscribed = false;
-      if (realtimeROS2Node != null)
-      {
-         realtimeROS2Node.destroy();
-         realtimeROS2Node = null;
-      }
    }
 
    public void changeTopics(ROS2Topic<ImageMessage> colorTopic, ROS2Topic<ImageMessage> depthTopic)

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/graphics/ros2/pointCloud/RDXROS2ColoredPointCloudVisualizerChannel.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/graphics/ros2/pointCloud/RDXROS2ColoredPointCloudVisualizerChannel.java
@@ -15,6 +15,7 @@ import us.ihmc.pubsub.common.SampleInfo;
 import us.ihmc.rdx.imgui.ImGuiAveragedFrequencyText;
 import us.ihmc.rdx.ui.graphics.RDXMessageSizeReadout;
 import us.ihmc.rdx.ui.graphics.RDXSequenceDiscontinuityPlot;
+import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Topic;
 import us.ihmc.ros2.RealtimeROS2Node;
 import us.ihmc.tools.thread.MissingThreadTools;
@@ -70,10 +71,9 @@ public abstract class RDXROS2ColoredPointCloudVisualizerChannel
       channelDecompressionThreadExecutor = MissingThreadTools.newSingleThreadExecutor("ChannelDecompressionThread", daemon, queueSize);
    }
 
-   public void subscribe(RealtimeROS2Node realtimeROS2Node, Object imageMessagesSyncObject)
+   public void subscribe(ROS2Node ros2Node, Object imageMessagesSyncObject)
    {
-      realtimeROS2Node.createSubscription(topic, subscriber ->
-      {
+      ros2Node.createSubscription(topic, subscriber -> {
          synchronized (imageMessagesSyncObject)
          {
             imageMessage.getData().resetQuick();

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXBallTrackingDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXBallTrackingDemo.java
@@ -133,7 +133,7 @@ public class RDXBallTrackingDemo
             perceptionVisualizerPanel.addVisualizer(colorImageVisualizer);
 
             RDXROS2ColoredPointCloudVisualizer pointCloudVisualizer = new RDXROS2ColoredPointCloudVisualizer("Point Cloud",
-                                                                                                             PubSubImplementation.FAST_RTPS,
+                                                                                                             ros2Node,
                                                                                                              PerceptionAPI.ZED2_DEPTH,
                                                                                                              PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.LEFT));
             pointCloudVisualizer.createRequestHeartbeat(ros2Node, PerceptionAPI.REQUEST_ZED_POINT_CLOUD);

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXIterativeClosestPointWorkerDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXIterativeClosestPointWorkerDemo.java
@@ -225,7 +225,7 @@ public class RDXIterativeClosestPointWorkerDemo
             perceptionVisualizerPanel.addVisualizer(zedDepthImageVisualizer);
 
             RDXROS2ColoredPointCloudVisualizer zedPointCloudVisualizer = new RDXROS2ColoredPointCloudVisualizer("ZED2 Colored Point Cloud",
-                                                                                                                DomainFactory.PubSubImplementation.FAST_RTPS,
+                                                                                                                node,
                                                                                                                 PerceptionAPI.ZED2_DEPTH,
                                                                                                                 PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.LEFT));
             zedPointCloudVisualizer.createRequestHeartbeat(node, PerceptionAPI.REQUEST_ZED_POINT_CLOUD);

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXYOLOv8PointCloudSegmentationDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXYOLOv8PointCloudSegmentationDemo.java
@@ -121,7 +121,7 @@ public class RDXYOLOv8PointCloudSegmentationDemo
             zedColorImageVisualizer.createRequestHeartbeat(node, PerceptionAPI.REQUEST_ZED_COLOR);
             perceptionVisualizerPanel.addVisualizer(zedColorImageVisualizer);
             RDXROS2ColoredPointCloudVisualizer zedPointCloudVisualizer = new RDXROS2ColoredPointCloudVisualizer("ZED 2 Colored Point Cloud",
-                                                                                                                DomainFactory.PubSubImplementation.FAST_RTPS,
+                                                                                                                node,
                                                                                                                 PerceptionAPI.ZED2_DEPTH,
                                                                                                                 PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.LEFT));
             zedPointCloudVisualizer.createRequestHeartbeat(node, PerceptionAPI.REQUEST_ZED_POINT_CLOUD);


### PR DESCRIPTION
This seemed unnecessary to me to have an extra ros2node in the point cloud visualizer