### PR TITLE
IK Teleoperation working for all handtypes

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/CommunicationsSyncedRobotModel.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/CommunicationsSyncedRobotModel.java
@@ -68,8 +68,7 @@ public abstract class CommunicationsSyncedRobotModel
       {
          for (RobotSide side : handModels.sides())
          {
-            if (robotModel.getRobotVersion().hasSakeGripperJoints(side))
-               handWrenchCalculators.put(side, new HandWrenchCalculator(side, fullRobotModel, null, StateEstimatorParameters.ROBOT_CONFIGURATION_DATA_PUBLISH_DT));
+            handWrenchCalculators.put(side, new HandWrenchCalculator(side, fullRobotModel, null, StateEstimatorParameters.ROBOT_CONFIGURATION_DATA_PUBLISH_DT));
          }
       }
    }


### PR DESCRIPTION
Due to only the SakeHandGripper getting handwrenches, moving the hands in RDX did not work for other hand types such as nub or no hand at all. 