### PR TITLE
Allow Multipl RTPS Subnets

### DIFF
--- a/ihmc-communication/src/main/java/us/ihmc/communication/ROS2Tools.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ROS2Tools.java
@@ -1,14 +1,21 @@
 package us.ihmc.communication;
 
 import us.ihmc.commons.thread.Notification;
+import us.ihmc.log.LogTools;
 import us.ihmc.pubsub.DomainFactory.PubSubImplementation;
 import us.ihmc.pubsub.TopicDataType;
-import us.ihmc.ros2.*;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2NodeInterface;
+import us.ihmc.ros2.ROS2QosProfile;
+import us.ihmc.ros2.ROS2Topic;
+import us.ihmc.ros2.ROS2TopicNameTools;
+import us.ihmc.ros2.RealtimeROS2Node;
 import us.ihmc.tools.thread.SwapReference;
 import us.ihmc.util.PeriodicRealtimeThreadSchedulerFactory;
 import us.ihmc.util.PeriodicThreadSchedulerFactory;
 
 import java.net.InetAddress;
+import java.util.Arrays;
 import java.util.function.Consumer;
 
 /**
@@ -89,7 +96,18 @@ public final class ROS2Tools
     */
    public static ROS2Node createLoopbackROS2Node(PubSubImplementation pubSubImplementation, String nodeName)
    {
-      return new ROS2Node(pubSubImplementation, nodeName, FACTORY.getDomainId(), InetAddress.getLoopbackAddress());
+      InetAddress loopbackAddress = InetAddress.getLoopbackAddress();
+      if (FACTORY.getAddressRestriction().length != 0 && !Arrays.asList(FACTORY.getAddressRestriction()).contains(loopbackAddress))
+      {
+         LogTools.warn("""
+                             You are creating a loopback ROS2 node, but your RTPSSubnet restriction does not allow the loopback address.
+                             For this node to communicate with other nodes, you can add {}/8 to the network parameters file.
+                             (Currently allowed addresses: {})""",
+                       loopbackAddress.getHostAddress(),
+                       FACTORY.getAddressRestriction());
+      }
+
+      return new ROS2Node(pubSubImplementation, nodeName, FACTORY.getDomainId(), loopbackAddress);
    }
 
    /**

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ROS2Tools.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ROS2Tools.java
@@ -100,9 +100,9 @@ public final class ROS2Tools
       if (FACTORY.getAddressRestriction().length != 0 && !Arrays.asList(FACTORY.getAddressRestriction()).contains(loopbackAddress))
       {
          LogTools.warn("""
-                             You are creating a loopback ROS2 node, but your RTPSSubnet restriction does not allow the loopback address.
-                             For this node to communicate with other nodes, you can add {}/8 to the network parameters file.
-                             (Currently allowed addresses: {})""",
+                       You are creating a loopback ROS2 node, but your RTPSSubnet restriction does not allow the loopback address.
+                       For this node to communicate with other nodes, you can add {}/8 to the network parameters file.
+                       (Currently allowed addresses: {})""",
                        loopbackAddress.getHostAddress(),
                        FACTORY.getAddressRestriction());
       }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/RTPSCommunicationFactory.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/RTPSCommunicationFactory.java
@@ -1,22 +1,24 @@
 package us.ihmc.communication;
 
+import org.apache.commons.lang3.SystemUtils;
+import org.apache.commons.net.util.SubnetUtils;
+import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
+import us.ihmc.communication.configuration.NetworkParameterKeys;
+import us.ihmc.communication.configuration.NetworkParameters;
+import us.ihmc.log.LogTools;
+
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InterfaceAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.SystemUtils;
-import org.apache.commons.net.util.SubnetUtils;
-
-import org.apache.commons.net.util.SubnetUtils.SubnetInfo;
-import us.ihmc.communication.configuration.NetworkParameterKeys;
-import us.ihmc.communication.configuration.NetworkParameters;
-import us.ihmc.log.LogTools;
 
 /**
  * Loads the Domain ID and Subnet Restriction from ~/.ihmc/IHMCNetworkParameters.ini
@@ -27,7 +29,7 @@ public class RTPSCommunicationFactory
    private static final List<InterfaceAddress> MACHINE_INTERFACE_ADDRESSES = findInterfaceAddresses();
 
    private final int defaultDomainID;
-   private final InetAddress defaultAddressRestriction;
+   private final InetAddress[] defaultAddressRestrictions;
 
    /**
     * Creates an RTPSCommunicationFactory. Loads the default RTPS Domain ID from the Network Parameter
@@ -55,66 +57,69 @@ public class RTPSCommunicationFactory
                      """.formatted(NetworkParameters.defaultParameterFile, rtpsDomainID));
       }
 
-      InetAddress foundAddressRestriction = null;
+      Set<InetAddress> foundAddressRestrictions = new HashSet<>();
 
-      String restrictionHost;
+      String restrictionHostString;
       if (MACHINE_INTERFACE_ADDRESSES != null
        && NetworkParameters.hasKey(NetworkParameterKeys.RTPSSubnet)
-       && !(restrictionHost = NetworkParameters.getHost(NetworkParameterKeys.RTPSSubnet)).isEmpty())
+       && !(restrictionHostString = NetworkParameters.getHost(NetworkParameterKeys.RTPSSubnet)).isEmpty())
       {
-         if (SystemUtils.IS_OS_WINDOWS && !restrictionHost.contains("127.0.0.1")) // 127.0.0.1/X might be the only one that works on Windows
+         if (SystemUtils.IS_OS_WINDOWS && !restrictionHostString.contains("127.0.0.1")) // 127.0.0.1/X might be the only one that works on Windows
          {
             LogTools.warn("This feature might not work on Windows! "
                           + "If you are not receiving data, try it using 127.0.0.1/24 or without setting a subnet restriction.");
          }
 
-         LogTools.info("Scanning interfaces for restriction: {}",  restrictionHost);
+         LogTools.info("Scanning interfaces for restriction: {}",  restrictionHostString);
 
-         SubnetInfo restrictionSubnetInfo = new SubnetUtils(restrictionHost).getInfo();
-         LogTools.debug("Restriction subnet info:\n{}", restrictionSubnetInfo);
-         LogTools.info("Restriction address: {}", restrictionSubnetInfo.getAddress());
-         LogTools.info("Restriction netmask: {}", restrictionSubnetInfo.getNetmask());
-
-         for (InterfaceAddress interfaceAddress : MACHINE_INTERFACE_ADDRESSES)
+         String[] restrictionHostList = restrictionHostString.split("\\s*,\\s*");
+         for (String restrictionHost : restrictionHostList)
          {
-            InetAddress address = interfaceAddress.getAddress();
+            SubnetInfo restrictionSubnetInfo = new SubnetUtils(restrictionHost).getInfo();
+            LogTools.debug("Restriction subnet info:\n{}", restrictionSubnetInfo);
+            LogTools.info("Restriction address: {}", restrictionSubnetInfo.getAddress());
+            LogTools.info("Restriction netmask: {}", restrictionSubnetInfo.getNetmask());
 
-            if (address instanceof Inet4Address)
+            for (InterfaceAddress interfaceAddress : MACHINE_INTERFACE_ADDRESSES)
             {
-               short netmaskAsShort = interfaceAddress.getNetworkPrefixLength();
+               InetAddress address = interfaceAddress.getAddress();
 
-               String interfaceHost = address.getHostAddress();
-               SubnetInfo interfaceSubnetInfo = new SubnetUtils(interfaceHost + "/" + netmaskAsShort).getInfo();
-
-               LogTools.debug("Interface Subnet Info: " + interfaceSubnetInfo);
-               LogTools.debug("Interface address: " + interfaceSubnetInfo.getAddress());
-               LogTools.debug("Interface netmask: " + interfaceSubnetInfo.getNetmask());
-
-               boolean inRange;
-               if (SystemUtils.IS_OS_WINDOWS)
+               if (address instanceof Inet4Address)
                {
-                  inRange = interfaceSubnetInfo.isInRange(restrictionSubnetInfo.getAddress()); // This worked on Windows, but not Linux: Doug
-               }
-               else // Linux and others
-               {
-                  // This works on Linux. Does not work on Windows. Not tested on Mac.
-                  inRange = restrictionSubnetInfo.isInRange(interfaceSubnetInfo.getAddress());
-               }
+                  short netmaskAsShort = interfaceAddress.getNetworkPrefixLength();
 
-               if (inRange)
-               {
-                  LogTools.info("Found address in range: {}", address);
-                  foundAddressRestriction = address;
-                  break;
+                  String interfaceHost = address.getHostAddress();
+                  SubnetInfo interfaceSubnetInfo = new SubnetUtils(interfaceHost + "/" + netmaskAsShort).getInfo();
+
+                  LogTools.debug("Interface Subnet Info: " + interfaceSubnetInfo);
+                  LogTools.debug("Interface address: " + interfaceSubnetInfo.getAddress());
+                  LogTools.debug("Interface netmask: " + interfaceSubnetInfo.getNetmask());
+
+                  boolean inRange;
+                  if (SystemUtils.IS_OS_WINDOWS)
+                  {
+                     inRange = interfaceSubnetInfo.isInRange(restrictionSubnetInfo.getAddress()); // This worked on Windows, but not Linux: Doug
+                  }
+                  else // Linux and others
+                  {
+                     // This works on Linux. Does not work on Windows. Not tested on Mac.
+                     inRange = restrictionSubnetInfo.isInRange(interfaceSubnetInfo.getAddress());
+                  }
+
+                  if (inRange)
+                  {
+                     LogTools.info("Found address in range: {}", address);
+                     foundAddressRestrictions.add(address);
+                  }
                }
             }
          }
       }
 
       defaultDomainID = rtpsDomainID;
-      defaultAddressRestriction = foundAddressRestriction;
-      if (defaultAddressRestriction != null)
-         LogTools.info("Setting IP restriction: {}", defaultAddressRestriction.getHostAddress());
+      defaultAddressRestrictions = foundAddressRestrictions.toArray(InetAddress[]::new);
+      if (defaultAddressRestrictions.length > 0)
+         LogTools.info("Setting IP restriction: {}", Arrays.stream(defaultAddressRestrictions).map(InetAddress::getHostAddress).toList());
    }
 
    private static List<InterfaceAddress> findInterfaceAddresses()
@@ -136,9 +141,9 @@ public class RTPSCommunicationFactory
     * 
     * @return
     */
-   public InetAddress getAddressRestriction()
+   public InetAddress[] getAddressRestriction()
    {
-      return defaultAddressRestriction;
+      return defaultAddressRestrictions;
    }
 
    int getDomainId()

--- a/ihmc-communication/src/main/java/us/ihmc/communication/RTPSCommunicationFactory.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/RTPSCommunicationFactory.java
@@ -75,7 +75,7 @@ public class RTPSCommunicationFactory
          String[] restrictionHostList = restrictionHostString.split("\\s*,\\s*");
          for (String restrictionHost : restrictionHostList)
          {
-            SubnetInfo restrictionSubnetInfo = new SubnetUtils(restrictionHost).getInfo();
+            SubnetInfo restrictionSubnetInfo = new SubnetUtils(restrictionHost.trim()).getInfo();
             LogTools.debug("Restriction subnet info:\n{}", restrictionSubnetInfo);
             LogTools.info("Restriction address: {}", restrictionSubnetInfo.getAddress());
             LogTools.info("Restriction netmask: {}", restrictionSubnetInfo.getNetmask());

--- a/ihmc-communication/src/main/java/us/ihmc/communication/configuration/NetworkParameterKeys.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/configuration/NetworkParameterKeys.java
@@ -17,8 +17,8 @@ public enum NetworkParameterKeys
    rightHand("Hostname/IP of the right hand.", "", true),
 
    RTPSDomainID("RTPS Domain ID used for rtps publishers and subscribers", "-1", false),
-   RTPSSubnet("RTPS subnet restriction, expected format: \"192.168.1.0/24\". "
-              + "When provided RTPS only communicate through the indicated sub-network. "
+   RTPSSubnet("RTPS subnet restriction, expected format: \"192.168.1.0/24, 127.0.0.1/8\". "
+              + "When provided RTPS only communicate through the indicated sub-network(s). "
               + "Might not work on Windows!", null, true);
 
    private final String description;

--- a/ihmc-communication/src/main/java/us/ihmc/communication/configuration/NetworkParameters.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/configuration/NetworkParameters.java
@@ -1,5 +1,8 @@
 package us.ihmc.communication.configuration;
 
+import org.apache.commons.lang3.StringUtils;
+import us.ihmc.log.LogTools;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -8,10 +11,6 @@ import java.net.URISyntaxException;
 import java.util.EnumMap;
 import java.util.Locale;
 import java.util.Properties;
-
-import org.apache.commons.lang3.StringUtils;
-
-import us.ihmc.log.LogTools;
 
 public class NetworkParameters
 {
@@ -179,5 +178,10 @@ public class NetworkParameters
    public static boolean hasKey(NetworkParameterKeys key)
    {
       return getInstance().parameters.containsKey(key);
+   }
+
+   public static synchronized void reload()
+   {
+      instance = null;
    }
 }

--- a/ihmc-communication/src/test/java/us/ihmc/communication/NetworkParametersTest.java
+++ b/ihmc-communication/src/test/java/us/ihmc/communication/NetworkParametersTest.java
@@ -1,0 +1,185 @@
+package us.ihmc.communication;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import us.ihmc.communication.configuration.NetworkParameterKeys;
+import us.ihmc.communication.configuration.NetworkParameters;
+import us.ihmc.log.LogTools;
+import us.ihmc.tools.IHMCCommonPaths;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Properties;
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class NetworkParametersTest
+{
+   protected static final Random RANDOM = new Random(0L);
+
+   private static final Path TEST_DIR_PATH = IHMCCommonPaths.DOT_IHMC_DIRECTORY.resolve("network-parameters-test");
+   private static final Path TEST_FILE_PATH = TEST_DIR_PATH.resolve("TestIHMCNetworkParameters.ini");
+   private static final File TEST_DIRECTORY = TEST_DIR_PATH.toFile();
+   private static final File TEST_FILE = TEST_FILE_PATH.toFile();
+
+   private static String PARAMETER_FILE_PATH;
+
+   @BeforeAll
+   public static void createTestingDirectory()
+   {
+      PARAMETER_FILE_PATH = System.getProperty("us.ihmc.networkParameterFile");
+
+      if (TEST_DIRECTORY.exists())
+         assumeTrue(TEST_DIRECTORY.delete(), "Could not delete an existing test directory" + TEST_DIR_PATH);
+      assumeTrue(TEST_DIRECTORY.mkdirs(), "Could not make a test directory: " + TEST_DIR_PATH);
+      TEST_DIRECTORY.deleteOnExit();
+
+      System.setProperty("us.ihmc.networkParameterFile", TEST_FILE_PATH.toString());
+   }
+
+   @AfterAll
+   public static void resetParameterFilePath()
+   {
+      if (PARAMETER_FILE_PATH != null)
+         System.setProperty("us.ihmc.networkParameterFile", PARAMETER_FILE_PATH);
+   }
+
+   @Test
+   public void testNoFile()
+   {
+      // Delete any existing test file
+      deleteTestFile();
+
+      // Reload existing network parameters
+      NetworkParameters.reload();
+
+      for (NetworkParameterKeys key : NetworkParameterKeys.values())
+      {
+         assertFalse(NetworkParameters.hasKey(key));
+         assertThrows(Exception.class, () -> NetworkParameters.getHost(key));
+      }
+
+      assertEquals(1, NetworkParameters.getRTPSDomainID());
+   }
+
+   @Test
+   public void testEmptyFile()
+   {
+      // Delete any existing test file
+      deleteTestFile();
+
+      // Create a new (empty) test file
+      createEmptyTestFile();
+
+      // Reload existing network parameters
+      NetworkParameters.reload();
+
+      for (NetworkParameterKeys key : NetworkParameterKeys.values())
+      {
+         assertFalse(NetworkParameters.hasKey(key));
+         assertThrows(Exception.class, () -> NetworkParameters.getHost(key));
+      }
+
+      assertEquals(1, NetworkParameters.getRTPSDomainID());
+   }
+
+   @Test
+   public void testLoadingRTPSDomainID()
+   {
+      testLoadingRTPSDomainID(RANDOM.nextInt(230));
+   }
+
+   protected void testLoadingRTPSDomainID(int testDomainID)
+   {
+      // Create parameters file with random domain id
+      createTestNetworkParametersFile(testDomainID);
+
+      // Reload the file
+      NetworkParameters.reload();
+
+      assertEquals(testDomainID, NetworkParameters.getRTPSDomainID());
+   }
+
+   @Test
+   public void testLoadingRTPSDomainRestrictions()
+   {
+      testLoadingRTPSDomainRestrictions("127.0.0.1/8", "192.0.2.0/24", "198.51.100.0/24", "0.0.0.0/24");
+   }
+
+   protected void testLoadingRTPSDomainRestrictions(String... testAddressRestrictions)
+   {
+      // Create parameters file with rtps subnet restrictions
+      createTestNetworkParametersFile(230, testAddressRestrictions);
+
+      // Reload the parameters
+      NetworkParameters.reload();
+
+      // Ensure parameters contain same restrictions
+      String combinedRestrictions = combineSubnetRestrictions(testAddressRestrictions);
+      assertEquals(combinedRestrictions, NetworkParameters.getHost(NetworkParameterKeys.RTPSSubnet));
+   }
+
+   protected void deleteTestFile()
+   {
+      if (TEST_FILE.exists())
+         assumeTrue(TEST_FILE.delete(), "Could not delete the test file: " + TEST_FILE_PATH);
+   }
+
+   protected void createEmptyTestFile()
+   {
+      boolean success = true;
+      try
+      {
+         assumeTrue(TEST_FILE.createNewFile(), "Could not create a test file: " + TEST_FILE_PATH);
+         TEST_FILE.deleteOnExit();
+      }
+      catch (IOException exception)
+      {
+         LogTools.error(exception);
+         success = false;
+      }
+
+      assumeTrue(success, "Exception thrown while creating a test file: " + TEST_FILE_PATH);
+   }
+
+   protected String combineSubnetRestrictions(String... subnetRestrictions)
+   {
+      StringBuilder combinedString = new StringBuilder(subnetRestrictions[0]);
+      for (int i = 1; i < subnetRestrictions.length; ++i)
+         combinedString.append(", ").append(subnetRestrictions[i]);
+      return combinedString.toString();
+   }
+
+   protected void createTestNetworkParametersFile(int rtpsDomainID, String... rtpsSubnetRestrictions)
+   {
+      boolean success = true;
+
+      deleteTestFile();
+
+      try
+      {
+         createEmptyTestFile();
+         FileOutputStream outputStream = new FileOutputStream(TEST_FILE);
+
+         Properties networkProperties = new Properties();
+         networkProperties.setProperty(NetworkParameterKeys.RTPSDomainID.toString(), String.valueOf(rtpsDomainID));
+
+         if (rtpsSubnetRestrictions != null && rtpsSubnetRestrictions.length > 0)
+            networkProperties.setProperty(NetworkParameterKeys.RTPSSubnet.toString(), combineSubnetRestrictions(rtpsSubnetRestrictions));
+
+         networkProperties.store(outputStream, "Test properties!");
+         outputStream.close();
+      }
+      catch (IOException exception)
+      {
+         success = false;
+      }
+
+      assumeTrue(success, "Failed to write to test file: " + TEST_FILE_PATH);
+   }
+}

--- a/ihmc-communication/src/test/java/us/ihmc/communication/RTPSCommunicationFactoryTest.java
+++ b/ihmc-communication/src/test/java/us/ihmc/communication/RTPSCommunicationFactoryTest.java
@@ -1,0 +1,138 @@
+package us.ihmc.communication;
+
+import org.apache.commons.lang3.mutable.MutableBoolean;
+import org.junit.jupiter.api.Test;
+
+import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.InterfaceAddress;
+import java.net.NetworkInterface;
+import java.net.SocketException;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+public class RTPSCommunicationFactoryTest extends NetworkParametersTest
+{
+   @Test
+   @Override
+   public void testNoFile()
+   {
+      super.testNoFile();
+
+      for (int i = 0; i < 90; ++i)
+      {
+         RTPSCommunicationFactory factory = new RTPSCommunicationFactory();
+         assertTrue(factory.getDomainId() > 199 && factory.getDomainId() < 230);
+         assertNotNull(factory.getAddressRestriction());
+         assertEquals(0, factory.getAddressRestriction().length);
+      }
+   }
+
+   @Test
+   @Override
+   public void testEmptyFile()
+   {
+      super.testEmptyFile();
+
+      for (int i = 0; i < 90; ++i)
+      {
+         RTPSCommunicationFactory factory = new RTPSCommunicationFactory();
+         assertTrue(factory.getDomainId() > 199 && factory.getDomainId() < 230);
+         assertNotNull(factory.getAddressRestriction());
+         assertEquals(0, factory.getAddressRestriction().length);
+      }
+   }
+
+   @Test
+   @Override
+   public void testLoadingRTPSDomainID()
+   {
+      int testDomainID = RANDOM.nextInt(230);
+      testLoadingRTPSDomainID(testDomainID);
+
+      RTPSCommunicationFactory factory = new RTPSCommunicationFactory();
+      assertEquals(testDomainID, factory.getDomainId());
+   }
+
+   @Test
+   @Override
+   public void testLoadingRTPSDomainRestrictions()
+   {
+      InterfaceAddress[] availableAddresses = getAvailableAddresses();
+
+      testLoadingRTPSDomainRestrictions(interfaceAddressToString(availableAddresses));
+
+      RTPSCommunicationFactory factory = new RTPSCommunicationFactory();
+      assertEquals(availableAddresses.length, factory.getAddressRestriction().length);
+   }
+
+   @Test
+   public void testLoopbackOnlyRestriction()
+   {
+      InterfaceAddress[] availableAddresses = getAvailableAddresses();
+      InterfaceAddress loopbackAddress = Arrays.stream(availableAddresses).filter(address -> address.getAddress().isLoopbackAddress()).findAny().orElse(null);
+      assumeTrue(loopbackAddress != null);
+
+      testLoadingRTPSDomainRestrictions(interfaceAddressToString(loopbackAddress));
+
+      RTPSCommunicationFactory factory = new RTPSCommunicationFactory();
+      assertEquals(1, factory.getAddressRestriction().length);
+      assertEquals(InetAddress.getLoopbackAddress(), factory.getAddressRestriction()[0]);
+   }
+
+   @Test
+   public void testAllExclusiveRestriction()
+   {
+      testLoadingRTPSDomainRestrictions("0.0.0.0/32");
+
+      RTPSCommunicationFactory factory = new RTPSCommunicationFactory();
+      assertEquals(0, factory.getAddressRestriction().length);
+   }
+
+   @Test
+   public void testAllInclusiveRestriction()
+   {
+      InterfaceAddress[] availableAddresses = getAvailableAddresses();
+
+      testLoadingRTPSDomainRestrictions("0.0.0.0/0");
+
+      RTPSCommunicationFactory factory = new RTPSCommunicationFactory();
+      assertEquals(availableAddresses.length, factory.getAddressRestriction().length);
+   }
+
+   private String[] interfaceAddressToString(InterfaceAddress... addresses)
+   {
+      String[] addressesAsStrings = new String[addresses.length];
+      for (int i = 0; i < addresses.length; ++i)
+         addressesAsStrings[i] = interfaceAddressToString(addresses[i]);
+      return addressesAsStrings;
+   }
+
+   private String interfaceAddressToString(InterfaceAddress address)
+   {
+      return address.getAddress().getHostAddress() + "/" + address.getNetworkPrefixLength();
+   }
+
+   private InterfaceAddress[] getAvailableAddresses()
+   {
+      MutableBoolean success = new MutableBoolean(true);
+      InterfaceAddress[] addresses;
+      try
+      {
+         addresses = NetworkInterface.networkInterfaces()
+                                     .flatMap(networkInterface -> networkInterface.getInterfaceAddresses().stream())
+                                     .filter(interfaceAddress -> interfaceAddress.getAddress() instanceof Inet4Address)
+                                     .toArray(InterfaceAddress[]::new);
+      }
+      catch (SocketException e)
+      {
+        success.setFalse();
+        addresses = null;
+      }
+
+      assumeTrue(success.getValue());
+      return addresses;
+   }
+}


### PR DESCRIPTION
Allow specifying multiple RTPS subnets in IHMCNetworkParameters.ini by separating them with commas. 