### PR TITLE
Disable old behavior tests.

### DIFF
--- a/.github/workflows/gradle-test-fast.yml
+++ b/.github/workflows/gradle-test-fast.yml
@@ -32,11 +32,6 @@ jobs:
     with:
       subproject: 'atlas'
       test-category: 'controller-api-2'
-  atlas-humanoid-behaviors:
-    uses: ihmcrobotics/ihmc-actions/.github/workflows/gradle-test.yml@main
-    with:
-      subproject: 'atlas'
-      test-category: 'humanoid-behaviors'
   atlas-humanoid-flat-ground:
     uses: ihmcrobotics/ihmc-actions/.github/workflows/gradle-test.yml@main
     with:

--- a/.github/workflows/gradle-test-slow.yml
+++ b/.github/workflows/gradle-test-slow.yml
@@ -35,11 +35,6 @@ jobs:
     with:
       subproject: 'atlas'
       test-category: 'controller-api-slow-4'
-  atlas-humanoid-behaviors-slow:
-    uses: ihmcrobotics/ihmc-actions/.github/workflows/gradle-test.yml@main
-    with:
-      subproject: 'atlas'
-      test-category: 'humanoid-behaviors-slow'
   atlas-humanoid-flat-ground-slow-2:
     uses: ihmcrobotics/ihmc-actions/.github/workflows/gradle-test.yml@main
     with:

--- a/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasBehaviorDispatcherTest.java
+++ b/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasBehaviorDispatcherTest.java
@@ -11,6 +11,8 @@ import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.RobotTarget;
 import us.ihmc.simulationConstructionSetTools.tools.CITools;
 
+@Disabled
+@Deprecated
 public class AtlasBehaviorDispatcherTest extends HumanoidBehaviorDispatcherTest
 {
    private final AtlasRobotModel robotModel;

--- a/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasFootstepListBehaviorTest.java
+++ b/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasFootstepListBehaviorTest.java
@@ -1,5 +1,6 @@
 package us.ihmc.atlas.behaviorTests;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,8 @@ import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.RobotTarget;
 import us.ihmc.simulationConstructionSetTools.tools.CITools;
 
+@Disabled
+@Deprecated
 public class AtlasFootstepListBehaviorTest extends DRCFootstepListBehaviorTest
 {
    private final AtlasRobotModel robotModel;

--- a/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasHandDesiredConfigurationBehaviorTest.java
+++ b/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasHandDesiredConfigurationBehaviorTest.java
@@ -1,5 +1,6 @@
 package us.ihmc.atlas.behaviorTests;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,8 @@ import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.RobotTarget;
 import us.ihmc.simulationConstructionSetTools.tools.CITools;
 
+@Disabled
+@Deprecated
 public class AtlasHandDesiredConfigurationBehaviorTest extends HumanoidHandDesiredConfigurationBehaviorTest
 {
    private final AtlasRobotModel robotModel;

--- a/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasHeadTrajectoryBehaviorTest.java
+++ b/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasHeadTrajectoryBehaviorTest.java
@@ -11,6 +11,8 @@ import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.RobotTarget;
 import us.ihmc.simulationConstructionSetTools.tools.CITools;
 
+@Disabled
+@Deprecated
 @Tag("humanoid-behaviors-slow")
 public class AtlasHeadTrajectoryBehaviorTest extends DRCHeadTrajectoryBehaviorTest
 {

--- a/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasHighLevelStateBehaviorTest.java
+++ b/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasHighLevelStateBehaviorTest.java
@@ -11,6 +11,8 @@ import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.RobotTarget;
 import us.ihmc.simulationConstructionSetTools.tools.CITools;
 
+@Disabled
+@Deprecated
 public class AtlasHighLevelStateBehaviorTest extends DRCHighLevelStateBehaviorTest
 {
    private final AtlasRobotModel robotModel;

--- a/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasObjectWeightBehaviorTest.java
+++ b/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasObjectWeightBehaviorTest.java
@@ -11,6 +11,8 @@ import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.RobotTarget;
 import us.ihmc.simulationConstructionSetTools.tools.CITools;
 
+@Disabled
+@Deprecated
 @Tag("humanoid-behaviors-slow")
 public class AtlasObjectWeightBehaviorTest extends DRCObjectWeightBehaviorTest
 {

--- a/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasWalkToLocationBehaviorTest.java
+++ b/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasWalkToLocationBehaviorTest.java
@@ -11,6 +11,8 @@ import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.RobotTarget;
 import us.ihmc.simulationConstructionSetTools.tools.CITools;
 
+@Disabled
+@Deprecated
 public class AtlasWalkToLocationBehaviorTest extends DRCWalkToLocationBehaviorTest
 {
    private final AtlasRobotModel robotModel;

--- a/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasWholeBodyInverseKinematicsBehaviorTest.java
+++ b/atlas/src/test/java/us/ihmc/atlas/behaviorTests/AtlasWholeBodyInverseKinematicsBehaviorTest.java
@@ -1,5 +1,6 @@
 package us.ihmc.atlas.behaviorTests;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -9,6 +10,8 @@ import us.ihmc.avatar.behaviorTests.WholeBodyInverseKinematicsBehaviorTest;
 import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.RobotTarget;
 
+@Disabled
+@Deprecated
 public class AtlasWholeBodyInverseKinematicsBehaviorTest extends WholeBodyInverseKinematicsBehaviorTest
 {
    private final DRCRobotModel robotModel = new AtlasRobotModel(AtlasRobotVersion.ATLAS_UNPLUGGED_V5_NO_HANDS, RobotTarget.SCS, false);

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCFootstepListBehaviorTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCFootstepListBehaviorTest.java
@@ -7,6 +7,7 @@ import java.util.ArrayList;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import controller_msgs.msg.dds.FootstepDataListMessage;
@@ -41,6 +42,8 @@ import us.ihmc.simulationConstructionSetTools.util.environments.DefaultCommonAva
 import us.ihmc.simulationconstructionset.util.simulationTesting.SimulationTestingParameters;
 import us.ihmc.tools.MemoryTools;
 
+@Disabled
+@Deprecated
 public abstract class DRCFootstepListBehaviorTest implements MultiRobotTestInterface
 {
    private static final SimulationTestingParameters simulationTestingParameters = SimulationTestingParameters.createFromSystemProperties();

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCHeadTrajectoryBehaviorTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCHeadTrajectoryBehaviorTest.java
@@ -5,6 +5,7 @@ import java.util.Random;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import controller_msgs.msg.dds.HeadTrajectoryMessage;
@@ -32,6 +33,8 @@ import us.ihmc.tools.MemoryTools;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+@Disabled
+@Deprecated
 public abstract class DRCHeadTrajectoryBehaviorTest implements MultiRobotTestInterface
 {
    private static final SimulationTestingParameters simulationTestingParameters = SimulationTestingParameters.createFromSystemProperties();

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCHighLevelStateBehaviorTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCHighLevelStateBehaviorTest.java
@@ -5,6 +5,7 @@ import static us.ihmc.robotics.Assert.assertTrue;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import us.ihmc.avatar.MultiRobotTestInterface;
@@ -20,6 +21,8 @@ import us.ihmc.simulationConstructionSetTools.util.environments.DefaultCommonAva
 import us.ihmc.simulationconstructionset.util.simulationTesting.SimulationTestingParameters;
 import us.ihmc.tools.MemoryTools;
 
+@Disabled
+@Deprecated
 public abstract class DRCHighLevelStateBehaviorTest implements MultiRobotTestInterface
 {
    private static final SimulationTestingParameters simulationTestingParameters = SimulationTestingParameters.createFromSystemProperties();

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCObjectWeightBehaviorTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCObjectWeightBehaviorTest.java
@@ -21,6 +21,8 @@ import us.ihmc.simulationconstructionset.util.simulationTesting.SimulationTestin
 import us.ihmc.tools.MemoryTools;
 import us.ihmc.yoVariables.variable.YoDouble;
 
+@Disabled
+@Deprecated
 public abstract class DRCObjectWeightBehaviorTest implements MultiRobotTestInterface
 {
    private static final SimulationTestingParameters simulationTestingParameters = SimulationTestingParameters.createFromSystemProperties();

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCWalkToLocationBehaviorTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/DRCWalkToLocationBehaviorTest.java
@@ -9,6 +9,7 @@ import java.util.Random;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import us.ihmc.avatar.MultiRobotTestInterface;
@@ -35,6 +36,8 @@ import us.ihmc.simulationConstructionSetTools.util.environments.FlatGroundEnviro
 import us.ihmc.simulationconstructionset.util.simulationTesting.SimulationTestingParameters;
 import us.ihmc.tools.MemoryTools;
 
+@Disabled
+@Deprecated
 public abstract class DRCWalkToLocationBehaviorTest implements MultiRobotTestInterface
 {
    private static final SimulationTestingParameters simulationTestingParameters = SimulationTestingParameters.createFromSystemProperties();

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/HumanoidBehaviorDispatcherTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/HumanoidBehaviorDispatcherTest.java
@@ -9,6 +9,7 @@ import java.util.Arrays;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import toolbox_msgs.msg.dds.BehaviorControlModePacket;
@@ -66,6 +67,8 @@ import us.ihmc.yoVariables.variable.YoBoolean;
 import us.ihmc.yoVariables.variable.YoDouble;
 import us.ihmc.yoVariables.variable.YoEnum;
 
+@Disabled
+@Deprecated
 public abstract class HumanoidBehaviorDispatcherTest implements MultiRobotTestInterface
 {
    private static final ReferenceFrame worldFrame = ReferenceFrame.getWorldFrame();

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/HumanoidHandDesiredConfigurationBehaviorTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/HumanoidHandDesiredConfigurationBehaviorTest.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import controller_msgs.msg.dds.HandDesiredConfigurationMessage;
@@ -28,6 +29,8 @@ import us.ihmc.simulationConstructionSetTools.util.environments.DefaultCommonAva
 import us.ihmc.simulationconstructionset.util.simulationTesting.SimulationTestingParameters;
 import us.ihmc.tools.MemoryTools;
 
+@Disabled
+@Deprecated
 public abstract class HumanoidHandDesiredConfigurationBehaviorTest implements MultiRobotTestInterface
 {
    private static final SimulationTestingParameters simulationTestingParameters = SimulationTestingParameters.createFromSystemProperties();

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/KinematicsPlanningBehaviorTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/KinematicsPlanningBehaviorTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import toolbox_msgs.msg.dds.KinematicsPlanningToolboxOutputStatus;
@@ -41,6 +42,8 @@ import us.ihmc.simulationConstructionSetTools.util.environments.ValkyrieEODObsta
 import us.ihmc.simulationconstructionset.util.simulationTesting.SimulationTestingParameters;
 import us.ihmc.tools.MemoryTools;
 
+@Disabled
+@Deprecated
 public abstract class KinematicsPlanningBehaviorTest implements MultiRobotTestInterface
 {
    private static final SimulationTestingParameters simulationTestingParameters = SimulationTestingParameters.createFromSystemProperties();

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/WholeBodyInverseKinematicsBehaviorTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/behaviorTests/WholeBodyInverseKinematicsBehaviorTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import us.ihmc.avatar.MultiRobotTestInterface;
@@ -40,6 +41,8 @@ import us.ihmc.simulationConstructionSetTools.util.environments.FlatGroundEnviro
 import us.ihmc.simulationconstructionset.util.simulationTesting.SimulationTestingParameters;
 import us.ihmc.tools.MemoryTools;
 
+@Disabled
+@Deprecated
 public abstract class WholeBodyInverseKinematicsBehaviorTest implements MultiRobotTestInterface
 {
    private static final SimulationTestingParameters simulationTestingParameters = SimulationTestingParameters.createFromSystemProperties();


### PR DESCRIPTION
These tests are failing and are for the old old behavior framework. They are broken because the code has rotted. I think we'll remove the whole thing soon (or just ditch it).