### PR TITLE
Remove onnx

### DIFF
--- a/ihmc-perception/build.gradle.kts
+++ b/ihmc-perception/build.gradle.kts
@@ -94,6 +94,11 @@ mainDependencies {
 
    api("us.ihmc:ihmc-common-walking-control-modules:source")
    api("us.ihmc:robot-environment-awareness:source")
+
+   // Previously used for HeightMapAutoencoder and FootstepPredictor
+   // This is a very large dependency, only uncomment for testing purposes
+   // api("com.microsoft.onnxruntime:onnxruntime:1.11.0")
+   // api("com.microsoft.onnxruntime:onnxruntime_gpu:1.11.0")
 }
 
 testDependencies {

--- a/ihmc-perception/build.gradle.kts
+++ b/ihmc-perception/build.gradle.kts
@@ -94,9 +94,6 @@ mainDependencies {
 
    api("us.ihmc:ihmc-common-walking-control-modules:source")
    api("us.ihmc:robot-environment-awareness:source")
-
-   api("com.microsoft.onnxruntime:onnxruntime:1.11.0")
-   api("com.microsoft.onnxruntime:onnxruntime_gpu:1.11.0")
 }
 
 testDependencies {

--- a/ihmc-perception/src/main/java/us/ihmc/perception/neural/FootstepPredictor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/neural/FootstepPredictor.java
@@ -33,7 +33,10 @@ public class FootstepPredictor
    private static final int IMAGE_INPUT_HEIGHT = 201;
    private static final int IMAGE_INPUT_WIDTH = 201;
 
-   // TODO: We should use pytorch/opencv instead of ONNX. ONNX is a huge dependency we don't use anywhere else and we already have opencv and heavily use that.
+   // TODO: We should use opencv to load this onnx model or perhaps use pytorch with opencv
+   // To readd the Microsoft onnx dependency, add this to the main gradle dependencies:
+   //    api("com.microsoft.onnxruntime:onnxruntime:1.11.0")
+   //    api("com.microsoft.onnxruntime:onnxruntime_gpu:1.11.0")
    private String onnxFilePath = IHMCCommonPaths.USER_HOME_DIRECTORY.resolve("Downloads/Model_Weights/footstep_predictor_4.onnx").toString();
 
 //   private OrtEnvironment environment = OrtEnvironment.getEnvironment();

--- a/ihmc-perception/src/main/java/us/ihmc/perception/neural/FootstepPredictor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/neural/FootstepPredictor.java
@@ -1,6 +1,6 @@
 package us.ihmc.perception.neural;
 
-import ai.onnxruntime.*;
+//import ai.onnxruntime.*;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_imgproc;
@@ -33,131 +33,133 @@ public class FootstepPredictor
    private static final int IMAGE_INPUT_HEIGHT = 201;
    private static final int IMAGE_INPUT_WIDTH = 201;
 
+   // TODO: We should use pytorch/opencv instead of ONNX. ONNX is a huge dependency we don't use anywhere else and we already have opencv and heavily use that.
    private String onnxFilePath = IHMCCommonPaths.USER_HOME_DIRECTORY.resolve("Downloads/Model_Weights/footstep_predictor_4.onnx").toString();
 
-   private OrtEnvironment environment = OrtEnvironment.getEnvironment();
-   private OrtSession.SessionOptions sessionOptions = new OrtSession.SessionOptions();
-   private OrtSession session;
+//   private OrtEnvironment environment = OrtEnvironment.getEnvironment();
+//   private OrtSession.SessionOptions sessionOptions = new OrtSession.SessionOptions();
+//   private OrtSession session;
 
    public FootstepPredictor()
    {
-      try
-      {
-         session = environment.createSession(onnxFilePath, sessionOptions);
-
-         for (Map.Entry<String, NodeInfo> stringNodeInfoEntry : session.getInputInfo().entrySet())
-         {
-            LogTools.info("{}: {}", stringNodeInfoEntry.getKey(), stringNodeInfoEntry.getValue());
-         }
-         for (Map.Entry<String, NodeInfo> stringNodeInfoEntry : session.getOutputInfo().entrySet())
-         {
-            LogTools.info("{}: {}", stringNodeInfoEntry.getKey(), stringNodeInfoEntry.getValue());
-         }
-
-         //print all input names and sizes
-         for (Map.Entry<String, NodeInfo> entry : session.getInputInfo().entrySet())
-         {
-            String inputName = entry.getKey();
-            NodeInfo nodeInfo = entry.getValue();
-            LogTools.info("Input Name: {}", inputName);
-            LogTools.info("Input Info: {}", nodeInfo.toString());
-         }
-      }
-      catch (OrtException e)
-      {
-         throw new RuntimeException(e);
-      }
+//      try
+//      {
+//         session = environment.createSession(onnxFilePath, sessionOptions);
+//
+//         for (Map.Entry<String, NodeInfo> stringNodeInfoEntry : session.getInputInfo().entrySet())
+//         {
+//            LogTools.info("{}: {}", stringNodeInfoEntry.getKey(), stringNodeInfoEntry.getValue());
+//         }
+//         for (Map.Entry<String, NodeInfo> stringNodeInfoEntry : session.getOutputInfo().entrySet())
+//         {
+//            LogTools.info("{}: {}", stringNodeInfoEntry.getKey(), stringNodeInfoEntry.getValue());
+//         }
+//
+//         //print all input names and sizes
+//         for (Map.Entry<String, NodeInfo> entry : session.getInputInfo().entrySet())
+//         {
+//            String inputName = entry.getKey();
+//            NodeInfo nodeInfo = entry.getValue();
+//            LogTools.info("Input Name: {}", inputName);
+//            LogTools.info("Input Info: {}", nodeInfo.toString());
+//         }
+//      }
+//      catch (OrtException e)
+//      {
+//         throw new RuntimeException(e);
+//      }
    }
 
    public ArrayList<Point3D> generateFootsteps(Mat heightMap, Point2D startPosition, Point2D goalPosition, Point2D sensorPosition)
    {
       ArrayList<Point3D> footstepPositions = new ArrayList<>();
-      FMatrixRMaj linearInput = new FMatrixRMaj(LINEAR_INPUT_SIZE, 1);
-      linearInput.set(0, 0, startPosition.getX32());
-      linearInput.set(1, 0, startPosition.getY32());
-      linearInput.set(2, 0, 0);
-      linearInput.set(3, 0, goalPosition.getX32());
-      linearInput.set(4, 0, goalPosition.getY32());
-      linearInput.set(5, 0, 0);
-
-      FMatrixRMaj linearOutput = null;
-
-      try
-      {
-         linearOutput = predict(heightMap, linearInput);
-      }
-      catch (OrtException e)
-      {
-         throw new RuntimeException(e);
-      }
-
-      if (linearOutput != null)
-      {
-         for (int i = 0; i < LINEAR_OUTPUT_SIZE / FOOTSTEP_VECTOR_SIZE; i++)
-         {
-            Point3D point = new Point3D(linearOutput.get(FOOTSTEP_VECTOR_SIZE * i, 0) + sensorPosition.getX32(),
-                                        linearOutput.get(FOOTSTEP_VECTOR_SIZE * i + 1, 0) + sensorPosition.getY32(),
-                                        1.0);
-            footstepPositions.add(point);
-         }
-      }
+//      FMatrixRMaj linearInput = new FMatrixRMaj(LINEAR_INPUT_SIZE, 1);
+//      linearInput.set(0, 0, startPosition.getX32());
+//      linearInput.set(1, 0, startPosition.getY32());
+//      linearInput.set(2, 0, 0);
+//      linearInput.set(3, 0, goalPosition.getX32());
+//      linearInput.set(4, 0, goalPosition.getY32());
+//      linearInput.set(5, 0, 0);
+//
+//      FMatrixRMaj linearOutput = null;
+//
+//      try
+//      {
+//         linearOutput = predict(heightMap, linearInput);
+//      }
+//      catch (OrtException e)
+//      {
+//         throw new RuntimeException(e);
+//      }
+//
+//      if (linearOutput != null)
+//      {
+//         for (int i = 0; i < LINEAR_OUTPUT_SIZE / FOOTSTEP_VECTOR_SIZE; i++)
+//         {
+//            Point3D point = new Point3D(linearOutput.get(FOOTSTEP_VECTOR_SIZE * i, 0) + sensorPosition.getX32(),
+//                                        linearOutput.get(FOOTSTEP_VECTOR_SIZE * i + 1, 0) + sensorPosition.getY32(),
+//                                        1.0);
+//            footstepPositions.add(point);
+//         }
+//      }
 
       return footstepPositions;
    }
 
-   public FMatrixRMaj predict(Mat imageInput, FMatrixRMaj linearInput) throws OrtException
+   public FMatrixRMaj predict(Mat imageInput, FMatrixRMaj linearInput)
    {
-      if (imageInput.rows() != IMAGE_INPUT_HEIGHT || imageInput.cols() != IMAGE_INPUT_WIDTH)
-         throw new RuntimeException("Image height and width must be " + IMAGE_INPUT_HEIGHT + " and " + IMAGE_INPUT_WIDTH);
-
-      if (linearInput.getNumRows() != LINEAR_INPUT_SIZE || linearInput.getNumCols() != 1)
-         throw new RuntimeException("Linear input size must be " + LINEAR_INPUT_SIZE + "x1");
-
-      LogTools.info("Image Input Size: {}x{}", imageInput.rows(), imageInput.cols());
-      LogTools.info("Linear Input Size: {}x{}", linearInput.getNumRows(), linearInput.getNumCols());
-
-      Mat heightMapImage = imageInput.clone();
-      heightMapImage.convertTo(heightMapImage, opencv_core.CV_32FC1, 1.0 / 10000.0, 0);
-
-      // set the image to be in the first input
-      String inputName = (String) session.getInputNames().toArray()[0];
-      long[] tensorInputShape = {1, 1, heightMapImage.rows(), heightMapImage.cols()};
-      FloatBuffer data = heightMapImage.getByteBuffer().asFloatBuffer();
-
-      // set the linear input to be in the second input (extract from linearInput matrix)
-      String inputName2 = (String) session.getInputNames().toArray()[1];
-      long[] tensorInputShape2 = {1, LINEAR_INPUT_SIZE};
-      float[] data2 = linearInput.getData();
-      FloatBuffer data2Buffer = FloatBuffer.wrap(data2);
-
-      // create a map to store the input tensors
-      Map<String, OnnxTensor> inputs = new HashMap<>();
-      inputs.put(inputName, OnnxTensor.createTensor(environment, data, tensorInputShape));
-      inputs.put(inputName2, OnnxTensor.createTensor(environment, data2Buffer, tensorInputShape2));
-
-      // run the inference
-      OrtSession.Result output = session.run(inputs);
-
-      FMatrixRMaj outputMatrix = new FMatrixRMaj(LINEAR_OUTPUT_SIZE, 1);
-      for (Map.Entry<String, OnnxValue> stringOnnxValueEntry : output)
-      {
-         LogTools.debug("{}: {}", stringOnnxValueEntry.getKey(), stringOnnxValueEntry.getValue());
-
-         OnnxTensor outputTensor = (OnnxTensor) stringOnnxValueEntry.getValue();
-         float[][] outputArray = (float[][]) outputTensor.getValue();
-
-         if (outputArray[0].length != LINEAR_OUTPUT_SIZE)
-            throw new RuntimeException("Linear output size must be " + LINEAR_OUTPUT_SIZE + "x1" + " but was " + outputArray[0].length);
-
-         outputMatrix.setData(outputArray[0]);
-
-         LogTools.info("Output: {}", outputTensor.getInfo());
-      }
-
-      return outputMatrix;
+//      if (imageInput.rows() != IMAGE_INPUT_HEIGHT || imageInput.cols() != IMAGE_INPUT_WIDTH)
+//         throw new RuntimeException("Image height and width must be " + IMAGE_INPUT_HEIGHT + " and " + IMAGE_INPUT_WIDTH);
+//
+//      if (linearInput.getNumRows() != LINEAR_INPUT_SIZE || linearInput.getNumCols() != 1)
+//         throw new RuntimeException("Linear input size must be " + LINEAR_INPUT_SIZE + "x1");
+//
+//      LogTools.info("Image Input Size: {}x{}", imageInput.rows(), imageInput.cols());
+//      LogTools.info("Linear Input Size: {}x{}", linearInput.getNumRows(), linearInput.getNumCols());
+//
+//      Mat heightMapImage = imageInput.clone();
+//      heightMapImage.convertTo(heightMapImage, opencv_core.CV_32FC1, 1.0 / 10000.0, 0);
+//
+//      // set the image to be in the first input
+//      String inputName = (String) session.getInputNames().toArray()[0];
+//      long[] tensorInputShape = {1, 1, heightMapImage.rows(), heightMapImage.cols()};
+//      FloatBuffer data = heightMapImage.getByteBuffer().asFloatBuffer();
+//
+//      // set the linear input to be in the second input (extract from linearInput matrix)
+//      String inputName2 = (String) session.getInputNames().toArray()[1];
+//      long[] tensorInputShape2 = {1, LINEAR_INPUT_SIZE};
+//      float[] data2 = linearInput.getData();
+//      FloatBuffer data2Buffer = FloatBuffer.wrap(data2);
+//
+//      // create a map to store the input tensors
+//      Map<String, OnnxTensor> inputs = new HashMap<>();
+//      inputs.put(inputName, OnnxTensor.createTensor(environment, data, tensorInputShape));
+//      inputs.put(inputName2, OnnxTensor.createTensor(environment, data2Buffer, tensorInputShape2));
+//
+//      // run the inference
+//      OrtSession.Result output = session.run(inputs);
+//
+//      FMatrixRMaj outputMatrix = new FMatrixRMaj(LINEAR_OUTPUT_SIZE, 1);
+//      for (Map.Entry<String, OnnxValue> stringOnnxValueEntry : output)
+//      {
+//         LogTools.debug("{}: {}", stringOnnxValueEntry.getKey(), stringOnnxValueEntry.getValue());
+//
+//         OnnxTensor outputTensor = (OnnxTensor) stringOnnxValueEntry.getValue();
+//         float[][] outputArray = (float[][]) outputTensor.getValue();
+//
+//         if (outputArray[0].length != LINEAR_OUTPUT_SIZE)
+//            throw new RuntimeException("Linear output size must be " + LINEAR_OUTPUT_SIZE + "x1" + " but was " + outputArray[0].length);
+//
+//         outputMatrix.setData(outputArray[0]);
+//
+//         LogTools.info("Output: {}", outputTensor.getInfo());
+//      }
+//
+//      return outputMatrix;
+      return null;
    }
 
-   public static void main(String[] args) throws OrtException
+   public static void main(String[] args)
    {
       String perceptionLogFile = IHMCCommonPaths.PERCEPTION_LOGS_DIRECTORY.resolve("20231018_135001_PerceptionLog.hdf5").toString();
       ArrayList<Point3D> startPositions = new ArrayList<>();

--- a/ihmc-perception/src/main/java/us/ihmc/perception/neural/HeightMapAutoencoder.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/neural/HeightMapAutoencoder.java
@@ -1,6 +1,6 @@
 package us.ihmc.perception.neural;
 
-import ai.onnxruntime.*;
+//import ai.onnxruntime.*;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_imgproc;
@@ -31,123 +31,125 @@ public class HeightMapAutoencoder
    private static final int IMAGE_WIDTH = 201;
 
    private WorkspaceResourceDirectory modelDirectory = new WorkspaceResourceDirectory(this.getClass(), "/weights/");
+   // TODO: We should use pytorch/opencv instead of ONNX. ONNX is a huge dependency we don't use anywhere else and we already have opencv and heavily use that.
    private WorkspaceFile onnxFile = new WorkspaceFile(modelDirectory, "height_map_autoencoder.onnx");
 
    // the following fields are used for model loading and inference using the ONNX runtime library and PyTorch trained model stored as .onnx file
-   private OrtEnvironment onnxRuntimeEnvironment = OrtEnvironment.getEnvironment();
-   private OrtSession.SessionOptions onnxRuntimeSessionOptions = new OrtSession.SessionOptions();
-   private OrtSession onnxRuntimeSession;
+//   private OrtEnvironment onnxRuntimeEnvironment = OrtEnvironment.getEnvironment();
+//   private OrtSession.SessionOptions onnxRuntimeSessionOptions = new OrtSession.SessionOptions();
+//   private OrtSession onnxRuntimeSession;
 
    public HeightMapAutoencoder()
    {
-      try
-      {
-         onnxRuntimeSession = onnxRuntimeEnvironment.createSession(onnxFile.getFilesystemFile().toString(), onnxRuntimeSessionOptions);
-
-         for (Map.Entry<String, NodeInfo> stringNodeInfoEntry : onnxRuntimeSession.getInputInfo().entrySet())
-         {
-            LogTools.info("{}: {}", stringNodeInfoEntry.getKey(), stringNodeInfoEntry.getValue());
-         }
-         for (Map.Entry<String, NodeInfo> stringNodeInfoEntry : onnxRuntimeSession.getOutputInfo().entrySet())
-         {
-            LogTools.info("{}: {}", stringNodeInfoEntry.getKey(), stringNodeInfoEntry.getValue());
-         }
-
-         //print all input names and sizes
-         for (Map.Entry<String, NodeInfo> entry : onnxRuntimeSession.getInputInfo().entrySet())
-         {
-            String inputName = entry.getKey();
-            NodeInfo nodeInfo = entry.getValue();
-            LogTools.info("Input Name: {}", inputName);
-            LogTools.info("Input Info: {}", nodeInfo.toString());
-         }
-      }
-      catch (OrtException e)
-      {
-         throw new RuntimeException(e);
-      }
+//      try
+//      {
+//         onnxRuntimeSession = onnxRuntimeEnvironment.createSession(onnxFile.getFilesystemFile().toString(), onnxRuntimeSessionOptions);
+//
+//         for (Map.Entry<String, NodeInfo> stringNodeInfoEntry : onnxRuntimeSession.getInputInfo().entrySet())
+//         {
+//            LogTools.info("{}: {}", stringNodeInfoEntry.getKey(), stringNodeInfoEntry.getValue());
+//         }
+//         for (Map.Entry<String, NodeInfo> stringNodeInfoEntry : onnxRuntimeSession.getOutputInfo().entrySet())
+//         {
+//            LogTools.info("{}: {}", stringNodeInfoEntry.getKey(), stringNodeInfoEntry.getValue());
+//         }
+//
+//         //print all input names and sizes
+//         for (Map.Entry<String, NodeInfo> entry : onnxRuntimeSession.getInputInfo().entrySet())
+//         {
+//            String inputName = entry.getKey();
+//            NodeInfo nodeInfo = entry.getValue();
+//            LogTools.info("Input Name: {}", inputName);
+//            LogTools.info("Input Info: {}", nodeInfo.toString());
+//         }
+//      }
+//      catch (OrtException e)
+//      {
+//         throw new RuntimeException(e);
+//      }
    }
 
    public Mat denoiseHeightMap(Mat heightMap, double offset)
    {
       Mat denoisedHeightMapImage = null;
-      try
-      {
-         long startTime = System.nanoTime();
-
-         denoisedHeightMapImage = predict(heightMap, (float) offset);
-
-         long endTime = System.nanoTime();
-         LogTools.debug("Inference time: {} ms", Conversions.nanosecondsToMilliseconds(endTime - startTime));
-      }
-      catch (OrtException e)
-      {
-         throw new RuntimeException(e);
-      }
+//      try
+//      {
+//         long startTime = System.nanoTime();
+//
+//         denoisedHeightMapImage = predict(heightMap, (float) offset);
+//
+//         long endTime = System.nanoTime();
+//         LogTools.debug("Inference time: {} ms", Conversions.nanosecondsToMilliseconds(endTime - startTime));
+//      }
+//      catch (OrtException e)
+//      {
+//         throw new RuntimeException(e);
+//      }
 
       return denoisedHeightMapImage;
    }
 
-   public Mat predict(Mat imageInput, float offset) throws OrtException
+   public Mat predict(Mat imageInput, float offset)
    {
-      if (imageInput.rows() != IMAGE_HEIGHT || imageInput.cols() != IMAGE_WIDTH)
-         throw new RuntimeException("Image height and width must be " + IMAGE_HEIGHT + " and " + IMAGE_WIDTH);
-
-      LogTools.debug("Image Input Size: {}x{}", imageInput.rows(), imageInput.cols());
-
-      Mat heightMapImage = imageInput.clone();
-
-      Mat heightMapInput = new Mat(IMAGE_HEIGHT, IMAGE_WIDTH, opencv_core.CV_32FC1);
-      heightMapImage.convertTo(heightMapInput, opencv_core.CV_32FC1, 1, 0);
-      FloatBuffer inputFloatBuffer = FloatBuffer.allocate(IMAGE_HEIGHT * IMAGE_WIDTH);
-
-      for (int i = 0; i < IMAGE_HEIGHT; i++)
-      {
-         for (int j = 0; j < IMAGE_WIDTH; j++)
-         {
-            inputFloatBuffer.put(heightMapInput.ptr(i, j).getFloat() / 10000.0f - offset);
-         }
-      }
-      inputFloatBuffer.rewind();
-
-      // set the image to be in the first input
-      String inputName = (String) onnxRuntimeSession.getInputNames().toArray()[0];
-      long[] tensorInputShape = {1, 1, heightMapInput.rows(), heightMapInput.cols()};
-
-      // create a map to store the input tensors
-      Map<String, OnnxTensor> inputs = new HashMap<>();
-      inputs.put(inputName, OnnxTensor.createTensor(onnxRuntimeEnvironment, inputFloatBuffer, tensorInputShape));
-
-      // run the inference
-      OrtSession.Result output = onnxRuntimeSession.run(inputs);
-
-      Mat outputImage = new Mat(IMAGE_HEIGHT, IMAGE_WIDTH, opencv_core.CV_32FC1);
-
-      Map.Entry<String, OnnxValue> stringOnnxValueEntry = output.iterator().next();
-      LogTools.debug("{}: {}", stringOnnxValueEntry.getKey(), stringOnnxValueEntry.getValue());
-      OnnxTensor outputTensor = (OnnxTensor) stringOnnxValueEntry.getValue();
-
-      float[][][][] outputArray = (float[][][][]) outputTensor.getValue();
-      LogTools.debug("Output: {}", outputTensor.getInfo());
-
-      if (outputArray[0][0].length != IMAGE_HEIGHT && outputArray[0][0][0].length != IMAGE_WIDTH)
-      {
-         throw new RuntimeException("Output size must be " + IMAGE_HEIGHT * IMAGE_WIDTH);
-      }
-
-      for (int i = 0; i < IMAGE_HEIGHT; i++)
-      {
-         for (int j = 0; j < IMAGE_WIDTH; j++)
-         {
-            outputImage.ptr(i, j).putFloat((outputArray[0][0][i][j] + offset) * 10000.0f);
-         }
-      }
-      // scale up the output image and convert to 16UC1
-      outputImage.convertTo(outputImage, opencv_core.CV_16UC1, 1, 0);
-      return outputImage;
+//      if (imageInput.rows() != IMAGE_HEIGHT || imageInput.cols() != IMAGE_WIDTH)
+//         throw new RuntimeException("Image height and width must be " + IMAGE_HEIGHT + " and " + IMAGE_WIDTH);
+//
+//      LogTools.debug("Image Input Size: {}x{}", imageInput.rows(), imageInput.cols());
+//
+//      Mat heightMapImage = imageInput.clone();
+//
+//      Mat heightMapInput = new Mat(IMAGE_HEIGHT, IMAGE_WIDTH, opencv_core.CV_32FC1);
+//      heightMapImage.convertTo(heightMapInput, opencv_core.CV_32FC1, 1, 0);
+//      FloatBuffer inputFloatBuffer = FloatBuffer.allocate(IMAGE_HEIGHT * IMAGE_WIDTH);
+//
+//      for (int i = 0; i < IMAGE_HEIGHT; i++)
+//      {
+//         for (int j = 0; j < IMAGE_WIDTH; j++)
+//         {
+//            inputFloatBuffer.put(heightMapInput.ptr(i, j).getFloat() / 10000.0f - offset);
+//         }
+//      }
+//      inputFloatBuffer.rewind();
+//
+//      // set the image to be in the first input
+//      String inputName = (String) onnxRuntimeSession.getInputNames().toArray()[0];
+//      long[] tensorInputShape = {1, 1, heightMapInput.rows(), heightMapInput.cols()};
+//
+//      // create a map to store the input tensors
+//      Map<String, OnnxTensor> inputs = new HashMap<>();
+//      inputs.put(inputName, OnnxTensor.createTensor(onnxRuntimeEnvironment, inputFloatBuffer, tensorInputShape));
+//
+//      // run the inference
+//      OrtSession.Result output = onnxRuntimeSession.run(inputs);
+//
+//      Mat outputImage = new Mat(IMAGE_HEIGHT, IMAGE_WIDTH, opencv_core.CV_32FC1);
+//
+//      Map.Entry<String, OnnxValue> stringOnnxValueEntry = output.iterator().next();
+//      LogTools.debug("{}: {}", stringOnnxValueEntry.getKey(), stringOnnxValueEntry.getValue());
+//      OnnxTensor outputTensor = (OnnxTensor) stringOnnxValueEntry.getValue();
+//
+//      float[][][][] outputArray = (float[][][][]) outputTensor.getValue();
+//      LogTools.debug("Output: {}", outputTensor.getInfo());
+//
+//      if (outputArray[0][0].length != IMAGE_HEIGHT && outputArray[0][0][0].length != IMAGE_WIDTH)
+//      {
+//         throw new RuntimeException("Output size must be " + IMAGE_HEIGHT * IMAGE_WIDTH);
+//      }
+//
+//      for (int i = 0; i < IMAGE_HEIGHT; i++)
+//      {
+//         for (int j = 0; j < IMAGE_WIDTH; j++)
+//         {
+//            outputImage.ptr(i, j).putFloat((outputArray[0][0][i][j] + offset) * 10000.0f);
+//         }
+//      }
+//      // scale up the output image and convert to 16UC1
+//      outputImage.convertTo(outputImage, opencv_core.CV_16UC1, 1, 0);
+//      return outputImage;
+      return null;
    }
 
-   public static void main(String[] args) throws OrtException
+   public static void main(String[] args)
    {
       String perceptionLogFile = IHMCCommonPaths.PERCEPTION_LOGS_DIRECTORY.resolve("20231023_131517_PerceptionLog.hdf5").toString();
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/neural/HeightMapAutoencoder.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/neural/HeightMapAutoencoder.java
@@ -31,7 +31,10 @@ public class HeightMapAutoencoder
    private static final int IMAGE_WIDTH = 201;
 
    private WorkspaceResourceDirectory modelDirectory = new WorkspaceResourceDirectory(this.getClass(), "/weights/");
-   // TODO: We should use pytorch/opencv instead of ONNX. ONNX is a huge dependency we don't use anywhere else and we already have opencv and heavily use that.
+   // TODO: We should use opencv to load this onnx model or perhaps use pytorch with opencv
+   // To readd the Microsoft onnx dependency, add this to the main gradle dependencies:
+   //    api("com.microsoft.onnxruntime:onnxruntime:1.11.0")
+   //    api("com.microsoft.onnxruntime:onnxruntime_gpu:1.11.0")
    private WorkspaceFile onnxFile = new WorkspaceFile(modelDirectory, "height_map_autoencoder.onnx");
 
    // the following fields are used for model loading and inference using the ONNX runtime library and PyTorch trained model stored as .onnx file


### PR DESCRIPTION
This onnx dependency is ~250MB, which is very large. The only place it was used is in `FootstepPredictor` and `HeightMapAutoencoder`. HeightMapAutoencoder had a main and was not used anywhere else. FootstepPredictor was used in this demo UI `NadiaRDXTerrainPlanningUI`. To be honest, I tried running that UI but everything was broken and I didn't want to spend time figuring it out or fixing it. 

I dont really see us using these modules as they exist currently. Ideally, we should use pytorch/opencv anyway since we heavily use that everywhere else in the code base. I don't know the exact reason onnx was used here.