### PR TITLE
Add CUDAKernel To Simplify Setting Parameters

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAKernel.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAKernel.java
@@ -1,0 +1,117 @@
+package us.ihmc.perception.cuda;
+
+import org.bytedeco.cuda.cudart.CUfunc_st;
+import org.bytedeco.cuda.cudart.CUmod_st;
+import org.bytedeco.cuda.cudart.CUstream_st;
+import org.bytedeco.cuda.cudart.dim3;
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.DoublePointer;
+import org.bytedeco.javacpp.FloatPointer;
+import org.bytedeco.javacpp.IntPointer;
+import org.bytedeco.javacpp.LongPointer;
+import org.bytedeco.javacpp.Pointer;
+import org.bytedeco.javacpp.PointerPointer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.bytedeco.cuda.global.cudart.cuLaunchKernel;
+import static org.bytedeco.cuda.global.cudart.cuModuleGetFunction;
+import static us.ihmc.perception.cuda.CUDATools.checkCUDAError;
+
+@SuppressWarnings("resource")
+public class CUDAKernel implements AutoCloseable
+{
+   private final CUfunc_st kernelFunction = new CUfunc_st();
+   private final List<Pointer> parameters = new ArrayList<>();
+
+   private int error;
+
+   public CUDAKernel(String name, CUmod_st kernelModule)
+   {
+      error = cuModuleGetFunction(kernelFunction, kernelModule, name);
+      checkCUDAError(error);
+   }
+
+   /**
+    * Launches the CUDA kernel.
+    *
+    * @param stream CUDA stream on which the kernel will be synchronized.
+    * @param gridSize Grid size of the kernel execution.
+    * @param blockSize Block size of the kernel execution. Should not exceed maximum block size of the device.
+    * @param sharedMemorySize Size, in byte, of the memory shared by threads in each block.
+    */
+   public void run(CUstream_st stream, dim3 gridSize, dim3 blockSize, int sharedMemorySize)
+   {
+      PointerPointer<Pointer> parametersPointer = new PointerPointer<>(parameters.size());
+      for (int i = 0; i < parameters.size(); ++i)
+         parametersPointer.put(i, parameters.get(i));
+
+      error = cuLaunchKernel(kernelFunction,
+                             gridSize.x(),
+                             gridSize.y(),
+                             gridSize.z(),
+                             blockSize.x(),
+                             blockSize.y(),
+                             blockSize.z(),
+                             sharedMemorySize,
+                             stream,
+                             parametersPointer,
+                             new PointerPointer<>());
+      CUDATools.checkCUDAError(error);
+      parametersPointer.close();
+   }
+
+   public CUDAKernel withByte(byte value)
+   {
+      parameters.add(new BytePointer(1L).put(value));
+      return this;
+   }
+
+   public CUDAKernel withInt(int value)
+   {
+      parameters.add(new IntPointer(1L).put(value));
+      return this;
+   }
+
+   public CUDAKernel withLong(long value)
+   {
+      parameters.add(new LongPointer(1L).put(value));
+      return this;
+   }
+
+   public CUDAKernel withFloat(float value)
+   {
+      parameters.add(new FloatPointer(1L).put(value));
+      return this;
+   }
+
+   public CUDAKernel withDouble(double value)
+   {
+      parameters.add(new DoublePointer(1L).put(value));
+      return this;
+   }
+
+   public CUDAKernel withPointer(Pointer pointer)
+   {
+      parameters.add(new PointerPointer<>(1L).put(pointer));
+      return this;
+   }
+
+   /**
+    * Clears the set parameters
+    */
+   public void clearParameters()
+   {
+      for (Pointer parameter : parameters)
+         parameter.close();
+      parameters.clear();
+   }
+
+   @Override
+   public void close()
+   {
+      clearParameters();
+      kernelFunction.close();
+   }
+}

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAProgram.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAProgram.java
@@ -1,14 +1,10 @@
 package us.ihmc.perception.cuda;
 
 import org.apache.logging.log4j.Level;
-import org.bytedeco.cuda.cudart.CUfunc_st;
 import org.bytedeco.cuda.cudart.CUmod_st;
-import org.bytedeco.cuda.cudart.CUstream_st;
 import org.bytedeco.cuda.cudart.cudaDeviceProp;
-import org.bytedeco.cuda.cudart.dim3;
 import org.bytedeco.cuda.nvrtc._nvrtcProgram;
 import org.bytedeco.javacpp.BytePointer;
-import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.PointerPointer;
 import org.bytedeco.javacpp.SizeTPointer;
 import us.ihmc.log.LogTools;
@@ -16,23 +12,18 @@ import us.ihmc.log.LogTools;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.Map;
 
 import static org.bytedeco.cuda.global.cudart.*;
 import static org.bytedeco.cuda.global.nvrtc.*;
 import static us.ihmc.perception.cuda.CUDATools.*;
 
-class CUDAProgram
+public class CUDAProgram implements AutoCloseable
 {
    private static final String[] DEFAULT_OPTIONS = {"-arch=" + getComputeVersion(),  // Target fairly recent GPU architecture
                                                     "--dopt=on",                     // Optimize code
                                                     "-G"};                           // More code optimization
 
    private final CUmod_st module = new CUmod_st();
-   private final Map<String, CUfunc_st> kernels = new HashMap<>();
-
-   private int error;
 
    /**
     * Construct a {@link CUDAProgram} with default compilation options
@@ -112,36 +103,23 @@ class CUDAProgram
       initialize(programName, programCode, headerNames, headerContents, compilationOptions);
    }
 
-   public void loadKernel(String kernelName)
+   public CUDAKernel loadKernel(String kernelName)
    {
       // Load the kernel from module
-      CUfunc_st kernel = new CUfunc_st();
-      error = cuModuleGetFunction(kernel, module, kernelName);
-      checkCUDAError(error);
-      kernels.put(kernelName, kernel);
+      return new CUDAKernel(kernelName, module);
    }
 
-   public void runKernel(CUstream_st stream, String kernelName, dim3 gridSize, dim3 blockSize, int sharedMemorySize, Pointer... arguments)
+   @Override
+   public void close()
    {
-      if (!kernels.containsKey(kernelName))
-         throw new IllegalStateException("Kernel (" + kernelName + ") requested has not been loaded yet.");
-
-      // Run kernel
-      CUfunc_st kernel = kernels.get(kernelName);
-      launchKernelFunction(stream, kernel, gridSize, blockSize, sharedMemorySize, arguments);
-   }
-
-   public void destroy()
-   {
-      for (CUfunc_st kernel : kernels.values())
-         kernel.close();
-
       cuModuleUnload(module);
       module.close();
    }
 
    private void initialize(String programName, String programCode, String[] headerNames, String[] headerContents, String[] compilationOptions)
    {
+      int error;
+
       // Compile the program
       _nvrtcProgram compiledProgram = new _nvrtcProgram();
       compileProgram(programName, programCode, headerNames, headerContents, compilationOptions, compiledProgram);
@@ -234,35 +212,6 @@ class CUDAProgram
 
       logSize.close();
       log.close();
-   }
-
-   /**
-    * Launches a CUDA kernel.
-    * @param stream CUDA stream on which the kernel will be synchronized.
-    * @param function The kernel function to launch.
-    * @param gridSize Grid size of the kernel execution.
-    * @param blockSize Block size of the kernel execution. Should not exceed maximum block size of the device.
-    * @param sharedMemorySize Size, in byte, of the memory shared by threads in each block.
-    * @param arguments List of arguments (parameters) being passed into the kernel.
-    */
-   private static void launchKernelFunction(CUstream_st stream, CUfunc_st function, dim3 gridSize, dim3 blockSize, int sharedMemorySize, Pointer... arguments)
-   {
-      PointerPointer<Pointer> argumentsPointer = arguments == null ? new PointerPointer<>() : new PointerPointer<>(arguments);
-
-      int error = cuLaunchKernel(function,
-                                 gridSize.x(),
-                                 gridSize.y(),
-                                 gridSize.z(),
-                                 blockSize.x(),
-                                 blockSize.y(),
-                                 blockSize.z(),
-                                 sharedMemorySize,
-                                 stream,
-                                 argumentsPointer,
-                                 new PointerPointer<>());
-
-      CUDATools.checkCUDAError(error);
-      argumentsPointer.close();
    }
 
    /**

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAProgramTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAProgramTest.java
@@ -3,8 +3,6 @@ package us.ihmc.perception.cuda;
 import org.bytedeco.cuda.cudart.CUstream_st;
 import org.bytedeco.cuda.cudart.dim3;
 import org.bytedeco.javacpp.IntPointer;
-import org.bytedeco.javacpp.Pointer;
-import org.bytedeco.javacpp.PointerPointer;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
@@ -47,24 +45,15 @@ public class CUDAProgramTest
       // Get a stream
       CUstream_st stream = CUDAStreamManager.getStream();
 
-      // Construct a program
-      CUDAProgram additionProgram = new CUDAProgram("add.cu", ADD_KERNEL);
-
-      // Load the kernel
-      additionProgram.loadKernel("add");
-
-      // Create host & device pointers
-      try (IntPointer a = new IntPointer(1L).put(3);
-           IntPointer b = new IntPointer(1L).put(7);
+      try (CUDAProgram additionProgram = new CUDAProgram("add.cu", ADD_KERNEL); // Construct the program
+           CUDAKernel additionKernel = additionProgram.loadKernel("add");         // Load the kernel
            IntPointer sum = new IntPointer(1L);
-           IntPointer deviceSum = new IntPointer();
-           PointerPointer<Pointer> deviceSumPointer = new PointerPointer<>(1L))
+           IntPointer deviceSum = new IntPointer())
       {
-         cudaMallocAsync(deviceSum, sum.sizeof(), stream);
-         deviceSumPointer.put(deviceSum);
+         cudaMallocAsync(deviceSum, deviceSum.sizeof(), stream);
 
-         // Run the kernel
-         additionProgram.runKernel(stream, "add", new dim3(), new dim3(), 0, a, b, deviceSumPointer);
+         additionKernel.withInt(3).withInt(7).withPointer(deviceSum);
+         additionKernel.run(stream, new dim3(), new dim3(), 0);
 
          // Copy result from device to host
          cudaMemcpyAsync(sum, deviceSum, sum.sizeof(), cudaMemcpyDefault, stream);
@@ -77,7 +66,44 @@ public class CUDAProgramTest
          assertEquals(10, sum.get());
       }
 
-      additionProgram.destroy();
+      CUDAStreamManager.releaseStream(stream);
+   }
+
+   @Test
+   public void testMultipleKernelRuns()
+   {
+      int runs = 10;
+
+      // Get a stream
+      CUstream_st stream = CUDAStreamManager.getStream();
+
+      try (CUDAProgram additionProgram = new CUDAProgram("add.cu", ADD_KERNEL); // Construct the program
+           CUDAKernel additionKernel = additionProgram.loadKernel("add");         // Load the kernel
+           IntPointer sum = new IntPointer(1L);
+           IntPointer deviceSum = new IntPointer())
+      {
+         cudaMallocAsync(deviceSum, deviceSum.sizeof(), stream);
+
+         for (int a = 0; a < runs; ++a)
+         {
+            for (int b = 0; b < runs; ++b)
+            {
+               additionKernel.clearParameters();
+               additionKernel.withInt(a).withInt(b).withPointer(deviceSum);
+               additionKernel.run(stream, new dim3(), new dim3(), 0);
+
+               // Copy result from device to host
+               cudaMemcpyAsync(sum, deviceSum, sum.sizeof(), cudaMemcpyDefault, stream);
+               cudaStreamSynchronize(stream);
+
+               // Ensure we got the correct result!
+               assertEquals(a + b, sum.get());
+            }
+         }
+
+         // Free host memory
+         cudaFreeAsync(deviceSum, stream);
+      }
 
       CUDAStreamManager.releaseStream(stream);
    }
@@ -91,22 +117,16 @@ public class CUDAProgramTest
       // Construct a program
       String[] headerName = {"test_values.cuh"};
       String[] headerContents = {KERNEL_HEADER};
-
-      CUDAProgram additionProgram = new CUDAProgram("add_header.cu", KERNEL_WITH_HEADER, headerName, headerContents);
-
-      // Load the kernel
-      additionProgram.loadKernel("add");
-
-      // Create pointers
-      try (IntPointer sum = new IntPointer(1L);
-           IntPointer deviceSum = new IntPointer();
-           PointerPointer<Pointer> deviceSumPointer = new PointerPointer<>(1L))
+      try (CUDAProgram additionProgram = new CUDAProgram("add_header.cu", KERNEL_WITH_HEADER, headerName, headerContents);
+           CUDAKernel additionKernel = additionProgram.loadKernel("add"); // Load the kernel
+           IntPointer sum = new IntPointer(1L);
+           IntPointer deviceSum = new IntPointer())
       {
          cudaMallocAsync(deviceSum, sum.sizeof(), stream);
-         deviceSumPointer.put(deviceSum);
 
          // Run the kernel
-         additionProgram.runKernel(stream, "add", new dim3(1, 1, 1), new dim3(1, 1, 1), 0, deviceSumPointer);
+         additionKernel.withPointer(deviceSum);
+         additionKernel.run(stream, new dim3(), new dim3(), 0);
 
          // Download result from device to host
          cudaMemcpyAsync(sum, deviceSum, sum.sizeof(), cudaMemcpyDefault, stream);
@@ -114,12 +134,7 @@ public class CUDAProgramTest
 
          // Free device memory
          cudaFreeAsync(deviceSum, stream);
-
-         // Ensure we got the correct result!
-         assertEquals(10, sum.get());
       }
-
-      additionProgram.destroy();
 
       CUDAStreamManager.releaseStream(stream);
    }
@@ -133,29 +148,25 @@ public class CUDAProgramTest
       // Create a CUDA program with files
       Path kernelPath = Path.of(Objects.requireNonNull(getClass().getResource("test_add_values.cu")).toURI());
       Path headerPath = Path.of(Objects.requireNonNull(getClass().getResource("test_values.cuh")).toURI());
-      CUDAProgram program = new CUDAProgram(kernelPath, headerPath);
 
-      // Load the kernels
-      program.loadKernel("add");
-      program.loadKernel("subtract");
+      try (CUDAProgram program = new CUDAProgram(kernelPath, headerPath);
 
-      // Create pointers
-      try (IntPointer sum = new IntPointer(1L);
+           // Load the kernels
+           CUDAKernel additionKernel = program.loadKernel("add");
+           CUDAKernel subtractionKernel = program.loadKernel("subtract");
+
+           // Create pointers
+           IntPointer sum = new IntPointer(1L);
            IntPointer deviceSum = new IntPointer();
-           PointerPointer<Pointer> deviceSumPointer = new PointerPointer<>(1L);
 
            IntPointer difference = new IntPointer(1L);
-           IntPointer deviceDifference = new IntPointer();
-           PointerPointer<Pointer> deviceDifferencePointer = new PointerPointer<>(1L))
+           IntPointer deviceDifference = new IntPointer())
       {
          cudaMallocAsync(deviceSum, sum.sizeof(), stream);
-         deviceSumPointer.put(deviceSum);
          cudaMallocAsync(deviceDifference, difference.sizeof(), stream);
-         deviceDifferencePointer.put(deviceDifference);
 
-         // Run the kernels
-         program.runKernel(stream, "add", new dim3(), new dim3(), 0, deviceSumPointer);
-         program.runKernel(stream, "subtract", new dim3(), new dim3(), 0, deviceDifferencePointer);
+         additionKernel.withPointer(deviceSum).run(stream, new dim3(), new dim3(), 0);
+         subtractionKernel.withPointer(deviceDifference).run(stream, new dim3(), new dim3(), 0);
 
          // Download results from device to host
          cudaMemcpyAsync(sum, deviceSum, sum.sizeof(), cudaMemcpyDefault, stream);
@@ -170,8 +181,6 @@ public class CUDAProgramTest
          assertEquals(10, sum.get());
          assertEquals(4, difference.get());
       }
-
-      program.destroy();
 
       CUDAStreamManager.releaseStream(stream);
    }


### PR DESCRIPTION
Now, instead of doing something like: 
```
cudaProgram.loadKernel("add"); // load the kernel

// Create parameter pointers
IntPointer a = new IntPointer(1L).put(3);
IntPointer b = new IntPointer(1L).put(7);
IntPointer sum = new IntPointer();
PointerPointer<IntPointer> sumPointer = new PointerPointer(1L).put(sum
// allocate sum to device...

cudaProgram.run(/* other params */, a, b, sumPointer); // run the loaded kernel
```

You can do something like: 
```
CUDAKernel kernel = cudaProgram.loadKernel("add"); // load the kernel

// Create pointer parameters
IntPointer sum = new IntPointer();
// allocate sum to device...

kernel.withInt(3).withInt(3).withPointer(sum).run(/* other params */);
```