### PR TITLE
Reduce use of BytedecoImage in ArUco code

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXBlackflyCalibrationSuite.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXBlackflyCalibrationSuite.java
@@ -408,7 +408,7 @@ public class RDXBlackflyCalibrationSuite
                                  undistortionRemapBorderValue);
 
             newCameraMatrixEstimate.copyTo(arUcoMarkerDetector.getCameraMatrix());
-            arUcoMarkerDetector.update(texture.getRGBA8Image());
+            arUcoMarkerDetector.update(texture.getRGBA8Image().getBytedecoOpenCVMat());
             arUcoMarkerDetectionUI.copyOutputData(arUcoMarkerDetector);
             arUcoMarkerDetectionResults.copyOutputData(arUcoMarkerDetector);
 

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXOpenCVArUcoMarkerDetectionUI.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXOpenCVArUcoMarkerDetectionUI.java
@@ -8,23 +8,23 @@ import imgui.type.ImBoolean;
 import imgui.type.ImDouble;
 import imgui.type.ImInt;
 import org.bytedeco.opencv.global.opencv_imgproc;
+import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.Scalar;
 import org.bytedeco.opencv.opencv_objdetect.DetectorParameters;
 import us.ihmc.commons.time.Stopwatch;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.perception.opencv.OpenCVArUcoMarker;
 import us.ihmc.perception.opencv.OpenCVArUcoMarkerDetectionResults;
 import us.ihmc.perception.opencv.OpenCVArUcoMarkerDetector;
-import us.ihmc.rdx.imgui.RDXPanel;
 import us.ihmc.rdx.imgui.ImGuiTools;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
+import us.ihmc.rdx.imgui.ImPlotDoublePlotLine;
+import us.ihmc.rdx.imgui.ImPlotPlot;
+import us.ihmc.rdx.imgui.RDXPanel;
 import us.ihmc.rdx.tools.RDXModelBuilder;
 import us.ihmc.rdx.tools.RDXModelInstance;
 import us.ihmc.rdx.ui.RDXImagePanel;
-import us.ihmc.rdx.imgui.ImPlotDoublePlotLine;
-import us.ihmc.rdx.imgui.ImPlotPlot;
-import us.ihmc.perception.BytedecoImage;
-import us.ihmc.perception.opencv.OpenCVArUcoMarker;
 import us.ihmc.tools.thread.SwapReference;
 
 import java.util.ArrayList;
@@ -149,13 +149,13 @@ public class RDXOpenCVArUcoMarkerDetectionUI
 
             if (markerImagePanel.getImagePanel().getIsShowing().get())
             {
-               BytedecoImage imageForDrawing = arUcoMarkerDetectionResults.getInputImage();
+               Mat imageForDrawing = arUcoMarkerDetectionResults.getInputImage();
 
-               arUcoMarkerDetectionResults.drawDetectedMarkers(imageForDrawing.getBytedecoOpenCVMat(), idColor);
-               arUcoMarkerDetectionResults.drawRejectedPoints(imageForDrawing.getBytedecoOpenCVMat());
+               arUcoMarkerDetectionResults.drawDetectedMarkers(imageForDrawing, idColor);
+               arUcoMarkerDetectionResults.drawRejectedPoints(imageForDrawing);
 
-               markerImagePanel.ensureDimensionsMatch(imageForDrawing.getImageWidth(), imageForDrawing.getImageHeight());
-               opencv_imgproc.cvtColor(imageForDrawing.getBytedecoOpenCVMat(), markerImagePanel.getImage(), opencv_imgproc.COLOR_RGB2RGBA);
+               markerImagePanel.ensureDimensionsMatch(imageForDrawing.cols(), imageForDrawing.rows());
+               opencv_imgproc.cvtColor(imageForDrawing, markerImagePanel.getImage(), opencv_imgproc.COLOR_RGB2RGBA);
 
                markerImagePanel.display();
             }
@@ -190,8 +190,8 @@ public class RDXOpenCVArUcoMarkerDetectionUI
          ImGui.checkbox(labels.get("Detection enabled"), detectionEnabled);
          ImGui.sameLine();
          ImGui.checkbox(labels.get("Show 3D graphics"), showGraphics);
-         BytedecoImage imageForDrawing = arUcoMarkerDetectionResults.getInputImage();
-         ImGui.text("Image width: " + imageForDrawing.getImageWidth() + " height: " + imageForDrawing.getImageHeight());
+         Mat imageForDrawing = arUcoMarkerDetectionResults.getInputImage();
+         ImGui.text("Image width: " + imageForDrawing.cols() + " height: " + imageForDrawing.rows());
          detectionDurationPlot.render();
          ImGui.text("Detected ArUco Markers:");
          for (RDXOpenCVArUcoTrackedMarker trackedMarker : trackedMarkers)

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXZEDArUcoMarkerDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXZEDArUcoMarkerDemo.java
@@ -13,7 +13,6 @@ import us.ihmc.communication.PerceptionAPI;
 import us.ihmc.communication.ROS2Tools;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
-import us.ihmc.perception.BytedecoImage;
 import us.ihmc.perception.RawImage;
 import us.ihmc.perception.opencv.OpenCVArUcoMarkerDetectionResults;
 import us.ihmc.perception.opencv.OpenCVArUcoMarkerDetector;
@@ -51,7 +50,7 @@ public class RDXZEDArUcoMarkerDemo
    private final ImFloat markerSize = new ImFloat(0.02975f);
 
    private final OpenCVArUcoMarkerDetector arUcoDetector;
-   private BytedecoImage detectionImage;
+   private Mat detectionImage;
    private final OpenCVArUcoMarkerDetectionResults arUcoResults;
    private final SwapReference<List<FramePose3D>> arUcoMarkerPoses = new SwapReference<>(new ArrayList<>(), new ArrayList<>());
 
@@ -61,7 +60,7 @@ public class RDXZEDArUcoMarkerDemo
 
    public RDXZEDArUcoMarkerDemo()
    {
-      ros2Node = ROS2Tools.createROS2Node(PubSubImplementation.FAST_RTPS, getClass().getSimpleName() + "-ROS2Node");
+      ros2Node = ROS2Tools.createROS2Node(PubSubImplementation.FAST_RTPS, getClass().getSimpleName() + "_ROS2Node");
 
       imageRetriever = new ZEDColorDepthImageRetriever(0, ReferenceFrame::getWorldFrame, () -> true, () -> true, true);
       imagePublisher = new ZEDColorDepthImagePublisher(PerceptionAPI.ZED2_COLOR_IMAGES, PerceptionAPI.ZED2_DEPTH, PerceptionAPI.ZED2_CUT_OUT_DEPTH);
@@ -102,7 +101,7 @@ public class RDXZEDArUcoMarkerDemo
       if (detectionImage == null)
          initializeDetection(colorImage);
 
-      colorImage.getCpuImageMat().copyTo(detectionImage.getBytedecoOpenCVMat());
+      colorImage.getCpuImageMat().copyTo(detectionImage);
       arUcoDetector.update();
       arUcoResults.copyOutputData(arUcoDetector);
       TIntArrayList detectedIDs = arUcoResults.getDetectedIDs();
@@ -133,9 +132,8 @@ public class RDXZEDArUcoMarkerDemo
 
    private void initializeDetection(RawImage colorImage)
    {
-      Mat image = new Mat();
-      colorImage.getCpuImageMat().copyTo(image);
-      detectionImage = new BytedecoImage(image);
+      detectionImage = new Mat();
+      colorImage.getCpuImageMat().copyTo(detectionImage);
       arUcoDetector.setSourceImageForDetection(detectionImage);
       arUcoDetector.setCameraIntrinsics(imageRetriever.getCameraIntrinsics(RobotSide.LEFT));
    }

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/simulation/scs2/RDXArUcoMarkerDetectionDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/simulation/scs2/RDXArUcoMarkerDetectionDemo.java
@@ -60,7 +60,7 @@ public class RDXArUcoMarkerDetectionDemo
             baseUI.getPrimaryScene().addRenderableProvider(cameraSensor::getRenderables);
 
             arUcoMarkerDetector = new OpenCVArUcoMarkerDetector();
-            arUcoMarkerDetector.setSourceImageForDetection(cameraSensor.getLowLevelSimulator().getRGBA8888ColorImage());
+            arUcoMarkerDetector.setSourceImageForDetection(cameraSensor.getLowLevelSimulator().getRGBA8888ColorImage().getBytedecoOpenCVMat());
             arUcoMarkerDetector.setCameraIntrinsics(cameraSensor.getDepthCameraIntrinsics());
             arUcoMarkerDetectionUI = new RDXOpenCVArUcoMarkerDetectionUI(" from Sensor");
             ArrayList<OpenCVArUcoMarker> markersToTrack = new ArrayList<>();
@@ -75,7 +75,7 @@ public class RDXArUcoMarkerDetectionDemo
 
             testImageArUcoMarkerDetector = new OpenCVArUcoMarkerDetector();
             arUcoMarkerDetector.getDetectorParameters().markerBorderBits(2);
-            testImageArUcoMarkerDetector.setSourceImageForDetection(testRGB888ColorImage);
+            testImageArUcoMarkerDetector.setSourceImageForDetection(testRGB888ColorImage.getBytedecoOpenCVMat());
             testImageArUcoMarkerDetector.setCameraIntrinsics(cameraSensor.getDepthCameraIntrinsics());
             testImageArUcoMarkerDetectionUI = new RDXOpenCVArUcoMarkerDetectionUI(" Test");
             testImageArUcoMarkerDetectionUI.create(testImageArUcoMarkerDetector.getDetectorParameters());

--- a/ihmc-perception/src/main/java/us/ihmc/perception/BytedecoImage.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/BytedecoImage.java
@@ -215,16 +215,21 @@ public class BytedecoImage
       ensureDimensionsMatch(other, null);
    }
 
+   public void ensureDimensionsMatch(BytedecoImage other, OpenCLManager openCLManager)
+   {
+      ensureDimensionsMatch(other.getBytedecoOpenCVMat(), openCLManager);
+   }
+
    /**
     * Resizes this image to match the dimensions of other if necessary.
     *
     * // FIXME: Broken for external byte buffers
     */
-   public void ensureDimensionsMatch(BytedecoImage other, OpenCLManager openCLManager)
+   public void ensureDimensionsMatch(Mat other, OpenCLManager openCLManager)
    {
-      if (!OpenCVTools.dimensionsMatch(this, other))
+      if (!OpenCVTools.dimensionsMatch(bytedecoOpenCVMat, other))
       {
-         resize(other.getImageWidth(), other.getImageHeight(), openCLManager, backingDirectByteBuffer);
+         resize(other.cols(), other.rows(), openCLManager, backingDirectByteBuffer);
       }
    }
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVArUcoMarkerDetectionResults.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVArUcoMarkerDetectionResults.java
@@ -27,7 +27,7 @@ import us.ihmc.perception.BytedecoImage;
  */
 public class OpenCVArUcoMarkerDetectionResults
 {
-   private final BytedecoImage inputImage;
+   private final Mat inputImage;
    private final MatVector corners;
    private final Mat ids;
    private final MatVector rejectedImagePoints;
@@ -59,7 +59,7 @@ public class OpenCVArUcoMarkerDetectionResults
 
    public OpenCVArUcoMarkerDetectionResults()
    {
-      inputImage = new BytedecoImage(100, 100, opencv_core.CV_8UC3);
+      inputImage = new Mat();
       cameraMatrix = new Mat(3, 3, opencv_core.CV_64F);
       distortionCoefficients = new Mat(1, 4, opencv_core.CV_32FC1);
       distortionCoefficients.ptr(0, 0).putFloat(0.0f);
@@ -83,8 +83,7 @@ public class OpenCVArUcoMarkerDetectionResults
     */
    public void copyOutputData(OpenCVArUcoMarkerDetector detector)
    {
-      inputImage.ensureDimensionsMatch(detector.getRGB8ImageForDetection());
-      detector.getRGB8ImageForDetection().getBytedecoOpenCVMat().copyTo(inputImage.getBytedecoOpenCVMat());
+      detector.getRGB8ImageForDetection().copyTo(inputImage);
 
       corners.clear();
       corners.put(detector.getCorners());
@@ -228,7 +227,7 @@ public class OpenCVArUcoMarkerDetectionResults
       opencv_objdetect.drawDetectedMarkers(imageForDrawing, rejectedImagePoints);
    }
 
-   public BytedecoImage getInputImage()
+   public Mat getInputImage()
    {
       return inputImage;
    }

--- a/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVArUcoMarkerDetectionResults.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVArUcoMarkerDetectionResults.java
@@ -18,7 +18,6 @@ import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformBasics;
 import us.ihmc.euclid.tuple3D.interfaces.Tuple3DBasics;
 import us.ihmc.log.LogTools;
-import us.ihmc.perception.BytedecoImage;
 
 /**
  * This class provides support for copying the full output from

--- a/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVArUcoMarkerDetector.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVArUcoMarkerDetector.java
@@ -10,7 +10,6 @@ import org.bytedeco.opencv.opencv_objdetect.DetectorParameters;
 import org.bytedeco.opencv.opencv_objdetect.Dictionary;
 import org.bytedeco.opencv.opencv_objdetect.RefineParameters;
 import us.ihmc.commons.time.Stopwatch;
-import us.ihmc.perception.BytedecoImage;
 import us.ihmc.perception.camera.CameraIntrinsics;
 
 /**
@@ -34,8 +33,8 @@ public class OpenCVArUcoMarkerDetector
    private final Mat cameraMatrix;
    private final Mat distortionCoefficients;
    private final Stopwatch stopwatch = new Stopwatch();
-   private BytedecoImage rgb8ImageForDetection;
-   private BytedecoImage optionalSourceColorImage;
+   private Mat rgb8ImageForDetection;
+   private Mat optionalSourceColorImage;
 
    public OpenCVArUcoMarkerDetector()
    {
@@ -55,7 +54,7 @@ public class OpenCVArUcoMarkerDetector
       distortionCoefficients.ptr(0, 4).putFloat(0.0f);
    }
 
-   public void setSourceImageForDetection(BytedecoImage optionalSourceColorImage)
+   public void setSourceImageForDetection(Mat optionalSourceColorImage)
    {
       this.optionalSourceColorImage = optionalSourceColorImage;
    }
@@ -83,11 +82,11 @@ public class OpenCVArUcoMarkerDetector
    }
 
    /** The user can pass in the image each time or set it once using {@link #setSourceImageForDetection}. */
-   public void update(BytedecoImage sourceColorImage)
+   public void update(Mat sourceColorImage)
    {
       if (rgb8ImageForDetection == null)
       {
-         rgb8ImageForDetection = new BytedecoImage(sourceColorImage.getImageWidth(), sourceColorImage.getImageHeight(), opencv_core.CV_8UC3);
+         rgb8ImageForDetection = new Mat(sourceColorImage.size(), opencv_core.CV_8UC3);
       }
 
       convertOrCopyToRGB(sourceColorImage, rgb8ImageForDetection);
@@ -95,34 +94,33 @@ public class OpenCVArUcoMarkerDetector
       performDetection(rgb8ImageForDetection);
    }
 
-   public static void convertOrCopyToRGB(BytedecoImage sourceColorImage, BytedecoImage rgb8ImageForDetection)
+   public static void convertOrCopyToRGB(Mat sourceColorImage, Mat rgb8ImageForDetection)
    {
-      rgb8ImageForDetection.ensureDimensionsMatch(sourceColorImage);
+      if (!OpenCVTools.dimensionsMatch(sourceColorImage, rgb8ImageForDetection))
+         rgb8ImageForDetection = new Mat(sourceColorImage.size(), opencv_core.CV_8UC3);
 
-      if (sourceColorImage.getBytedecoOpenCVMat().type() == opencv_core.CV_8UC4)
+      if (sourceColorImage.type() == opencv_core.CV_8UC4)
       {
          // ArUco library doesn't support alpha channel being in there
-         opencv_imgproc.cvtColor(sourceColorImage.getBytedecoOpenCVMat(),
-                                 rgb8ImageForDetection.getBytedecoOpenCVMat(),
-                                 opencv_imgproc.COLOR_RGBA2RGB);
+         opencv_imgproc.cvtColor(sourceColorImage, rgb8ImageForDetection, opencv_imgproc.COLOR_RGBA2RGB);
       }
       else
       {
-         sourceColorImage.getBytedecoOpenCVMat().copyTo(rgb8ImageForDetection.getBytedecoOpenCVMat());
+         sourceColorImage.copyTo(rgb8ImageForDetection);
       }
    }
 
    /** For use if the user already has a valid image. */
-   public void performDetection(BytedecoImage rgb8ImageForDetection)
+   public void performDetection(Mat rgb8ImageForDetection)
    {
       arucoDetector.setDetectorParameters(detectorParameters);
       // detectMarkers is the big slow thing, so we put it on an async thread.
       stopwatch.start();
-      arucoDetector.detectMarkers(rgb8ImageForDetection.getBytedecoOpenCVMat(), corners, ids, rejectedImagePoints);
+      arucoDetector.detectMarkers(rgb8ImageForDetection, corners, ids, rejectedImagePoints);
       stopwatch.suspend();
    }
 
-   public BytedecoImage getRGB8ImageForDetection()
+   public Mat getRGB8ImageForDetection()
    {
       return rgb8ImageForDetection;
    }

--- a/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/arUco/ArUcoDetectionUpdater.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/arUco/ArUcoDetectionUpdater.java
@@ -1,6 +1,10 @@
 package us.ihmc.perception.sceneGraph.arUco;
 
-import org.bytedeco.opencv.global.*;
+import org.bytedeco.opencv.global.opencv_calib3d;
+import org.bytedeco.opencv.global.opencv_core;
+import org.bytedeco.opencv.global.opencv_cudaimgproc;
+import org.bytedeco.opencv.global.opencv_cudawarping;
+import org.bytedeco.opencv.global.opencv_imgproc;
 import org.bytedeco.opencv.opencv_core.GpuMat;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.Size;
@@ -8,10 +12,9 @@ import us.ihmc.commons.thread.TypedNotification;
 import us.ihmc.communication.ros2.ROS2Helper;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.log.LogTools;
-import us.ihmc.perception.BytedecoImage;
 import us.ihmc.perception.RawImage;
-import us.ihmc.perception.opencv.OpenCVArUcoMarkerDetector;
 import us.ihmc.perception.opencv.OpenCVArUcoMarkerDetectionResults;
+import us.ihmc.perception.opencv.OpenCVArUcoMarkerDetector;
 import us.ihmc.perception.opencv.OpenCVArUcoMarkerROS2Publisher;
 import us.ihmc.perception.sceneGraph.SceneObjectDefinitions;
 import us.ihmc.perception.sensorHead.BlackflyLensProperties;
@@ -34,7 +37,7 @@ public class ArUcoDetectionUpdater
    private OpenCVArUcoMarkerDetector arUcoMarkerDetector;
    private OpenCVArUcoMarkerDetectionResults arUcoMarkerDetectionResults;
    private OpenCVArUcoMarkerROS2Publisher arUcoMarkerPublisher;
-   private BytedecoImage arUcoBytedecoImage;
+   private Mat arUcoImageMat;
    private final Supplier<ReferenceFrame> blackflyFrameSupplier;
 
    private final BlackflyLensProperties blackflyLensProperties;
@@ -62,7 +65,7 @@ public class ArUcoDetectionUpdater
       {
          RawImage arUcoImage = distortedInputImage.read();
 
-         if (arUcoBytedecoImage == null)
+         if (arUcoImageMat == null)
             initialize(arUcoImage.getWidth(), arUcoImage.getHeight());
 
          // Convert color from BGR to RGB
@@ -73,8 +76,8 @@ public class ArUcoDetectionUpdater
          GpuMat undistortedImageRGB = new GpuMat(arUcoImage.getHeight(), arUcoImage.getWidth(), arUcoImage.getOpenCVType());
          opencv_cudawarping.remap(imageForUndistortionRGB, undistortedImageRGB, undistortionMap1, undistortionMap2, opencv_imgproc.INTER_LINEAR);
 
-         // Update the Bytedeco image
-         undistortedImageRGB.download(arUcoBytedecoImage.getBytedecoOpenCVMat());
+         // Update the image mat
+         undistortedImageRGB.download(arUcoImageMat);
 
          arUcoMarkerDetector.update();
          arUcoMarkerDetectionResults.copyOutputData(arUcoMarkerDetector);
@@ -94,9 +97,9 @@ public class ArUcoDetectionUpdater
       LogTools.info("Image dimensions: {} x {}", imageWidth, imageHeight);
 
       initializeImageUndistortion(imageWidth, imageHeight);
-      arUcoBytedecoImage = new BytedecoImage(imageWidth, imageHeight, opencv_core.CV_8UC3);
+      arUcoImageMat = new Mat(imageHeight, imageWidth, opencv_core.CV_8UC3);
       arUcoMarkerDetector = new OpenCVArUcoMarkerDetector();
-      arUcoMarkerDetector.setSourceImageForDetection(arUcoBytedecoImage);
+      arUcoMarkerDetector.setSourceImageForDetection(arUcoImageMat);
       cameraMatrixEstimate.copyTo(arUcoMarkerDetector.getCameraMatrix());
       arUcoMarkerDetectionResults = new OpenCVArUcoMarkerDetectionResults();
 


### PR DESCRIPTION
As part of the Perception Autonomy Cleanup effort, I'd like to reduce the usage of `BytedecoImage` where it's not needed. In a lot of cases, a simple `Mat` suffices. 

I've tested the changes using the BehaviorUI, and ZED ArUco Demo. Also ran the ArUco Marker Detection Demo, but I can't tell if it's working correctly (though there's no difference compared to develop). 