### PR TITLE
[Feature] CUDAProgram Use URL Instead of Path

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAProgram.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAProgram.java
@@ -9,9 +9,14 @@ import org.bytedeco.javacpp.PointerPointer;
 import org.bytedeco.javacpp.SizeTPointer;
 import us.ihmc.log.LogTools;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 
 import static org.bytedeco.cuda.global.cudart.*;
 import static org.bytedeco.cuda.global.nvrtc.*;
@@ -27,6 +32,56 @@ public class CUDAProgram implements AutoCloseable
                                                     "-G"};                           // More code optimization
 
    private final CUmod_st module = new CUmod_st();
+
+   /**
+    * Construct a {@link CUDAProgram} with default compilation options
+    *
+    * @param programPath {@link Path} to the .cu file.
+    * @param headerPaths {@link Path}s to the header files included (with {@code #include}) in the .cu file.
+    */
+   public CUDAProgram(Path programPath, Path... headerPaths)
+   {
+      this(programPath, headerPaths, DEFAULT_OPTIONS);
+   }
+
+   /**
+    * Construct a {@link CUDAProgram} specifying the path to the .cu file, paths to the header files, and compilation options.
+    *
+    * @param programPath        {@link Path} to the .cu file.
+    * @param headerPaths        {@link Path}s to the header files included (with {@code #include}) in the .cu file.
+    * @param compilationOptions List of compilation options
+    *                           (You can see the available options <a href="https://docs.nvidia.com/cuda/nvrtc/index.html#supported-compile-options">here</a>)
+    */
+   public CUDAProgram(Path programPath, Path[] headerPaths, String... compilationOptions)
+   {
+      try
+      {
+         String programName = programPath.getFileName().toString();
+
+         String programContents = new String(Files.readAllBytes(programPath));
+
+         String[] headerNames = null;
+         String[] headerContents = null;
+
+         if (headerPaths != null && headerPaths.length > 0)
+         {
+            headerNames = new String[headerPaths.length];
+            headerContents = new String[headerPaths.length];
+
+            for (int i = 0; i < headerPaths.length; i++)
+            {
+               headerNames[i] = headerPaths[i].getFileName().toString();
+               headerContents[i] = new String(Files.readAllBytes(headerPaths[i]));
+            }
+         }
+
+         initialize(programName, programContents, headerNames, headerContents, compilationOptions);
+      }
+      catch (IOException e)
+      {
+         throw new RuntimeException(e);
+      }
+   }
 
    /**
     * Construct a {@link CUDAProgram} with default compilation options

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAProgram.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAProgram.java
@@ -10,7 +10,8 @@ import org.bytedeco.javacpp.SizeTPointer;
 import us.ihmc.log.LogTools;
 
 import java.io.IOException;
-import java.nio.file.Files;
+import java.io.InputStream;
+import java.net.URL;
 import java.nio.file.Path;
 
 import static org.bytedeco.cuda.global.cudart.*;
@@ -34,7 +35,7 @@ public class CUDAProgram implements AutoCloseable
     * @param programPath {@link Path} to the .cu file.
     * @param headerPaths {@link Path}s to the header files included (with {@code #include}) in the .cu file.
     */
-   public CUDAProgram(Path programPath, Path... headerPaths)
+   public CUDAProgram(URL programPath, URL... headerPaths)
    {
       this(programPath, headerPaths, DEFAULT_OPTIONS);
    }
@@ -47,12 +48,15 @@ public class CUDAProgram implements AutoCloseable
     * @param compilationOptions List of compilation options
     *                           (You can see the available options <a href="https://docs.nvidia.com/cuda/nvrtc/index.html#supported-compile-options">here</a>)
     */
-   public CUDAProgram(Path programPath, Path[] headerPaths, String... compilationOptions)
+   public CUDAProgram(URL programPath, URL[] headerPaths, String... compilationOptions)
    {
       try
       {
-         String programName = programPath.getFileName().toString();
-         String programContents = new String(Files.readAllBytes(programPath));
+         String programName = programPath.getFile();
+
+         InputStream programContentsStream = programPath.openStream();
+         String programContents = new String(programContentsStream.readAllBytes());
+         programContentsStream.close();
 
          String[] headerNames = null;
          String[] headerContents = null;
@@ -64,8 +68,11 @@ public class CUDAProgram implements AutoCloseable
 
             for (int i = 0; i < headerPaths.length; i++)
             {
-               headerNames[i] = headerPaths[i].getFileName().toString();
-               headerContents[i] = new String(Files.readAllBytes(headerPaths[i]));
+               headerNames[i] = headerPaths[i].getFile();
+
+               InputStream headerInputStream = headerPaths[i].openStream();
+               headerContents[i] = new String(headerInputStream.readAllBytes());
+               headerInputStream.close();
             }
          }
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAProgram.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAProgram.java
@@ -12,7 +12,6 @@ import us.ihmc.log.LogTools;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.nio.file.Path;
 
 import static org.bytedeco.cuda.global.cudart.*;
 import static org.bytedeco.cuda.global.nvrtc.*;
@@ -32,8 +31,8 @@ public class CUDAProgram implements AutoCloseable
    /**
     * Construct a {@link CUDAProgram} with default compilation options
     *
-    * @param programPath {@link Path} to the .cu file.
-    * @param headerPaths {@link Path}s to the header files included (with {@code #include}) in the .cu file.
+    * @param programPath {@link URL} to the .cu file.
+    * @param headerPaths {@link URL}s to the header files included (with {@code #include}) in the .cu file.
     */
    public CUDAProgram(URL programPath, URL... headerPaths)
    {
@@ -43,8 +42,8 @@ public class CUDAProgram implements AutoCloseable
    /**
     * Construct a {@link CUDAProgram} specifying the path to the .cu file, paths to the header files, and compilation options.
     *
-    * @param programPath        {@link Path} to the .cu file.
-    * @param headerPaths        {@link Path}s to the header files included (with {@code #include}) in the .cu file.
+    * @param programPath        {@link URL} to the .cu file.
+    * @param headerPaths        {@link URL}s to the header files included (with {@code #include}) in the .cu file.
     * @param compilationOptions List of compilation options
     *                           (You can see the available options <a href="https://docs.nvidia.com/cuda/nvrtc/index.html#supported-compile-options">here</a>)
     */

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAProgramTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAProgramTest.java
@@ -6,8 +6,7 @@ import org.bytedeco.javacpp.IntPointer;
 import org.junit.jupiter.api.Test;
 
 import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.util.Objects;
+import java.net.URL;
 
 import static org.bytedeco.cuda.global.cudart.*;
 import static org.junit.jupiter.api.Assertions.*;
@@ -146,8 +145,8 @@ public class CUDAProgramTest
       CUstream_st stream = CUDAStreamManager.getStream();
 
       // Create a CUDA program with files
-      Path kernelPath = Path.of(Objects.requireNonNull(getClass().getResource("test_add_values.cu")).toURI());
-      Path headerPath = Path.of(Objects.requireNonNull(getClass().getResource("test_values.cuh")).toURI());
+      URL kernelPath = getClass().getResource("test_add_values.cu");
+      URL headerPath = getClass().getResource("test_values.cuh");
 
       try (CUDAProgram program = new CUDAProgram(kernelPath, headerPath);
 

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/examples/ExampleCUDAKernel2D.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/examples/ExampleCUDAKernel2D.java
@@ -11,9 +11,7 @@ import us.ihmc.perception.cuda.CUDAKernel;
 import us.ihmc.perception.cuda.CUDAProgram;
 import us.ihmc.perception.cuda.CUDAStreamManager;
 
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.util.Objects;
+import java.net.URL;
 
 /**
  * This is an example of using a more complex CUDA kernel that takes in an OpenCV {@link Mat} object. We do this often for kernels, so this example walks you
@@ -23,10 +21,10 @@ import java.util.Objects;
  */
 public class ExampleCUDAKernel2D
 {
-   public ExampleCUDAKernel2D() throws URISyntaxException
+   public ExampleCUDAKernel2D()
    {
       // We load the kernel from resources; this is a good place to store kernels to separate them from the Java classes
-      Path programPath = Path.of(Objects.requireNonNull(getClass().getResource("matrix_element_wise_addition.cu")).toURI());
+      URL programPath = getClass().getResource("matrix_element_wise_addition.cu");
       // Create the stream
       CUstream_st stream = CUDAStreamManager.getStream();
 
@@ -119,7 +117,7 @@ public class ExampleCUDAKernel2D
       }
    }
 
-   public static void main(String[] args) throws URISyntaxException
+   public static void main(String[] args)
    {
       new ExampleCUDAKernel2D();
    }


### PR DESCRIPTION
We were having trouble loading the .cu from resources when deployed on Nadia, so maybe this'll help. 
It also simplifies loading the .cu files from resources in general (no `URISyntaxException` or `Objects.requireNonNull()`)