### PR TITLE
Added the ability to walk backwards with the continuous hiking pipeline. This is done via the xbox controller

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXContinuousHikingPanel.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXContinuousHikingPanel.java
@@ -337,13 +337,16 @@ public class RDXContinuousHikingPanel extends RDXPanel implements RenderableProv
       // Setup a bunch of variables to be published in the message
       boolean walkWithKeyboard = ImGui.getIO().getKeyCtrl();
       boolean walkWithController = false;
+      boolean walkBackwards = false;
       double lateralJoystickValue = 0.0;
       double forwardJoystickValue = 0.0;
       double turningJoystickValue = 0.0;
 
       if (controllerConnected)
       {
+         walkBackwards = joystickController.getButton(joystickController.getMapping().buttonB);
          walkWithController = joystickController.getButton(joystickController.getMapping().buttonA);
+         walkWithController |= walkBackwards;
          forwardJoystickValue = -joystickController.getAxis(joystickController.getMapping().axisLeftY);
          lateralJoystickValue = -joystickController.getAxis(joystickController.getMapping().axisLeftX);
          turningJoystickValue = -joystickController.getAxis(joystickController.getMapping().axisRightX);
@@ -355,6 +358,7 @@ public class RDXContinuousHikingPanel extends RDXPanel implements RenderableProv
       {
          commandMessage.setEnableContinuousHikingWithKeyboard(walkWithKeyboard);
          commandMessage.setEnableContinuousHikingWithJoystickController(walkWithController);
+         commandMessage.setWalkBackwards(walkBackwards);
          commandMessage.setForwardValue(forwardJoystickValue);
          commandMessage.setLateralValue(lateralJoystickValue);
          commandMessage.setTurningValue(turningJoystickValue);

--- a/ihmc-high-level-behaviors/src/main/generated-java/us/ihmc/behaviors/activeMapping/ContinuousHikingParameters.java
+++ b/ihmc-high-level-behaviors/src/main/generated-java/us/ihmc/behaviors/activeMapping/ContinuousHikingParameters.java
@@ -24,6 +24,7 @@ public class ContinuousHikingParameters extends StoredPropertySet implements Con
    public static final IntegerStoredPropertyKey numberOfStepsToSend = keys.addIntegerKey("Number of steps to send");
    public static final DoubleStoredPropertyKey goalPoseForwardDistance = keys.addDoubleKey("Goal pose forward distance");
    public static final DoubleStoredPropertyKey goalPoseUpDistance = keys.addDoubleKey("Goal pose up distance");
+   public static final DoubleStoredPropertyKey goalPoseBackwardDistance = keys.addDoubleKey("Goal pose backward distance");
    public static final DoubleStoredPropertyKey swingTime = keys.addDoubleKey("Swing time");
    public static final DoubleStoredPropertyKey transferTime = keys.addDoubleKey("Transfer time");
    public static final DoubleStoredPropertyKey planningTimeoutAsAFractionOfTheStepDuration = keys.addDoubleKey("Planning timeout as a fraction of the step duration");

--- a/ihmc-high-level-behaviors/src/main/generated-java/us/ihmc/behaviors/activeMapping/ContinuousHikingParametersBasics.java
+++ b/ihmc-high-level-behaviors/src/main/generated-java/us/ihmc/behaviors/activeMapping/ContinuousHikingParametersBasics.java
@@ -38,6 +38,11 @@ public interface ContinuousHikingParametersBasics extends ContinuousHikingParame
       set(ContinuousHikingParameters.goalPoseUpDistance, goalPoseUpDistance);
    }
 
+   default void setGoalPoseBackwardDistance(double goalPoseBackwardDistance)
+   {
+      set(ContinuousHikingParameters.goalPoseBackwardDistance, goalPoseBackwardDistance);
+   }
+
    default void setSwingTime(double swingTime)
    {
       set(ContinuousHikingParameters.swingTime, swingTime);

--- a/ihmc-high-level-behaviors/src/main/generated-java/us/ihmc/behaviors/activeMapping/ContinuousHikingParametersReadOnly.java
+++ b/ihmc-high-level-behaviors/src/main/generated-java/us/ihmc/behaviors/activeMapping/ContinuousHikingParametersReadOnly.java
@@ -40,6 +40,11 @@ public interface ContinuousHikingParametersReadOnly extends StoredPropertySetRea
       return get(goalPoseUpDistance);
    }
 
+   default double getGoalPoseBackwardDistance()
+   {
+      return get(goalPoseBackwardDistance);
+   }
+
    default double getSwingTime()
    {
       return get(swingTime);

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/ContinuousHikingStateMachine/ReadyToPlanState.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/ContinuousHikingStateMachine/ReadyToPlanState.java
@@ -155,24 +155,33 @@ public class ReadyToPlanState implements State
          {
             if (commandMessage.get().getEnableContinuousHikingWithKeyboard())
             {
-               goalPoses = ContinuousPlannerTools.setRandomizedStraightGoalPoses(continuousPlanner.getWalkingStartMidPose(),
+               goalPoses = ContinuousPlannerTools.setStraightForwardGoalPoses(continuousPlanner.getWalkingStartMidPose(),
+                                                                              continuousPlanner.getStartStancePose(),
+                                                                              (float) continuousHikingParameters.getGoalPoseForwardDistance(),
+                                                                              (float) continuousHikingParameters.getGoalPoseUpDistance(),
+                                                                              X_RANDOM_MARGIN,
+                                                                              NOMINAL_STANCE_WIDTH);
+            }
+            else if (commandMessage.get().getEnableContinuousHikingWithJoystickController())
+            {
+               if (commandMessage.get().getWalkBackwards())
+               {
+                  goalPoses = ContinuousPlannerTools.setStraightBackwardGoalPoses(continuousPlanner.getWalkingStartMidPose(),
+                                                                                  continuousPlanner.getStartStancePose(),
+                                                                                  (float) continuousHikingParameters.getGoalPoseBackwardDistance(),
+                                                                                  (float) continuousHikingParameters.getGoalPoseUpDistance(),
+                                                                                  X_RANDOM_MARGIN,
+                                                                                  NOMINAL_STANCE_WIDTH);
+               }
+               // Here we assume the joystick isn't being turned at all, so we give a direction of straight forward
+               else if (Math.abs(commandMessage.get().getLateralValue()) < 0.1)
+               {
+                  goalPoses = ContinuousPlannerTools.setStraightForwardGoalPoses(continuousPlanner.getWalkingStartMidPose(),
                                                                                  continuousPlanner.getStartStancePose(),
                                                                                  (float) continuousHikingParameters.getGoalPoseForwardDistance(),
                                                                                  (float) continuousHikingParameters.getGoalPoseUpDistance(),
                                                                                  X_RANDOM_MARGIN,
                                                                                  NOMINAL_STANCE_WIDTH);
-            }
-            else if (commandMessage.get().getEnableContinuousHikingWithJoystickController())
-            {
-               // Here we assume the joystick isn't being turned at all, so we give a direction of straight forward
-               if (Math.abs(commandMessage.get().getLateralValue()) < 0.1)
-               {
-                  goalPoses = ContinuousPlannerTools.setRandomizedStraightGoalPoses(continuousPlanner.getWalkingStartMidPose(),
-                                                                                    continuousPlanner.getStartStancePose(),
-                                                                                    (float) continuousHikingParameters.getGoalPoseForwardDistance(),
-                                                                                    (float) continuousHikingParameters.getGoalPoseUpDistance(),
-                                                                                    X_RANDOM_MARGIN,
-                                                                                    NOMINAL_STANCE_WIDTH);
                }
                else
                {

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/ContinuousPlanner.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/ContinuousPlanner.java
@@ -130,7 +130,6 @@ public class ContinuousPlanner
    public void planToGoal(ContinuousWalkingCommandMessage command, SideDependentList<FramePose3D> goalPoses)
    {
       this.command = command;
-      long startTimeForStatistics = System.currentTimeMillis();
 
       if (command.getUseAstarFootstepPlanner())
       {
@@ -179,6 +178,22 @@ public class ContinuousPlanner
       request.setTerrainMapData(terrainMapData);
       request.setSnapGoalSteps(true);
       request.setAbortIfGoalStepSnappingFails(true);
+
+      // When walking backwards, we want to keep the body facing in the same direction, otherwise the robot will turn as it tries to step backwards
+      if (command.getWalkBackwards())
+      {
+         FramePose3D bodyMidGoalPose = new FramePose3D();
+         bodyMidGoalPose.interpolate(goalPoses.get(RobotSide.LEFT), goalPoses.get(RobotSide.RIGHT), 0.5);
+         request.getBodyPathWaypoints().add(walkingStartMidPose);
+         request.getBodyPathWaypoints().add(bodyMidGoalPose);
+
+         // To allow walking backwards, we need to change the minimum step length, but this affects other walking, so we only do it when going backwards
+         footstepPlannerParameters.setMinStepLength(-0.3);
+      }
+      else
+      {
+         footstepPlannerParameters.setMinStepLength(0.1);
+      }
 
       if (useMonteCarloPlanAsReference && monteCarloFootstepPlan.get() != null && monteCarloFootstepPlan.get().getNumberOfSteps() > 0)
       {
@@ -310,7 +325,7 @@ public class ContinuousPlanner
       long timeEnd = System.nanoTime();
 
       continuousHikingLogger.appendString(String.format("Total Time: %.3f ms, Plan Size: %d, Visited: %d, Layer Counts: %s",
-                                            (timeEnd - timeStart) / 1e6,
+                                                        (timeEnd - timeStart) / 1e6,
                                                         latestMonteCarloPlan.getNumberOfSteps(),
                                                         monteCarloFootstepPlanner.getVisitedNodes().size(),
                                                         MonteCarloPlannerTools.getLayerCountsString(monteCarloFootstepPlanner.getRoot())));

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/ContinuousPlannerTools.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/ContinuousPlannerTools.java
@@ -36,12 +36,13 @@ public class ContinuousPlannerTools
     * This method takes in a reference frame on the robot
     * and computes a desired goal that's rotated around the reference frame by the lateral value in radians.
     * And the goal is shifted forward by the x distance provided.
-    * @param pelvisFrame is the current location of the robot
-    * @param midFeetZUpFrame is used to get the height above the feet on the robot to set the goal pose from
+    *
+    * @param pelvisFrame           is the current location of the robot
+    * @param midFeetZUpFrame       is used to get the height above the feet on the robot to set the goal pose from
     * @param lateralValueInRadians in the value the goal will be rotated (in radians)
-    * @param xDistance the distance away from the robot the goal will be placed in the X-axis (in meters)
-    * @param zDistance the distance away from the robot the goal win be placed in the Z-axis (in meters)
-    * @param nominalStanceWidth is the default width we want the feet to be apart when we set the goal poses
+    * @param xDistance             the distance away from the robot the goal will be placed in the X-axis (in meters)
+    * @param zDistance             the distance away from the robot the goal win be placed in the Z-axis (in meters)
+    * @param nominalStanceWidth    is the default width we want the feet to be apart when we set the goal poses
     * @return the goal poses in which to attempt to plan towards.
     */
    public static SideDependentList<FramePose3D> setGoalPoseBasedOnLateralJoystickValue(ReferenceFrame pelvisFrame,
@@ -85,12 +86,12 @@ public class ContinuousPlannerTools
       return goalPose;
    }
 
-   public static SideDependentList<FramePose3D> setRandomizedStraightGoalPoses(FramePose3D walkingStartPose,
-                                                                               SideDependentList<FramePose3D> stancePose,
-                                                                               float xDistance,
-                                                                               float zDistance,
-                                                                               float xRandomMargin,
-                                                                               float nominalStanceWidth)
+   public static SideDependentList<FramePose3D> setStraightForwardGoalPoses(FramePose3D walkingStartPose,
+                                                                            SideDependentList<FramePose3D> stancePose,
+                                                                            float xDistance,
+                                                                            float zDistance,
+                                                                            float xRandomMargin,
+                                                                            float nominalStanceWidth)
    {
       float offsetX = (float) (Math.random() * xRandomMargin - xRandomMargin / 2.0f);
 
@@ -113,6 +114,43 @@ public class ContinuousPlannerTools
          goalPose.get(side).getPosition().set(walkingStartPose.getPosition());
          goalPose.get(side).getOrientation().set(walkingStartPose.getOrientation());
          goalPose.get(side).appendTranslation(xWalkDistance + xDistance + offsetX, 0, stanceMidPose.getZ() + zDistance - walkingStartPose.getZ());
+      }
+
+      // These are done after the for loop because of the ( - ) or ( + ) for the nominal stance
+      goalPose.get(RobotSide.LEFT).appendTranslation(0.0, nominalStanceWidth / 2.0f, 0.0);
+      goalPose.get(RobotSide.RIGHT).appendTranslation(0.0, -nominalStanceWidth / 2.0f, 0.0);
+
+      return goalPose;
+   }
+
+   public static SideDependentList<FramePose3D> setStraightBackwardGoalPoses(FramePose3D walkingStartPose,
+                                                                             SideDependentList<FramePose3D> stancePose,
+                                                                             float xDistance,
+                                                                             float zDistance,
+                                                                             float xRandomMargin,
+                                                                             float nominalStanceWidth)
+   {
+      float offsetX = (float) (Math.random() * xRandomMargin - xRandomMargin / 2.0f);
+
+      FramePose3D stanceMidPose = new FramePose3D();
+      stanceMidPose.interpolate(stancePose.get(RobotSide.LEFT), stancePose.get(RobotSide.RIGHT), 0.5);
+
+      SideDependentList<FramePose3D> goalPose = new SideDependentList<>();
+      for (RobotSide side : RobotSide.values)
+      {
+         goalPose.put(side, new FramePose3D());
+         RigidBodyTransform stanceToWalkingFrameTransform = new RigidBodyTransform();
+         RigidBodyTransform worldToWalkingFrameTransform = new RigidBodyTransform();
+
+         stanceToWalkingFrameTransform.set(stanceMidPose);
+         worldToWalkingFrameTransform.set(walkingStartPose);
+         worldToWalkingFrameTransform.invert();
+         stanceToWalkingFrameTransform.multiply(worldToWalkingFrameTransform);
+
+         double xWalkDistance = stanceToWalkingFrameTransform.getTranslation().norm();
+         goalPose.get(side).getPosition().set(walkingStartPose.getPosition());
+         goalPose.get(side).getOrientation().set(walkingStartPose.getOrientation());
+         goalPose.get(side).appendTranslation(-xWalkDistance - xDistance - offsetX, 0, stanceMidPose.getZ() + zDistance - walkingStartPose.getZ());
       }
 
       // These are done after the for loop because of the ( - ) or ( + ) for the nominal stance

--- a/ihmc-high-level-behaviors/src/main/resources/us/ihmc/behaviors/activeMapping/ContinuousHikingParameters.json
+++ b/ihmc-high-level-behaviors/src/main/resources/us/ihmc/behaviors/activeMapping/ContinuousHikingParameters.json
@@ -6,6 +6,7 @@
   "Number of steps to send" : 3,
   "Goal pose forward distance" : 1.4,
   "Goal pose up distance" : 0.5,
+  "Goal pose backward distance" : 0.8,
   "Swing time" : 0.95,
   "Transfer time" : 0.6,
   "Planning timeout as a fraction of the step duration" : 0.3,

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/behaviors/activeMapping/ContinuousPlannerToolsTest.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/behaviors/activeMapping/ContinuousPlannerToolsTest.java
@@ -42,18 +42,18 @@ public class ContinuousPlannerToolsTest
    /**
     * This test checks to make sure the goal poses are at the expected distance from the start, and at the expected height from the start, and that the width
     * is about as expected (not super strict on the accuracy of the width). Meant to test
-    * {@link ContinuousPlannerTools#setRandomizedStraightGoalPoses(FramePose3D, SideDependentList, float, float, float, float)}
+    * {@link ContinuousPlannerTools#setStraightForwardGoalPoses(FramePose3D, SideDependentList, float, float, float, float)}
     */
    @Test
    public void testRandomizedStraightGoalPoses()
    {
       // Pass everything to the tools method to get the forward goal position
-      SideDependentList<FramePose3D> goalPoses = ContinuousPlannerTools.setRandomizedStraightGoalPoses(walkingStartMidPose,
-                                                                                                       stancePose,
-                                                                                                       (float) continuousHikingParameters.getGoalPoseForwardDistance(),
-                                                                                                       (float) continuousHikingParameters.getGoalPoseUpDistance(),
-                                                                                                       X_RANDOM_MARGIN,
-                                                                                                       NOMINAL_STANCE_WIDTH);
+      SideDependentList<FramePose3D> goalPoses = ContinuousPlannerTools.setStraightForwardGoalPoses(walkingStartMidPose,
+                                                                                                    stancePose,
+                                                                                                    (float) continuousHikingParameters.getGoalPoseForwardDistance(),
+                                                                                                    (float) continuousHikingParameters.getGoalPoseUpDistance(),
+                                                                                                    X_RANDOM_MARGIN,
+                                                                                                    NOMINAL_STANCE_WIDTH);
 
       // These are the maximum and minimum values where the goal pose should be able to exist
       double maxForwardGoalDistance = walkingStartMidPose.getX() + continuousHikingParameters.getGoalPoseForwardDistance() + X_RANDOM_MARGIN;

--- a/ihmc-interfaces/src/main/generated-idl/behavior_msgs/msg/ContinuousWalkingCommandMessage_.idl
+++ b/ihmc-interfaces/src/main/generated-idl/behavior_msgs/msg/ContinuousWalkingCommandMessage_.idl
@@ -20,6 +20,10 @@ module behavior_msgs
          */
         boolean enable_continuous_hiking_with_joystick_controller;
         /**
+         * flag to walk backwards with the continuous hiking state machine
+         */
+        boolean walk_backwards;
+        /**
          * forward joystick value
          */
         double forward_value;

--- a/ihmc-interfaces/src/main/generated-java/behavior_msgs/msg/dds/ContinuousWalkingCommandMessage.java
+++ b/ihmc-interfaces/src/main/generated-java/behavior_msgs/msg/dds/ContinuousWalkingCommandMessage.java
@@ -17,6 +17,10 @@ public class ContinuousWalkingCommandMessage extends Packet<ContinuousWalkingCom
             */
    public boolean enable_continuous_hiking_with_joystick_controller_;
    /**
+            * flag to walk backwards with the continuous hiking state machine
+            */
+   public boolean walk_backwards_;
+   /**
             * forward joystick value
             */
    public double forward_value_;
@@ -65,6 +69,8 @@ public class ContinuousWalkingCommandMessage extends Packet<ContinuousWalkingCom
 
       enable_continuous_hiking_with_joystick_controller_ = other.enable_continuous_hiking_with_joystick_controller_;
 
+      walk_backwards_ = other.walk_backwards_;
+
       forward_value_ = other.forward_value_;
 
       lateral_value_ = other.lateral_value_;
@@ -111,6 +117,21 @@ public class ContinuousWalkingCommandMessage extends Packet<ContinuousWalkingCom
    public boolean getEnableContinuousHikingWithJoystickController()
    {
       return enable_continuous_hiking_with_joystick_controller_;
+   }
+
+   /**
+            * flag to walk backwards with the continuous hiking state machine
+            */
+   public void setWalkBackwards(boolean walk_backwards)
+   {
+      walk_backwards_ = walk_backwards;
+   }
+   /**
+            * flag to walk backwards with the continuous hiking state machine
+            */
+   public boolean getWalkBackwards()
+   {
+      return walk_backwards_;
    }
 
    /**
@@ -255,6 +276,8 @@ public class ContinuousWalkingCommandMessage extends Packet<ContinuousWalkingCom
 
       if (!us.ihmc.idl.IDLTools.epsilonEqualsBoolean(this.enable_continuous_hiking_with_joystick_controller_, other.enable_continuous_hiking_with_joystick_controller_, epsilon)) return false;
 
+      if (!us.ihmc.idl.IDLTools.epsilonEqualsBoolean(this.walk_backwards_, other.walk_backwards_, epsilon)) return false;
+
       if (!us.ihmc.idl.IDLTools.epsilonEqualsPrimitive(this.forward_value_, other.forward_value_, epsilon)) return false;
 
       if (!us.ihmc.idl.IDLTools.epsilonEqualsPrimitive(this.lateral_value_, other.lateral_value_, epsilon)) return false;
@@ -288,6 +311,8 @@ public class ContinuousWalkingCommandMessage extends Packet<ContinuousWalkingCom
 
       if(this.enable_continuous_hiking_with_joystick_controller_ != otherMyClass.enable_continuous_hiking_with_joystick_controller_) return false;
 
+      if(this.walk_backwards_ != otherMyClass.walk_backwards_) return false;
+
       if(this.forward_value_ != otherMyClass.forward_value_) return false;
 
       if(this.lateral_value_ != otherMyClass.lateral_value_) return false;
@@ -318,6 +343,8 @@ public class ContinuousWalkingCommandMessage extends Packet<ContinuousWalkingCom
       builder.append(this.enable_continuous_hiking_with_keyboard_);      builder.append(", ");
       builder.append("enable_continuous_hiking_with_joystick_controller=");
       builder.append(this.enable_continuous_hiking_with_joystick_controller_);      builder.append(", ");
+      builder.append("walk_backwards=");
+      builder.append(this.walk_backwards_);      builder.append(", ");
       builder.append("forward_value=");
       builder.append(this.forward_value_);      builder.append(", ");
       builder.append("lateral_value=");

--- a/ihmc-interfaces/src/main/generated-java/behavior_msgs/msg/dds/ContinuousWalkingCommandMessagePubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/behavior_msgs/msg/dds/ContinuousWalkingCommandMessagePubSubType.java
@@ -15,7 +15,7 @@ public class ContinuousWalkingCommandMessagePubSubType implements us.ihmc.pubsub
    @Override
    public final java.lang.String getDefinitionChecksum()
    {
-   		return "8ab35374b15b8d54fab6bc5de9cb813684cd6641c734e8e7cab662203c31c81a";
+   		return "f758c83c4b6c80fb6df0a3ecfd60a8f3a93372821d16b63c3e75fd063d7b8700";
    }
    
    @Override
@@ -56,6 +56,8 @@ public class ContinuousWalkingCommandMessagePubSubType implements us.ihmc.pubsub
 
       current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
 
+      current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
+
       current_alignment += 8 + us.ihmc.idl.CDR.alignment(current_alignment, 8);
 
       current_alignment += 8 + us.ihmc.idl.CDR.alignment(current_alignment, 8);
@@ -84,6 +86,9 @@ public class ContinuousWalkingCommandMessagePubSubType implements us.ihmc.pubsub
    public final static int getCdrSerializedSize(behavior_msgs.msg.dds.ContinuousWalkingCommandMessage data, int current_alignment)
    {
       int initial_alignment = current_alignment;
+
+      current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
+
 
       current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
 
@@ -125,6 +130,8 @@ public class ContinuousWalkingCommandMessagePubSubType implements us.ihmc.pubsub
 
       cdr.write_type_7(data.getEnableContinuousHikingWithJoystickController());
 
+      cdr.write_type_7(data.getWalkBackwards());
+
       cdr.write_type_6(data.getForwardValue());
 
       cdr.write_type_6(data.getLateralValue());
@@ -148,6 +155,8 @@ public class ContinuousWalkingCommandMessagePubSubType implements us.ihmc.pubsub
       data.setEnableContinuousHikingWithKeyboard(cdr.read_type_7());
       	
       data.setEnableContinuousHikingWithJoystickController(cdr.read_type_7());
+      	
+      data.setWalkBackwards(cdr.read_type_7());
       	
       data.setForwardValue(cdr.read_type_6());
       	
@@ -173,6 +182,7 @@ public class ContinuousWalkingCommandMessagePubSubType implements us.ihmc.pubsub
    {
       ser.write_type_7("enable_continuous_hiking_with_keyboard", data.getEnableContinuousHikingWithKeyboard());
       ser.write_type_7("enable_continuous_hiking_with_joystick_controller", data.getEnableContinuousHikingWithJoystickController());
+      ser.write_type_7("walk_backwards", data.getWalkBackwards());
       ser.write_type_6("forward_value", data.getForwardValue());
       ser.write_type_6("lateral_value", data.getLateralValue());
       ser.write_type_6("turning_value", data.getTurningValue());
@@ -188,6 +198,7 @@ public class ContinuousWalkingCommandMessagePubSubType implements us.ihmc.pubsub
    {
       data.setEnableContinuousHikingWithKeyboard(ser.read_type_7("enable_continuous_hiking_with_keyboard"));
       data.setEnableContinuousHikingWithJoystickController(ser.read_type_7("enable_continuous_hiking_with_joystick_controller"));
+      data.setWalkBackwards(ser.read_type_7("walk_backwards"));
       data.setForwardValue(ser.read_type_6("forward_value"));
       data.setLateralValue(ser.read_type_6("lateral_value"));
       data.setTurningValue(ser.read_type_6("turning_value"));

--- a/ihmc-interfaces/src/main/messages/ihmc_interfaces/behavior_msgs/msg/ContinuousWalkingCommandMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ihmc_interfaces/behavior_msgs/msg/ContinuousWalkingCommandMessage.msg
@@ -4,6 +4,9 @@ bool enable_continuous_hiking_with_keyboard
 # flag to enable/disable continuous hiking state machine with joystick controller
 bool enable_continuous_hiking_with_joystick_controller
 
+# flag to walk backwards with the continuous hiking state machine
+bool walk_backwards
+
 # forward joystick value
 float64 forward_value
 

--- a/ihmc-interfaces/src/main/messages/ros1/behavior_msgs/msg/ContinuousWalkingCommandMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ros1/behavior_msgs/msg/ContinuousWalkingCommandMessage.msg
@@ -5,6 +5,9 @@ bool enable_continuous_hiking_with_keyboard
 # flag to enable/disable continuous hiking state machine with joystick controller
 bool enable_continuous_hiking_with_joystick_controller
 
+# flag to walk backwards with the continuous hiking state machine
+bool walk_backwards
+
 # forward joystick value
 float64 forward_value
 


### PR DESCRIPTION
- Added field to message that checks if the user is asking the robot to walk backwards.
- Inside the `ReadyToPlan` state added the check that "if the user wants to go backwards" we set the goal pose to be behind the robot
- Added a parameter for the distance of the goal pose behind the robot
- When walking backwards we want to keep the robot facing the same direction, so we add a couple body path poses so the robot doesn't turn when walking backwards.
- When walking backwards we want to adjust some parameters so we can encourage going backwards, and when not walking backwards we want to change them back
-