### PR TITLE
Reduce ihmc-perception dependencies

### DIFF
--- a/atlas/src/main/java/us/ihmc/atlas/multisenseTestbench/MultisenseTestBenchWithZeroPoseModuleNetworkProcessor.java
+++ b/atlas/src/main/java/us/ihmc/atlas/multisenseTestbench/MultisenseTestBenchWithZeroPoseModuleNetworkProcessor.java
@@ -23,7 +23,7 @@ import us.ihmc.communication.util.NetworkPorts;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.humanoidRobotics.kryo.IHMCCommunicationKryoNetClassList;
 import us.ihmc.humanoidRobotics.kryo.PPSTimestampOffsetProvider;
-import us.ihmc.perception.time.AlwaysZeroOffsetPPSTimestampOffsetProvider;
+import us.ihmc.avatar.networkProcessor.time.AlwaysZeroOffsetPPSTimestampOffsetProvider;
 import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
 import us.ihmc.pubsub.DomainFactory.PubSubImplementation;
 import us.ihmc.robotModels.FullHumanoidRobotModel;

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/networkProcessor/time/AlwaysZeroOffsetPPSTimestampOffsetProvider.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/networkProcessor/time/AlwaysZeroOffsetPPSTimestampOffsetProvider.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.time;
+package us.ihmc.avatar.networkProcessor.time;
 
 import controller_msgs.msg.dds.RobotConfigurationData;
 import us.ihmc.humanoidRobotics.kryo.PPSTimestampOffsetProvider;

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/networkProcessor/time/DRCROSAlwaysZeroOffsetPPSTimestampOffsetProvider.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/networkProcessor/time/DRCROSAlwaysZeroOffsetPPSTimestampOffsetProvider.java
@@ -2,7 +2,6 @@ package us.ihmc.avatar.networkProcessor.time;
 
 
 import us.ihmc.avatar.ros.DRCROSPPSTimestampOffsetProvider;
-import us.ihmc.perception.time.AlwaysZeroOffsetPPSTimestampOffsetProvider;
 import us.ihmc.utilities.ros.RosNodeInterface;
 
 public class DRCROSAlwaysZeroOffsetPPSTimestampOffsetProvider extends AlwaysZeroOffsetPPSTimestampOffsetProvider implements DRCROSPPSTimestampOffsetProvider

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXHumanoidPerceptionUI.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXHumanoidPerceptionUI.java
@@ -11,7 +11,7 @@ import org.bytedeco.opencv.opencv_core.Mat;
 import us.ihmc.communication.ros2.ROS2Helper;
 import us.ihmc.perception.gpuHeightMap.HeatMapGenerator;
 import us.ihmc.perception.gpuHeightMap.RapidHeightMapExtractor;
-import us.ihmc.perception.headless.HumanoidPerceptionModule;
+import us.ihmc.perception.HumanoidPerceptionModule;
 import us.ihmc.perception.heightMap.TerrainMapData;
 import us.ihmc.rdx.imgui.RDXPanel;
 import us.ihmc.rdx.sceneManager.RDXRenderableProvider;

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/ActivePlanarMappingRemoteTask.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/ActivePlanarMappingRemoteTask.java
@@ -12,7 +12,7 @@ import us.ihmc.footstepPlanning.swing.SwingPlannerParametersBasics;
 import us.ihmc.humanoidRobotics.communication.packets.walking.WalkingStatus;
 import us.ihmc.humanoidRobotics.frames.HumanoidReferenceFrames;
 import us.ihmc.log.LogTools;
-import us.ihmc.perception.headless.LocalizationAndMappingTask;
+import us.ihmc.perception.LocalizationAndMappingTask;
 import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Topic;
 

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/PerceptionBasedContinuousHiking.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/activeMapping/PerceptionBasedContinuousHiking.java
@@ -10,7 +10,7 @@ import us.ihmc.footstepPlanning.MonteCarloFootstepPlannerParameters;
 import us.ihmc.footstepPlanning.communication.ContinuousWalkingAPI;
 import us.ihmc.footstepPlanning.graphSearch.parameters.DefaultFootstepPlannerParametersBasics;
 import us.ihmc.footstepPlanning.swing.SwingPlannerParametersBasics;
-import us.ihmc.perception.headless.TerrainPerceptionProcessWithDriver;
+import us.ihmc.perception.TerrainPerceptionProcessWithDriver;
 import us.ihmc.perception.realsense.RealsenseConfiguration;
 import us.ihmc.pubsub.DomainFactory;
 import us.ihmc.ros2.ROS2Node;

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/HumanoidPerceptionModule.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/HumanoidPerceptionModule.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.headless;
+package us.ihmc.perception;
 
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.opencl.global.OpenCL;
@@ -17,7 +17,6 @@ import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.euclid.tuple4D.Quaternion;
 import us.ihmc.humanoidRobotics.frames.HumanoidReferenceFrames;
 import us.ihmc.log.LogTools;
-import us.ihmc.perception.BytedecoImage;
 import us.ihmc.perception.camera.CameraIntrinsics;
 import us.ihmc.perception.depthData.CollisionBoxProvider;
 import us.ihmc.perception.filters.CollidingScanRegionFilter;

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/LocalizationAndMappingTask.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/LocalizationAndMappingTask.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.headless;
+package us.ihmc.perception;
 
 import controller_msgs.msg.dds.HighLevelStateMessage;
 import controller_msgs.msg.dds.WalkingControllerFailureStatusMessage;

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/StructuralPerceptionProcessWithDriver.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/StructuralPerceptionProcessWithDriver.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.headless;
+package us.ihmc.perception;
 
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.IntPointer;
@@ -15,7 +15,6 @@ import us.ihmc.communication.ros2.ROS2Helper;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.log.LogTools;
-import us.ihmc.perception.BytedecoImage;
 import us.ihmc.perception.comms.PerceptionComms;
 import us.ihmc.perception.imageMessage.CompressionType;
 import us.ihmc.perception.imageMessage.PixelFormat;

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/TerrainPerceptionProcessWithDriver.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/TerrainPerceptionProcessWithDriver.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.headless;
+package us.ihmc.perception;
 
 import controller_msgs.msg.dds.RobotConfigurationData;
 import org.bytedeco.javacpp.BytePointer;
@@ -14,8 +14,6 @@ import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.humanoidRobotics.frames.HumanoidReferenceFrames;
 import us.ihmc.log.LogTools;
-import us.ihmc.perception.BytedecoImage;
-import us.ihmc.perception.CameraModel;
 import us.ihmc.perception.comms.PerceptionComms;
 import us.ihmc.perception.depthData.CollisionBoxProvider;
 import us.ihmc.perception.opencl.OpenCLManager;

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/L515DepthImageReceiver.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/L515DepthImageReceiver.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.realsense.example;
+package us.ihmc.perception.footstepSnapping;
 
 import java.nio.ShortBuffer;
 

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/L515SimpleSnapperExample.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/L515SimpleSnapperExample.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.realsense.example;
+package us.ihmc.perception.footstepSnapping;
 
 import static org.bytedeco.librealsense2.global.realsense2.RS2_EXTENSION_DEPTH_FRAME;
 import static org.bytedeco.librealsense2.global.realsense2.rs2_is_frame_extendable_to;

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/L515Visualizer.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/L515Visualizer.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.realsense.example;
+package us.ihmc.perception.footstepSnapping;
 
 import java.nio.ShortBuffer;
 import java.util.ArrayList;
@@ -12,7 +12,6 @@ import us.ihmc.graphicsDescription.appearance.YoAppearance;
 import us.ihmc.graphicsDescription.yoGraphics.YoGraphicPosition;
 import us.ihmc.graphicsDescription.yoGraphics.YoGraphicsListRegistry;
 import us.ihmc.robotics.referenceFrames.PoseReferenceFrame;
-import us.ihmc.yoVariables.euclid.referenceFrame.YoFramePose3D;
 import us.ihmc.yoVariables.euclid.referenceFrame.YoFramePoseUsingYawPitchRoll;
 import us.ihmc.yoVariables.registry.YoRegistry;
 import us.ihmc.yoVariables.variable.YoBoolean;

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/RealtimeL515.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/RealtimeL515.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.realsense.example;
+package us.ihmc.perception.footstepSnapping;
 
 import static org.bytedeco.librealsense2.global.realsense2.rs2_release_frame;
 

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/StandAloneL515Streamer.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/footstepSnapping/StandAloneL515Streamer.java
@@ -1,4 +1,4 @@
-package us.ihmc.perception.realsense.example;
+package us.ihmc.perception.footstepSnapping;
 
 import static org.bytedeco.librealsense2.global.realsense2.rs2_release_frame;
 import static us.ihmc.pubsub.DomainFactory.PubSubImplementation.FAST_RTPS;

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXRapidHeightMapExtractionDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXRapidHeightMapExtractionDemo.java
@@ -14,7 +14,7 @@ import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.euclid.tuple4D.Quaternion;
 import us.ihmc.log.LogTools;
 import us.ihmc.perception.camera.CameraIntrinsics;
-import us.ihmc.perception.headless.HumanoidPerceptionModule;
+import us.ihmc.perception.HumanoidPerceptionModule;
 import us.ihmc.perception.logging.PerceptionDataLoader;
 import us.ihmc.perception.logging.PerceptionLoggerConstants;
 import us.ihmc.perception.opencl.OpenCLManager;

--- a/ihmc-perception/build.gradle.kts
+++ b/ihmc-perception/build.gradle.kts
@@ -85,7 +85,7 @@ mainDependencies {
       exclude(group = "org.bytedeco", module = "javacpp")
    }
 
-   api("us.ihmc:ihmc-common-walking-control-modules:source")
+   api("us.ihmc:ihmc-humanoid-robotics:source")
    api("us.ihmc:robot-environment-awareness:source")
 
    // Previously used for HeightMapAutoencoder and FootstepPredictor


### PR DESCRIPTION
Move some classes up the dependency tree to reduce the amount of dependencies for ihmc-perception, which is meant to be lower level.