### PR TITLE
Fix saving behaviors that are in subdirectories.

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/behavior/tree/RDXBehaviorTree.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/behavior/tree/RDXBehaviorTree.java
@@ -71,10 +71,10 @@ public class RDXBehaviorTree
                                                    panel3D,
                                                    referenceFrameLibrary);
       treeRebuilder = new BehaviorTreeExtensionSubtreeRebuilder(this::getRootNode, crdtInfo);
-      fileMenu = new RDXBehaviorTreeFileMenu(treeFilesDirectory);
+      fileMenu = new RDXBehaviorTreeFileMenu();
 
       state = new BehaviorTreeState(nodeBuilder, treeRebuilder, this::getRootNode, crdtInfo, treeFilesDirectory);
-      fileLoader = new BehaviorTreeFileLoader<>(state, nodeBuilder);
+      fileLoader = new BehaviorTreeFileLoader<>(state, nodeBuilder, treeFilesDirectory);
       nodeCreationMenu = new RDXBehaviorTreeNodeCreationMenu(this, treeFilesDirectory, referenceFrameLibrary);
       treeWidgetsVerticalLayout = new RDXBehaviorTreeWidgetsVerticalLayout(this);
       baseUI.getImGuiPanelManager().addPanel(panel);

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/behavior/tree/RDXBehaviorTreeFileMenu.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/behavior/tree/RDXBehaviorTreeFileMenu.java
@@ -4,20 +4,13 @@ import imgui.ImGui;
 import us.ihmc.commons.thread.Notification;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
 import us.ihmc.rdx.ui.RDXBaseUI;
-import us.ihmc.tools.io.WorkspaceResourceDirectory;
 
 import javax.annotation.Nullable;
 
 public class RDXBehaviorTreeFileMenu
 {
-   private final WorkspaceResourceDirectory treeFilesDirectory;
    private final ImGuiUniqueLabelMap labels = new ImGuiUniqueLabelMap(getClass());
    private final Notification menuShouldClose = new Notification();
-
-   public RDXBehaviorTreeFileMenu(WorkspaceResourceDirectory treeFilesDirectory)
-   {
-      this.treeFilesDirectory = treeFilesDirectory;
-   }
 
    public void renderFileMenu(@Nullable RDXBehaviorTreeNode<?, ?> rootNode, RDXBehaviorTreeNodeCreationMenu nodeCreationMenu)
    {

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/BehaviorTreeExecutor.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/BehaviorTreeExecutor.java
@@ -24,6 +24,7 @@ public class BehaviorTreeExecutor
    private final BehaviorTreeState state;
    private BehaviorTreeNodeExecutor<?, ?> rootNode;
    private final BehaviorTreeFileLoader<BehaviorTreeNodeExecutor<?, ?>> fileLoader;
+   private final WorkspaceResourceDirectory saveFileDirectory = new WorkspaceResourceDirectory(BehaviorTreeExecutor.class, "/behaviorTrees");
 
    public BehaviorTreeExecutor(DRCRobotModel robotModel,
                                ROS2SyncedRobotModel syncedRobot,
@@ -36,7 +37,7 @@ public class BehaviorTreeExecutor
       treeRebuilder = new BehaviorTreeExtensionSubtreeRebuilder(this::getRootNode, crdtInfo);
 
       state = new BehaviorTreeState(nodeBuilder, treeRebuilder, this::getRootNode, crdtInfo, null);
-      fileLoader = new BehaviorTreeFileLoader<>(state, nodeBuilder);
+      fileLoader = new BehaviorTreeFileLoader<>(state, nodeBuilder, saveFileDirectory);
    }
 
    public void update()
@@ -91,7 +92,7 @@ public class BehaviorTreeExecutor
 
    public void loadBehavior(String jsonFileName)
    {
-      WorkspaceResourceFile file = new WorkspaceResourceFile(new WorkspaceResourceDirectory(BehaviorTreeExecutor.class, "/behaviorTrees"), jsonFileName);
+      WorkspaceResourceFile file = new WorkspaceResourceFile(saveFileDirectory, jsonFileName);
       if (file.getClasspathResource() != null)
       {
          state.modifyTreeTopology(topologyOperationQueue ->

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/BehaviorTreeFileLoader.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/BehaviorTreeFileLoader.java
@@ -28,89 +28,108 @@ public class BehaviorTreeFileLoader<T extends BehaviorTreeNodeLayer<T, ?, ?, ?>>
       this.treeFilesDirectory = treeFilesDirectory;
    }
 
-   public T loadFromFile(WorkspaceResourceFile fileToLoad, BehaviorTreeTopologyOperationQueue topologyOperationQueue)
+   public T loadFromFile(WorkspaceResourceFile file, BehaviorTreeTopologyOperationQueue topologyOperationQueue)
+   {
+      return loadFromFile(file, null, null, topologyOperationQueue);
+   }
+
+   private T loadFromFile(WorkspaceResourceFile file, JsonNode jsonNode, T parentNode, BehaviorTreeTopologyOperationQueue topologyOperationQueue)
    {
       MutableObject<T> loadedNode = new MutableObject<>();
 
-      try
+      if (jsonNode == null)
       {
-         // Try loading from file first, since maybe the user saved a new version
-         Path file = fileToLoad.getFilesystemFile();
-         if (file != null && Files.exists(file))
+         try
          {
-            LogTools.info("Loading from file: {}", file);
-            String relativePath = treeFilesDirectory.getFilesystemDirectory().relativize(file).toString();
-            JSONFileTools.load(fileToLoad, jsonNode -> loadedNode.setValue(loadFromFile(relativePath, jsonNode, null, topologyOperationQueue)));
-         }
-         else
-         {
-            URL classpathResource = fileToLoad.getClasspathResource();
-            if (classpathResource != null)
+            // Try loading from file first, since maybe the user saved a new version
+            Path filesystemFile = file.getFilesystemFile();
+            if (filesystemFile != null && Files.exists(filesystemFile))
             {
-               LogTools.info("Loading from resource: {}", classpathResource);
-               String relativePath = classpathResource.toString().replaceAll(treeFilesDirectory.getPathNecessaryForClasspathLoading(), "");
-               JSONFileTools.load(classpathResource, jsonNode -> loadedNode.setValue(loadFromFile(relativePath, jsonNode, null, topologyOperationQueue)));
+               LogTools.info("Loading from file: {}", filesystemFile);
+               JSONFileTools.load(file, childJsonNode ->
+                     loadedNode.setValue(loadFromFile(file, childJsonNode, parentNode, topologyOperationQueue)));
+            }
+            else
+            {
+               URL classpathResource = file.getClasspathResource();
+               if (classpathResource != null)
+               {
+                  LogTools.info("Loading from resource: {}", classpathResource);
+                  JSONFileTools.load(classpathResource, childJsonNode ->
+                        loadedNode.setValue(loadFromFile(file, childJsonNode, parentNode, topologyOperationQueue)));
+               }
             }
          }
+         catch (Exception e)
+         {
+            LogTools.error("""
+                           Error loading {}.
+                           Please run the JSON sanitizer in debug mode with the NullPointerException breakpoint enabled.
+                           Error: {}
+                           """, file.getFileName(), e.getMessage());
+         }
       }
-      catch (Exception e)
+      else
       {
-         LogTools.error("""
-                        Error loading {}.
-                        Please run the JSON sanitizer in debug mode with the NullPointerException breakpoint enabled.
-                        Error: {}
-                        """, fileToLoad.getFileName(), e.getMessage());
+         String typeName = jsonNode.get("type").textValue();
+
+         T node = nodeBuilder.createNode(BehaviorTreeDefinitionRegistry.getClassFromTypeName(typeName),
+                                         behaviorTreeState.getAndIncrementNextID(),
+                                         behaviorTreeState.getCRDTInfo(),
+                                         behaviorTreeState.getSaveFileDirectory());
+         node.getDefinition().loadFromFile(jsonNode);
+
+         // Make sure the node is named the same as the file including subdirectory
+         if (node.getDefinition().isJSONRoot())
+         {
+            String relativePathString;
+            Path filesystemFile = file.getFilesystemFile();
+            if (filesystemFile != null && Files.exists(filesystemFile))
+            {
+               relativePathString = treeFilesDirectory.getFilesystemDirectory().relativize(filesystemFile).toString();
+            }
+            else
+            {
+               String classpathResourceString = file.getClasspathResource().getPath();
+               String pathNecessaryForClasspathLoading = treeFilesDirectory.getPathNecessaryForClasspathLoading();
+
+               relativePathString = classpathResourceString.substring(classpathResourceString.lastIndexOf(pathNecessaryForClasspathLoading)
+                                                                      + pathNecessaryForClasspathLoading.length() + 1); // Include ending '/'
+            }
+            if (!node.getDefinition().getName().equals(relativePathString))
+            {
+               LogTools.warn("Renaming node to match file name: {} -> {}", node.getDefinition().getName(), relativePathString);
+               node.getDefinition().setName(relativePathString);
+            }
+         }
+
+         LogTools.info("Creating node: {}:{}", node.getDefinition().getName(), node.getState().getID());
+
+         if (parentNode != null)
+         {
+            topologyOperationQueue.queueAddAndFreezeNode(node, parentNode);
+         }
+
+         JSONTools.forEachArrayElement(jsonNode, "children", childJsonNode ->
+         {
+            if (childJsonNode.has("file"))
+            {
+               WorkspaceResourceFile childFile = new WorkspaceResourceFile(behaviorTreeState.getSaveFileDirectory(), childJsonNode.get("file").asText());
+               loadFromFile(childFile, null, node, topologyOperationQueue);
+            }
+            else
+            {
+               loadFromFile(file, childJsonNode, node, topologyOperationQueue);
+            }
+         });
+
+         // Set the on disk fields after the children are added so we
+         // can mark modified when children topology changes
+         topologyOperationQueue.queueOperation(() -> node.getDefinition().setOnDiskFields());
+
+         loadedNode.setValue(node);
       }
 
       return loadedNode.getValue();
-   }
-
-   private T loadFromFile(String filePath, JsonNode jsonNode, T parentNode, BehaviorTreeTopologyOperationQueue topologyOperationQueue)
-   {
-      String typeName = jsonNode.get("type").textValue();
-
-      T node = nodeBuilder.createNode(BehaviorTreeDefinitionRegistry.getClassFromTypeName(typeName),
-                                      behaviorTreeState.getAndIncrementNextID(),
-                                      behaviorTreeState.getCRDTInfo(),
-                                      behaviorTreeState.getSaveFileDirectory());
-      node.getDefinition().loadFromFile(jsonNode);
-
-      if (node.getDefinition().isJSONRoot() && !node.getDefinition().getName().equals(filePath))
-      {
-         LogTools.warn("Renaming node to match file name: {} -> {}", node.getDefinition().getName(), filePath);
-         node.getDefinition().setName(filePath);
-      }
-
-      LogTools.info("Creating node: {}:{}", node.getDefinition().getName(), node.getState().getID());
-
-      if (parentNode != null)
-      {
-         topologyOperationQueue.queueAddAndFreezeNode(node, parentNode);
-      }
-
-      JSONTools.forEachArrayElement(jsonNode, "children", childJsonNode ->
-      {
-         JsonNode fileNode = childJsonNode.get("file");
-         if (fileNode == null)
-         {
-            loadFromFile(filePath, childJsonNode, node, topologyOperationQueue);
-         }
-         else
-         {
-            WorkspaceResourceFile childFile = new WorkspaceResourceFile(behaviorTreeState.getSaveFileDirectory(), fileNode.asText());
-            LogTools.info("Loading {}", childFile.getFilesystemFile());
-            String relativePath = treeFilesDirectory.getFilesystemDirectory().relativize(childFile.getFilesystemFile()).toString();
-            JSONFileTools.load(childFile, childJSONNode ->
-            {
-               loadFromFile(relativePath, childJSONNode, node, topologyOperationQueue);
-            });
-         }
-      });
-
-      // Set the on disk fields after the children are added so we
-      // can mark modified when children topology changes
-      topologyOperationQueue.queueOperation(() -> node.getDefinition().setOnDiskFields());
-
-      return node;
    }
 }

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/BehaviorTreeFileLoader.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/BehaviorTreeFileLoader.java
@@ -6,6 +6,7 @@ import us.ihmc.behaviors.behaviorTree.topology.BehaviorTreeTopologyOperationQueu
 import us.ihmc.log.LogTools;
 import us.ihmc.tools.io.JSONFileTools;
 import us.ihmc.tools.io.JSONTools;
+import us.ihmc.tools.io.WorkspaceResourceDirectory;
 import us.ihmc.tools.io.WorkspaceResourceFile;
 
 import java.net.URL;
@@ -16,11 +17,15 @@ public class BehaviorTreeFileLoader<T extends BehaviorTreeNodeLayer<T, ?, ?, ?>>
 {
    private final BehaviorTreeState behaviorTreeState;
    private final BehaviorTreeNodeStateBuilder<T> nodeBuilder;
+   private final WorkspaceResourceDirectory treeFilesDirectory;
 
-   public BehaviorTreeFileLoader(BehaviorTreeState behaviorTreeState, BehaviorTreeNodeStateBuilder<T> nodeBuilder)
+   public BehaviorTreeFileLoader(BehaviorTreeState behaviorTreeState,
+                                 BehaviorTreeNodeStateBuilder<T> nodeBuilder,
+                                 WorkspaceResourceDirectory treeFilesDirectory)
    {
       this.behaviorTreeState = behaviorTreeState;
       this.nodeBuilder = nodeBuilder;
+      this.treeFilesDirectory = treeFilesDirectory;
    }
 
    public T loadFromFile(WorkspaceResourceFile fileToLoad, BehaviorTreeTopologyOperationQueue topologyOperationQueue)
@@ -34,7 +39,8 @@ public class BehaviorTreeFileLoader<T extends BehaviorTreeNodeLayer<T, ?, ?, ?>>
          if (file != null && Files.exists(file))
          {
             LogTools.info("Loading from file: {}", file);
-            JSONFileTools.load(fileToLoad, jsonNode -> loadedNode.setValue(loadFromFile(jsonNode, null, topologyOperationQueue)));
+            String relativePath = treeFilesDirectory.getFilesystemDirectory().relativize(file).toString();
+            JSONFileTools.load(fileToLoad, jsonNode -> loadedNode.setValue(loadFromFile(relativePath, jsonNode, null, topologyOperationQueue)));
          }
          else
          {
@@ -42,7 +48,8 @@ public class BehaviorTreeFileLoader<T extends BehaviorTreeNodeLayer<T, ?, ?, ?>>
             if (classpathResource != null)
             {
                LogTools.info("Loading from resource: {}", classpathResource);
-               JSONFileTools.load(classpathResource, jsonNode -> loadedNode.setValue(loadFromFile(jsonNode, null, topologyOperationQueue)));
+               String relativePath = classpathResource.toString().replaceAll(treeFilesDirectory.getPathNecessaryForClasspathLoading(), "");
+               JSONFileTools.load(classpathResource, jsonNode -> loadedNode.setValue(loadFromFile(relativePath, jsonNode, null, topologyOperationQueue)));
             }
          }
       }
@@ -58,7 +65,7 @@ public class BehaviorTreeFileLoader<T extends BehaviorTreeNodeLayer<T, ?, ?, ?>>
       return loadedNode.getValue();
    }
 
-   private T loadFromFile(JsonNode jsonNode, T parentNode, BehaviorTreeTopologyOperationQueue topologyOperationQueue)
+   private T loadFromFile(String filePath, JsonNode jsonNode, T parentNode, BehaviorTreeTopologyOperationQueue topologyOperationQueue)
    {
       String typeName = jsonNode.get("type").textValue();
 
@@ -67,6 +74,13 @@ public class BehaviorTreeFileLoader<T extends BehaviorTreeNodeLayer<T, ?, ?, ?>>
                                       behaviorTreeState.getCRDTInfo(),
                                       behaviorTreeState.getSaveFileDirectory());
       node.getDefinition().loadFromFile(jsonNode);
+
+      if (node.getDefinition().isJSONRoot() && !node.getDefinition().getName().equals(filePath))
+      {
+         LogTools.warn("Renaming node to match file name: {} -> {}", node.getDefinition().getName(), filePath);
+         node.getDefinition().setName(filePath);
+      }
+
       LogTools.info("Creating node: {}:{}", node.getDefinition().getName(), node.getState().getID());
 
       if (parentNode != null)
@@ -79,15 +93,16 @@ public class BehaviorTreeFileLoader<T extends BehaviorTreeNodeLayer<T, ?, ?, ?>>
          JsonNode fileNode = childJsonNode.get("file");
          if (fileNode == null)
          {
-            loadFromFile(childJsonNode, node, topologyOperationQueue);
+            loadFromFile(filePath, childJsonNode, node, topologyOperationQueue);
          }
          else
          {
             WorkspaceResourceFile childFile = new WorkspaceResourceFile(behaviorTreeState.getSaveFileDirectory(), fileNode.asText());
             LogTools.info("Loading {}", childFile.getFilesystemFile());
+            String relativePath = treeFilesDirectory.getFilesystemDirectory().relativize(childFile.getFilesystemFile()).toString();
             JSONFileTools.load(childFile, childJSONNode ->
             {
-               loadFromFile(childJSONNode, node, topologyOperationQueue);
+               loadFromFile(relativePath, childJSONNode, node, topologyOperationQueue);
             });
          }
       });

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/BehaviorTreeTools.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/BehaviorTreeTools.java
@@ -1,9 +1,6 @@
 package us.ihmc.behaviors.behaviorTree;
 
 import us.ihmc.behaviors.sequence.ActionNodeDefinition;
-import us.ihmc.behaviors.sequence.ActionSequenceDefinition;
-import us.ihmc.behaviors.sequence.ActionSequenceExecutor;
-import us.ihmc.behaviors.sequence.ActionSequenceState;
 
 import java.util.ArrayList;
 import java.util.List;


### PR DESCRIPTION
Currently, behaviors save to the behaviorTrees root directory even if they are in a subfolder. This fixes that by storing the subdirectory as part of the node name, which matches with the .json:
![20241202_191159](https://github.com/user-attachments/assets/eb3d388d-d436-41b4-95db-6bfb024bca5c)
