### PR TITLE
:arrow_down: openjfx 17.0.8

### DIFF
--- a/ihmc-common-walking-control-modules/build.gradle.kts
+++ b/ihmc-common-walking-control-modules/build.gradle.kts
@@ -29,7 +29,7 @@ visualizersDependencies {
    api("us.ihmc:simulation-construction-set:0.25.1")
    api("us.ihmc:scs2-simulation-construction-set:17-0.27.3")
 
-   var javaFXVersion = "17.0.9"
+   var javaFXVersion = "17.0.8"
    api(ihmc.javaFXModule("base", javaFXVersion))
    api(ihmc.javaFXModule("controls", javaFXVersion))
    api(ihmc.javaFXModule("graphics", javaFXVersion))

--- a/ihmc-graphics/build.gradle.kts
+++ b/ihmc-graphics/build.gradle.kts
@@ -34,7 +34,7 @@ jmonkeyengineDependencies {
 
    api("us.ihmc:simulation-construction-set-tools:source")
 
-   var javaFXVersion = "17.0.9"
+   var javaFXVersion = "17.0.8"
    api(ihmc.javaFXModule("graphics", javaFXVersion)) // JFX Color
 }
 
@@ -70,7 +70,7 @@ libgdxDependencies {
    api("io.github.spair:imgui-java-natives-macos-ft:$imguiVersion")
    api("io.github.spair:imgui-java-natives-windows-ft:$imguiVersion")
 
-   val javaFXVersion = "17.0.9"
+   val javaFXVersion = "17.0.8"
    api(ihmc.javaFXModule("graphics", javaFXVersion)) // JFX Color
 
    api("org.bytedeco:javacpp:1.5.9")


### PR DESCRIPTION
I am proposing to downgrade to 17.0.8 from 17.0.9.

17.0.9 has an incomplete artifact set. It is missing artifacts for linux-arm64.

[17.0.8](https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/17.0.8/)
[17.0.9](https://repo.maven.apache.org/maven2/org/openjfx/javafx-base/17.0.9/)