### PR TITLE
[Feature] Enable Proper YUV JPEG Encoding with NVJPEG

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAJPEGProcessor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAJPEGProcessor.java
@@ -13,8 +13,6 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.SizeTPointer;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_cudaarithm;
-import org.bytedeco.opencv.global.opencv_cudaimgproc;
-import org.bytedeco.opencv.global.opencv_imgproc;
 import org.bytedeco.opencv.opencv_core.GpuMat;
 import org.bytedeco.opencv.opencv_core.GpuMatVector;
 import org.bytedeco.opencv.opencv_core.Mat;
@@ -84,23 +82,23 @@ public class CUDAJPEGProcessor
    /**
     * Encodes a YUV I420 image into jpeg.
     *
-    * @param sourceImage  the YUV I420 image (OpenCV's 8UC1 format)
-    * @param encodedImage pointer to the jpeg image output
+    * @param imageToEncode INPUT: the YUV I420 image (OpenCV type 8UC1)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
     */
-   public void encodeYUVI420(Mat sourceImage, BytePointer encodedImage)
+   public void encodeYUVI420(Mat imageToEncode, BytePointer encodedImage)
    {
-      encodeYUVI420(sourceImage.data(), sourceImage.cols(), sourceImage.rows(), sourceImage.step(), encodedImage);
+      encodeYUVI420(imageToEncode.data(), imageToEncode.cols(), imageToEncode.rows(), imageToEncode.step(), encodedImage);
    }
 
    /**
     * Encodes a YUV I420 image into jpeg.
     *
-    * @param sourceImage  the YUV I420 image (OpenCV's 8UC1 format)
-    * @param encodedImage pointer to the jpeg image output
+    * @param imageToEncode INPUT: the YUV I420 image (OpenCV type 8UC1)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
     */
-   public void encodeYUVI420(GpuMat sourceImage, BytePointer encodedImage)
+   public void encodeYUVI420(GpuMat imageToEncode, BytePointer encodedImage)
    {
-      encodeYUVI420(sourceImage.data(), sourceImage.cols(), sourceImage.rows(), sourceImage.step(), encodedImage);
+      encodeYUVI420(imageToEncode.data(), imageToEncode.cols(), imageToEncode.rows(), imageToEncode.step(), encodedImage);
    }
 
    private void encodeYUVI420(Pointer sourceImageData, int sourceWidth, int sourceHeight, long sourcePitch, BytePointer encodedImage)
@@ -124,15 +122,15 @@ public class CUDAJPEGProcessor
       // Copy over each plane to
       Pointer planePointer = sourceImageData.getPointer();
       error = cudaMemcpy2DAsync(yPlaneData, sourceWidth, planePointer, sourcePitch, sourceWidth, lumaHeight, cudaMemcpyDefault, cudaStream);
-      CUDATools.checkCUDAError(error);
+      checkCUDAError(error);
 
       planePointer = planePointer.getPointer(sourcePitch * lumaHeight);
       error = cudaMemcpy2DAsync(uPlaneData, sourceWidth, planePointer, sourcePitch, sourceWidth, chromaHeight / 2, cudaMemcpyDefault, cudaStream);
-      CUDATools.checkCUDAError(error);
+      checkCUDAError(error);
 
       planePointer = planePointer.getPointer(sourcePitch * chromaHeight / 2);
       error = cudaMemcpy2DAsync(vPlaneData, sourceWidth, planePointer, sourcePitch, sourceWidth, chromaHeight / 2, cudaMemcpyDefault, cudaStream);
-      CUDATools.checkCUDAError(error);
+      checkCUDAError(error);
 
       // Create the nvjpeg image
       nvjpegImage_t nvjpegImage = new nvjpegImage_t();
@@ -157,14 +155,14 @@ public class CUDAJPEGProcessor
    /**
     * Encodes a YUV 444 image into jpeg.
     *
-    * @param sourceImage  the YUV 444 image
-    * @param encodedImage pointer to the jpeg image output
+    * @param imageToEncode INPUT: the YUV 444 image (OpenCV type 8UC3)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
     */
-   public void encodeYUV444(Mat sourceImage, BytePointer encodedImage)
+   public void encodeYUV444(Mat imageToEncode, BytePointer encodedImage)
    {
       // Split the source image into its planes
       MatVector sourceImagePlanes = new MatVector();
-      opencv_core.split(sourceImage, sourceImagePlanes);
+      opencv_core.split(imageToEncode, sourceImagePlanes);
 
       // Get the pointers to the planes
       Pointer[] planePointers = new Pointer[(int) sourceImagePlanes.size()];
@@ -176,7 +174,7 @@ public class CUDAJPEGProcessor
       }
 
       // Encode the image
-      encodeYUV444(planePointers, planePitches, sourceImage.cols(), sourceImage.rows(), encodedImage);
+      encodeYUV444(planePointers, planePitches, imageToEncode.cols(), imageToEncode.rows(), encodedImage);
 
       // Free resources
       for (int i = 0; i < sourceImagePlanes.size(); ++i)
@@ -187,14 +185,14 @@ public class CUDAJPEGProcessor
    /**
     * Encodes a YUV 444 image into jpeg.
     *
-    * @param sourceImage  the YUV 444 image
-    * @param encodedImage pointer to the jpeg image output
+    * @param imageToEncode INPUT: the YUV 444 image (OpenCV type 8UC3)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
     */
-   public void encodeYUV444(GpuMat sourceImage, BytePointer encodedImage)
+   public void encodeYUV444(GpuMat imageToEncode, BytePointer encodedImage)
    {
       // Split the source image into its planes
       GpuMatVector sourceImagePlanes = new GpuMatVector();
-      opencv_cudaarithm.split(sourceImage, sourceImagePlanes);
+      opencv_cudaarithm.split(imageToEncode, sourceImagePlanes);
 
       // Get the pointers to the planes
       Pointer[] planePointers = new Pointer[(int) sourceImagePlanes.size()];
@@ -206,7 +204,7 @@ public class CUDAJPEGProcessor
       }
 
       // Encode the image
-      encodeYUV444(planePointers, planePitches, sourceImage.cols(), sourceImage.rows(), encodedImage);
+      encodeYUV444(planePointers, planePitches, imageToEncode.cols(), imageToEncode.rows(), encodedImage);
 
       // Free resources
       for (int i = 0; i < sourceImagePlanes.size(); ++i)
@@ -223,8 +221,8 @@ public class CUDAJPEGProcessor
       for (int i = 0; i < 3; ++i)
       {
          BytePointer plane = new BytePointer();
-         cudaMallocAsync(plane, (long) width * height, cudaStream);
-         cudaMemcpy2DAsync(plane, width, sourceImagePlanes[i], planePitches[i], width, height, cudaMemcpyDefault, cudaStream);
+         CUDATools.mallocAsync(plane, (long) width * height, cudaStream);
+         checkCUDAError(cudaMemcpy2DAsync(plane, width, sourceImagePlanes[i], planePitches[i], width, height, cudaMemcpyDefault, cudaStream));
          nvjpegImage.channel(i, plane).pitch(i, width);
       }
 
@@ -237,7 +235,49 @@ public class CUDAJPEGProcessor
       nvjpegImage.close();
    }
 
-   public void encodeYUV(nvjpegImage_t imageToEncode, int width, int height, int chromaSubSampling, BytePointer encodedImage)
+   /**
+    * Encodes a gray image into jpeg.
+    *
+    * @param imageToEncode INPUT: the gray image (OpenCV type 8UC1)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
+    */
+   public void encodeGray(Mat imageToEncode, BytePointer encodedImage)
+   {
+      encodeGray(imageToEncode.data(), imageToEncode.step(), imageToEncode.cols(), imageToEncode.rows(), encodedImage);
+   }
+
+   /**
+    * Encodes a gray image into jpeg.
+    *
+    * @param imageToEncode INPUT: the gray image (OpenCV type 8UC1)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
+    */
+   public void encodeGray(GpuMat imageToEncode, BytePointer encodedImage)
+   {
+      encodeGray(imageToEncode.data(), imageToEncode.step(), imageToEncode.cols(), imageToEncode.rows(), encodedImage);
+   }
+
+   private void encodeGray(Pointer sourceImageData, long pitch, int width, int height, BytePointer encodedImage)
+   {
+      // Copy data over to CUDA memory
+      BytePointer cudaData = new BytePointer();
+      CUDATools.mallocAsync(cudaData, (long) width * height, cudaStream);
+      checkCUDAError(cudaMemcpy2DAsync(cudaData, width, sourceImageData, pitch, width, height, cudaMemcpyDefault, cudaStream));
+
+      // Create nvjpeg image
+      nvjpegImage_t nvjpegImage = new nvjpegImage_t();
+      nvjpegImage.channel(0, cudaData).pitch(0, width);
+
+      // Encode the image
+      encodeYUV(nvjpegImage, width, height, NVJPEG_CSS_GRAY, encodedImage);
+
+      // Free resources
+      cudaFreeAsync(cudaData, cudaStream);
+      cudaData.close();
+      nvjpegImage.close();
+   }
+
+   private void encodeYUV(nvjpegImage_t imageToEncode, int width, int height, int chromaSubSampling, BytePointer encodedImage)
    {
       // Set sampling factor
       checkNVJPEGError(nvjpegEncoderParamsSetSamplingFactors(encoderParameters, chromaSubSampling, cudaStream));
@@ -259,6 +299,12 @@ public class CUDAJPEGProcessor
       jpegSize.close();
    }
 
+   /**
+    * Encodes a BGR image into jpeg
+    *
+    * @param imageToEncode INPUT: the BGR image (OpenCV type 8UC3)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
+    */
    public void encodeBGR(Mat imageToEncode, BytePointer encodedImage)
    {
       encodeInterleaved(imageToEncode.data(),
@@ -270,6 +316,12 @@ public class CUDAJPEGProcessor
                         encodedImage);
    }
 
+   /**
+    * Encodes a BGR image into jpeg
+    *
+    * @param imageToEncode INPUT: the BGR image (OpenCV type 8UC3)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
+    */
    public void encodeBGR(GpuMat imageToEncode, BytePointer encodedImage)
    {
       encodeInterleaved(imageToEncode.data(),
@@ -281,6 +333,12 @@ public class CUDAJPEGProcessor
                         encodedImage);
    }
 
+   /**
+    * Encodes a RGB image into jpeg
+    *
+    * @param imageToEncode INPUT: the RGB image (OpenCV type 8UC3)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
+    */
    public void encodeRGB(Mat imageToEncode, BytePointer encodedImage)
    {
       encodeInterleaved(imageToEncode.data(),
@@ -292,6 +350,12 @@ public class CUDAJPEGProcessor
                         encodedImage);
    }
 
+   /**
+    * Encodes a RGB image into jpeg
+    *
+    * @param imageToEncode INPUT: the RGB image (OpenCV type 8UC3)
+    * @param encodedImage  OUTPUT: pointer to the jpeg image output
+    */
    public void encodeRGB(GpuMat imageToEncode, BytePointer encodedImage)
    {
       encodeInterleaved(imageToEncode.data(),
@@ -303,33 +367,17 @@ public class CUDAJPEGProcessor
                         encodedImage);
    }
 
-   public void encodeGray(Mat imageToEncode, BytePointer encodedImage)
-   {
-      GpuMat gpuImageToEncode = new GpuMat(imageToEncode.size(), imageToEncode.type());
-      gpuImageToEncode.upload(imageToEncode);
-      encodeGray(gpuImageToEncode, encodedImage);
-      gpuImageToEncode.close();
-   }
-
-   public void encodeGray(GpuMat imageToEncode, BytePointer encodedImage)
-   {
-      GpuMat bgrImage = new GpuMat();
-      opencv_cudaimgproc.cvtColor(imageToEncode, bgrImage, opencv_imgproc.CV_GRAY2BGR);
-      encodeBGR(bgrImage, encodedImage);
-      bgrImage.close();
-   }
-
    /**
     * Encodes an interleaved image into jpeg
     *
-    * @param imageToEncode          the BGR image to encode
+    * @param sourceImageData        the interleaved image data to encode
     * @param imageWidth             width of the source image
     * @param imageHeight            height of the source image
     * @param imagePitch             pitch (aka step in OpenCV land) of the source image
     * @param interleavedInputFormat either NVJPEG_INPUT_BGRI or NVJPEG_INPUT_RGBI
     * @param encodedImage           output pointer for encoded data
     */
-   public void encodeInterleaved(BytePointer imageToEncode,
+   public void encodeInterleaved(BytePointer sourceImageData,
                                  int imageWidth,
                                  int imageHeight,
                                  long elementSize,
@@ -346,7 +394,7 @@ public class CUDAJPEGProcessor
       // Upload image data to device
       BytePointer deviceImagePointer = new BytePointer();
       checkCUDAError(cudaMallocAsync(deviceImagePointer, totalSize, cudaStream));
-      checkCUDAError(cudaMemcpy2DAsync(deviceImagePointer, rowSize, imageToEncode, imagePitch, rowSize, imageHeight, cudaMemcpyDefault, cudaStream));
+      checkCUDAError(cudaMemcpy2DAsync(deviceImagePointer, rowSize, sourceImageData, imagePitch, rowSize, imageHeight, cudaMemcpyDefault, cudaStream));
 
       // Create nvjpeg image
       nvjpegImage_t nvjpegImage = new nvjpegImage_t();
@@ -383,9 +431,9 @@ public class CUDAJPEGProcessor
    /**
     * Decodes a jpeg encoded image to BGR format.
     *
-    * @param encodedImage     INPUT: An encoded multi-channel image.
-    * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage     OUTPUT: The decoded image.
+    * @param encodedImage     INPUT: a jpeg encoded image.
+    * @param encodedImageSize INPUT: size, in bytes, of the encoded image.
+    * @param decodedImage     OUTPUT: the decoded image.
     */
    public void decodeToBGR(BytePointer encodedImage, long encodedImageSize, Mat decodedImage)
    {
@@ -414,9 +462,9 @@ public class CUDAJPEGProcessor
    /**
     * Decodes a jpeg encoded image to BGR format.
     *
-    * @param encodedImage     INPUT: An encoded multi-channel image.
-    * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage     OUTPUT: The decoded image.
+    * @param encodedImage     INPUT: a jpeg encoded image.
+    * @param encodedImageSize INPUT: size, in bytes, of the encoded image.
+    * @param decodedImage     OUTPUT: the decoded image.
     */
    public void decodeToBGR(BytePointer encodedImage, long encodedImageSize, GpuMat decodedImage)
    {
@@ -441,15 +489,13 @@ public class CUDAJPEGProcessor
    }
 
    /**
-    * Decodes a jpeg encoded image to YUV I420 format.
+    * Decodes a jpeg encoded image to a YUV format.
+    * The output YUV format will match the format of the encoded image data.
+    * Currently, this may be YUV444 or YUV I420.
     *
-    * @param encodedImage     INPUT: An encoded multi-channel image.
-    * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage     OUTPUT: The decoded image.
-    * @apiNote Despite the name, this method does not work when the passed in encoded image is in an OpenCV YUV format.
-    *       To decode an OpenCV YUV_I420 image, use {@link CUDAJPEGProcessor#decodeUnchanged(BytePointer, long, Mat)}.
-    *       While this method returns an image when the input is an OpenCV YUV image, the colors are incorrect.
-    *       TODO: Find out why the colors are incorrect when providing an OpenCV YUV image.
+    * @param encodedImage     INPUT: a jpeg encoded image.
+    * @param encodedImageSize INPUT: size, in bytes, of the encoded image.
+    * @param decodedImage     OUTPUT: the decoded image.
     */
    public void decodeToYUV(BytePointer encodedImage, long encodedImageSize, Mat decodedImage)
    {
@@ -503,6 +549,13 @@ public class CUDAJPEGProcessor
       }
    }
 
+   /**
+    * Decodes a jpeg encoded image to gray format.
+    *
+    * @param encodedImage     INPUT: a jpeg encoded image.
+    * @param encodedImageSize INPUT: size, in bytes, of the encoded image.
+    * @param decodedImage     OUTPUT: the decoded image.
+    */
    public void decodeToGray(BytePointer encodedImage, long encodedImageSize, Mat decodedImage)
    {
       NVJPEGImageInfo imageInfo = getImageInfo(encodedImage, encodedImageSize);
@@ -526,6 +579,13 @@ public class CUDAJPEGProcessor
       decodingResult.close();
    }
 
+   /**
+    * Decodes a jpeg encoded image to gray format.
+    *
+    * @param encodedImage     INPUT: a jpeg encoded image.
+    * @param encodedImageSize INPUT: size, in bytes, of the encoded image.
+    * @param decodedImage     OUTPUT: the decoded image.
+    */
    public void decodeToGray(BytePointer encodedImage, long encodedImageSize, GpuMat decodedImage)
    {
       NVJPEGImageInfo imageInfo = getImageInfo(encodedImage, encodedImageSize);
@@ -547,98 +607,6 @@ public class CUDAJPEGProcessor
       checkCUDAError(cudaFreeAsync(decodedData.get(0), cudaStream));
       decodedData.get(0).close();
       decodingResult.close();
-   }
-
-   /**
-    * Decodes a jpeg encoded image, leaving the jpeg's format as is.
-    * If the jpeg has multiple channels, the output format is likely to be YUV.
-    * If the jpeg has a single channel, the output format will be gray scale.
-    *
-    * @param encodedImage     INPUT: An encoded multi-channel image.
-    * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage     OUTPUT: The decoded image.
-    */
-   public void decodeUnchanged(BytePointer encodedImage, long encodedImageSize, Mat decodedImage)
-   {
-      // Get decoded image info
-      NVJPEGImageInfo imageInfo = getImageInfo(encodedImage, encodedImageSize);
-
-      // Allocate host memory for the decoded image channels
-      int numberOfDecodedChannels = imageInfo.numberOfComponents();
-      long[] decodedChannelSizes = getOutputChannelSizes(NVJPEG_OUTPUT_UNCHANGED, imageInfo);
-      List<BytePointer> decodedChannels = new ArrayList<>(numberOfDecodedChannels);
-      for (int i = 0; i < numberOfDecodedChannels; ++i)
-      {
-         decodedChannels.add(new BytePointer());
-         checkCUDAError(cudaMallocHost(decodedChannels.get(i), decodedChannelSizes[i]));
-      }
-
-      // Decode the image, packing result into the allocated buffers.
-      decodeImage(encodedImage, encodedImageSize, imageInfo, NVJPEG_OUTPUT_UNCHANGED, decodedChannels);
-
-      // Put all channels into a MatVector
-      MatVector decodedChannelMats = new MatVector();
-      for (int i = 0; i < numberOfDecodedChannels; ++i)
-      {
-         Mat channelMat = new Mat(imageInfo.maxHeight(), imageInfo.maxWidth(), opencv_core.CV_8UC1, decodedChannels.get(i));
-         decodedChannelMats.push_back(channelMat);
-      }
-
-      // Combine the channels into 1 Mat, pack into output image
-      opencv_core.merge(decodedChannelMats, decodedImage);
-
-      // Free all memory
-      for (int i = 0; i < numberOfDecodedChannels; ++i)
-      {
-         checkCUDAError(cudaFreeHost(decodedChannels.get(i)));
-         decodedChannels.get(i).close();
-      }
-   }
-
-   /**
-    * Decodes a jpeg encoded image, leaving the jpeg's format as is.
-    * If the jpeg has multiple channels, the output format is likely to be YUV.
-    * If the jpeg has a single channel, the output format will be gray scale.
-    *
-    * @param encodedImage     INPUT: An encoded multi-channel image.
-    * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage     OUTPUT: The decoded image.
-    */
-   public void decodeUnchanged(BytePointer encodedImage, long encodedImageSize, GpuMat decodedImage)
-   {
-      // Get decoded image info
-      NVJPEGImageInfo imageInfo = getImageInfo(encodedImage, encodedImageSize);
-
-      // Allocate host memory for the decoded image channels
-      int numberOfDecodedChannels = imageInfo.numberOfComponents();
-      long[] decodedChannelSizes = getOutputChannelSizes(NVJPEG_OUTPUT_UNCHANGED, imageInfo);
-      List<BytePointer> decodedChannels = new ArrayList<>(numberOfDecodedChannels);
-      for (int i = 0; i < numberOfDecodedChannels; ++i)
-      {
-         decodedChannels.add(new BytePointer());
-         checkCUDAError(cudaMallocAsync(decodedChannels.get(i), decodedChannelSizes[i], cudaStream));
-      }
-
-      // Decode the image, packing result into the allocated buffers.
-      decodeImage(encodedImage, encodedImageSize, imageInfo, NVJPEG_OUTPUT_UNCHANGED, decodedChannels);
-
-      // Put all channels into a MatVector
-      GpuMatVector decodedChannelMats = new GpuMatVector();
-      for (int i = 0; i < numberOfDecodedChannels; ++i)
-      {
-         GpuMat channelMat = new GpuMat(imageInfo.maxHeight(), imageInfo.maxWidth(), opencv_core.CV_8UC1, decodedChannels.get(i));
-         decodedChannelMats.push_back(channelMat);
-      }
-
-      // Combine the channels into 1 Mat, pack into output image
-      opencv_cudaarithm.merge(decodedChannelMats, decodedImage);
-
-      // Free all memory
-      for (int i = 0; i < numberOfDecodedChannels; ++i)
-      {
-         checkCUDAError(cudaFreeAsync(decodedChannels.get(i), cudaStream));
-         decodedChannels.get(i).close();
-      }
    }
 
    /**
@@ -813,7 +781,6 @@ public class CUDAJPEGProcessor
     */
    private record NVJPEGImageInfo(int numberOfComponents, int[] subSamplingTypes, int[] widths, int[] heights)
    {
-
       private int subSamplingType(int channel)
       {
          return subSamplingTypes[channel];
@@ -824,27 +791,9 @@ public class CUDAJPEGProcessor
          return widths[channel];
       }
 
-      private int maxWidth()
-      {
-         int maxWidth = width(0);
-         for (int i = 1; i < numberOfComponents; ++i)
-            if (width(i) > maxWidth)
-               maxWidth = width(i);
-         return maxWidth;
-      }
-
       private int height(int channel)
       {
          return heights[channel];
-      }
-
-      private int maxHeight()
-      {
-         int maxHeight = height(0);
-         for (int i = 1; i < numberOfComponents; ++i)
-            if (height(i) > maxHeight)
-               maxHeight = height(i);
-         return maxHeight;
       }
    }
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAJPEGProcessor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAJPEGProcessor.java
@@ -8,6 +8,7 @@ import org.bytedeco.cuda.nvjpeg.nvjpegImage_t;
 import org.bytedeco.cuda.nvjpeg.nvjpegJpegState;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.javacpp.IntPointer;
+import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.javacpp.SizeTPointer;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_cudaarithm;
@@ -80,64 +81,85 @@ public class CUDAJPEGProcessor
     * Encodes a YUV I420 image into jpeg.
     *
     * @param sourceImage        the YUV I420 image
-    * @param outputImagePointer pointer to the jpeg image output
-    * @param imageWidth         width (in bytes) of the source image
-    * @param imageHeight        height (in bytes) of the source image
+    * @param encodedImage pointer to the jpeg image output
     */
-   public void encodeYUV420(BytePointer sourceImage, BytePointer outputImagePointer, int imageWidth, int imageHeight)
+   public void encodeYUV420(Pointer sourceImage, BytePointer encodedImage)
    {
-      int frameSize = imageWidth * imageHeight;
-      long quarterOfFrameSize = ((frameSize % 4 == 0) ? (frameSize / 4) : (frameSize / 4 + 1)); // ensure integer math goes well
-      long halfOfImageWidth = ((imageWidth % 2 == 0) ? (imageWidth / 2) : (imageWidth / 2 + 1));
+      GpuMat gpuSourceImage = new GpuMat();
+      if (sourceImage instanceof Mat cpuMat)
+         gpuSourceImage.upload(cpuMat);
+      else if (sourceImage instanceof GpuMat gpuImage)
+         gpuImage.copyTo(gpuSourceImage);
 
-      // Set params to correct sampling factor
-      checkNVJPEGError(nvjpegEncoderParamsSetSamplingFactors(encoderParameters, NVJPEG_CSS_420, cudaStream));
+      int totalHeight = gpuSourceImage.rows();
+      int lumaHeight = (2 * totalHeight) / 3;
 
-      // Get Y plane data
-      BytePointer yPlanePointer = new BytePointer(); // create a pointer for the Y plane
-      checkCUDAError(cudaMallocAsync(yPlanePointer, frameSize, cudaStream)); // allocate Y plane memory
-      checkCUDAError(cudaMemcpyAsync(yPlanePointer, sourceImage, frameSize, cudaMemcpyHostToDevice, cudaStream)); // copy Y plane data to device memory
+      int width = gpuSourceImage.cols();
+      int chromaWidth = width / 2;
 
+      GpuMatVector planes = new GpuMatVector();
+      planes.push_back(gpuSourceImage.rowRange(0, lumaHeight));                                          // Y
+      planes.push_back(gpuSourceImage.rowRange(lumaHeight, totalHeight).colRange(0, chromaWidth));       // U
+      planes.push_back(gpuSourceImage.rowRange(lumaHeight, totalHeight).colRange(chromaWidth, width));   // V
+
+      encodeYUV(planes, NVJPEG_CSS_420, encodedImage);
+
+      planes.close();
+      gpuSourceImage.close();
+   }
+
+   public void encodeYUV444(Pointer sourceImage, BytePointer encodedImage)
+   {
+      GpuMat gpuSourceImage = new GpuMat();
+      if (sourceImage instanceof Mat cpuMat)
+         gpuSourceImage.upload(cpuMat);
+      else if (sourceImage instanceof GpuMat gpuImage)
+         gpuImage.copyTo(gpuSourceImage);
+
+      GpuMatVector planes = new GpuMatVector();
+      opencv_cudaarithm.split(gpuSourceImage, planes);
+
+      encodeYUV(planes, NVJPEG_CSS_444, encodedImage);
+
+      planes.close();
+      gpuSourceImage.close();
+   }
+
+   public void encodeYUV(GpuMatVector imageToEncode, int chromaSubSampling, BytePointer encodedImage)
+   {
+      // Set sampling factor
+      checkNVJPEGError(nvjpegEncoderParamsSetSamplingFactors(encoderParameters, chromaSubSampling, cudaStream));
+
+      // Create nvjpeg image
       nvjpegImage_t nvjpegImage = new nvjpegImage_t();
-      nvjpegImage.pitch(0, imageWidth); // set the pitch
-      nvjpegImage.channel(0, yPlanePointer); //set the channel
-      sourceImage.position(sourceImage.position() + frameSize); // move pointer to start of U plane
+      for (int i = 0; i < imageToEncode.size() && i < 4; ++i)
+      {
+         GpuMat plane = imageToEncode.get(i);
+         nvjpegImage.pitch(i, plane.step());
+         nvjpegImage.channel(i, plane.data());
+      }
 
-      // Get U plane data
-      BytePointer uPlanePointer = new BytePointer();
-      checkCUDAError(cudaMallocAsync(uPlanePointer, quarterOfFrameSize, cudaStream));
-      checkCUDAError(cudaMemcpyAsync(uPlanePointer, sourceImage, quarterOfFrameSize, cudaMemcpyHostToDevice, cudaStream));
-      nvjpegImage.pitch(1, halfOfImageWidth);
-      nvjpegImage.channel(1, uPlanePointer);
-      sourceImage.position(sourceImage.position() + quarterOfFrameSize);
+      GpuMat lumaPlane = imageToEncode.get(0);
+      checkNVJPEGError(nvjpegEncodeYUV(nvjpegHandle,
+                                       encoderState,
+                                       encoderParameters,
+                                       nvjpegImage,
+                                       chromaSubSampling,
+                                       lumaPlane.cols(),
+                                       lumaPlane.rows(),
+                                       cudaStream));
 
-      // Get V plane data
-      BytePointer vPlanePointer = new BytePointer();
-      checkCUDAError(cudaMallocAsync(vPlanePointer, quarterOfFrameSize, cudaStream));
-      checkCUDAError(cudaMemcpyAsync(vPlanePointer, sourceImage, quarterOfFrameSize, cudaMemcpyHostToDevice, cudaStream));
-      nvjpegImage.pitch(2, halfOfImageWidth);
-      nvjpegImage.channel(2, vPlanePointer);
-
-      // Encode image (mem)
-      checkNVJPEGError(nvjpegEncodeYUV(nvjpegHandle, encoderState, encoderParameters, nvjpegImage, NVJPEG_CSS_420, imageWidth, imageHeight, cudaStream));
-
-      // Get compressed size
+      // Get compressed image size
       SizeTPointer jpegSize = new SizeTPointer(1);
       checkNVJPEGError(nvjpegEncodeRetrieveBitstream(nvjpegHandle, encoderState, (BytePointer) null, jpegSize, cudaStream));
 
       // Retrieve bitstream
-      outputImagePointer.limit(jpegSize.get());
-      checkNVJPEGError(nvjpegEncodeRetrieveBitstream(nvjpegHandle, encoderState, outputImagePointer, jpegSize, cudaStream));
+      encodedImage.limit(jpegSize.get());
+      checkNVJPEGError(nvjpegEncodeRetrieveBitstream(nvjpegHandle, encoderState, encodedImage, jpegSize, cudaStream));
 
-      // Free GPU memory
-      checkCUDAError(cudaFreeAsync(yPlanePointer, cudaStream));
-      checkCUDAError(cudaFreeAsync(uPlanePointer, cudaStream));
-      checkCUDAError(cudaFreeAsync(vPlanePointer, cudaStream));
+      checkCUDAError(cudaStreamSynchronize(cudaStream));
 
-      // Close pointers
-      yPlanePointer.close();
-      uPlanePointer.close();
-      vPlanePointer.close();
+      // Close everything
       jpegSize.close();
       nvjpegImage.close();
    }

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAJPEGProcessor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAJPEGProcessor.java
@@ -1,5 +1,6 @@
 package us.ihmc.perception.cuda;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.bytedeco.cuda.cudart.CUstream_st;
 import org.bytedeco.cuda.nvjpeg.nvjpegEncoderParams;
 import org.bytedeco.cuda.nvjpeg.nvjpegEncoderState;
@@ -18,8 +19,10 @@ import org.bytedeco.opencv.opencv_core.GpuMat;
 import org.bytedeco.opencv.opencv_core.GpuMatVector;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.MatVector;
+import us.ihmc.perception.opencv.OpenCVTools;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.bytedeco.cuda.global.cudart.*;
@@ -30,9 +33,9 @@ import static us.ihmc.perception.cuda.CUDATools.checkNVJPEGError;
 /**
  * Used for encoding images using CUDA.
  * Ensure that the computer has CUDA available before using this class. Most all Nvidia graphics cards should have CUDA available.
- *
+ * <p>
  * This class has been adapted from the SampleJpegEncoder of bytedeco:
- * https://github.com/bytedeco/javacpp-presets/blob/master/cuda/samples/SampleJpegEncoder.java
+ * <a href="https://github.com/bytedeco/javacpp-presets/blob/master/cuda/samples/SampleJpegEncoder.java">SampleJpegEncoder.java</a>
  */
 public class CUDAJPEGProcessor
 {
@@ -49,6 +52,7 @@ public class CUDAJPEGProcessor
 
    /**
     * Initialize necessary CUDA components
+    *
     * @param quality value between 1 and 100 representing the quality of the jpeg image. 1 will result in the lowest quality, but highest compression.
     */
    public CUDAJPEGProcessor(int quality)
@@ -80,74 +84,166 @@ public class CUDAJPEGProcessor
    /**
     * Encodes a YUV I420 image into jpeg.
     *
-    * @param sourceImage        the YUV I420 image
+    * @param sourceImage  the YUV I420 image (OpenCV's 8UC1 format)
     * @param encodedImage pointer to the jpeg image output
     */
-   public void encodeYUV420(Pointer sourceImage, BytePointer encodedImage)
+   public void encodeYUVI420(Mat sourceImage, BytePointer encodedImage)
    {
-      GpuMat gpuSourceImage = new GpuMat();
-      if (sourceImage instanceof Mat cpuMat)
-         gpuSourceImage.upload(cpuMat);
-      else if (sourceImage instanceof GpuMat gpuImage)
-         gpuImage.copyTo(gpuSourceImage);
-
-      int totalHeight = gpuSourceImage.rows();
-      int lumaHeight = (2 * totalHeight) / 3;
-
-      int width = gpuSourceImage.cols();
-      int chromaWidth = width / 2;
-
-      GpuMatVector planes = new GpuMatVector();
-      planes.push_back(gpuSourceImage.rowRange(0, lumaHeight));                                          // Y
-      planes.push_back(gpuSourceImage.rowRange(lumaHeight, totalHeight).colRange(0, chromaWidth));       // U
-      planes.push_back(gpuSourceImage.rowRange(lumaHeight, totalHeight).colRange(chromaWidth, width));   // V
-
-      encodeYUV(planes, NVJPEG_CSS_420, encodedImage);
-
-      planes.close();
-      gpuSourceImage.close();
+      encodeYUVI420(sourceImage.data(), sourceImage.cols(), sourceImage.rows(), sourceImage.step(), encodedImage);
    }
 
-   public void encodeYUV444(Pointer sourceImage, BytePointer encodedImage)
+   /**
+    * Encodes a YUV I420 image into jpeg.
+    *
+    * @param sourceImage  the YUV I420 image (OpenCV's 8UC1 format)
+    * @param encodedImage pointer to the jpeg image output
+    */
+   public void encodeYUVI420(GpuMat sourceImage, BytePointer encodedImage)
    {
-      GpuMat gpuSourceImage = new GpuMat();
-      if (sourceImage instanceof Mat cpuMat)
-         gpuSourceImage.upload(cpuMat);
-      else if (sourceImage instanceof GpuMat gpuImage)
-         gpuImage.copyTo(gpuSourceImage);
-
-      GpuMatVector planes = new GpuMatVector();
-      opencv_cudaarithm.split(gpuSourceImage, planes);
-
-      encodeYUV(planes, NVJPEG_CSS_444, encodedImage);
-
-      planes.close();
-      gpuSourceImage.close();
+      encodeYUVI420(sourceImage.data(), sourceImage.cols(), sourceImage.rows(), sourceImage.step(), encodedImage);
    }
 
-   public void encodeYUV(GpuMatVector imageToEncode, int chromaSubSampling, BytePointer encodedImage)
+   private void encodeYUVI420(Pointer sourceImageData, int sourceWidth, int sourceHeight, long sourcePitch, BytePointer encodedImage)
+   {
+      int error;
+
+      // Get some useful values
+      int lumaHeight = (2 * sourceHeight) / 3;        // luma takes 2/3 of the total height
+      int chromaHeight = sourceHeight - lumaHeight;   // chroma planes take rest of the height
+      int chromaWidth = sourceWidth / 2;              // chroma planes each take half the width of the image
+
+      // Declare and allocate CUDA pointers for each plane
+      BytePointer yPlaneData = new BytePointer();
+      BytePointer uPlaneData = new BytePointer();
+      BytePointer vPlaneData = new BytePointer();
+
+      CUDATools.mallocAsync(yPlaneData, (long) sourceWidth * lumaHeight, cudaStream);
+      CUDATools.mallocAsync(uPlaneData, (long) chromaWidth * chromaHeight, cudaStream);
+      CUDATools.mallocAsync(vPlaneData, (long) chromaWidth * chromaHeight, cudaStream);
+
+      // Copy over each plane to
+      Pointer planePointer = sourceImageData.getPointer();
+      error = cudaMemcpy2DAsync(yPlaneData, sourceWidth, planePointer, sourcePitch, sourceWidth, lumaHeight, cudaMemcpyDefault, cudaStream);
+      CUDATools.checkCUDAError(error);
+
+      planePointer = planePointer.getPointer(sourcePitch * lumaHeight);
+      error = cudaMemcpy2DAsync(uPlaneData, sourceWidth, planePointer, sourcePitch, sourceWidth, chromaHeight / 2, cudaMemcpyDefault, cudaStream);
+      CUDATools.checkCUDAError(error);
+
+      planePointer = planePointer.getPointer(sourcePitch * chromaHeight / 2);
+      error = cudaMemcpy2DAsync(vPlaneData, sourceWidth, planePointer, sourcePitch, sourceWidth, chromaHeight / 2, cudaMemcpyDefault, cudaStream);
+      CUDATools.checkCUDAError(error);
+
+      // Create the nvjpeg image
+      nvjpegImage_t nvjpegImage = new nvjpegImage_t();
+      nvjpegImage.channel(0, yPlaneData).pitch(0, sourceWidth);   // Y
+      nvjpegImage.channel(1, uPlaneData).pitch(1, chromaWidth);   // U
+      nvjpegImage.channel(2, vPlaneData).pitch(2, chromaWidth);   // V
+
+      // Encode the image
+      encodeYUV(nvjpegImage, sourceWidth, lumaHeight, NVJPEG_CSS_420, encodedImage);
+
+      // Free resources
+      checkCUDAError(cudaFreeAsync(yPlaneData, cudaStream));
+      checkCUDAError(cudaFreeAsync(uPlaneData, cudaStream));
+      checkCUDAError(cudaFreeAsync(vPlaneData, cudaStream));
+      yPlaneData.close();
+      uPlaneData.close();
+      vPlaneData.close();
+      planePointer.close();
+      nvjpegImage.close();
+   }
+
+   /**
+    * Encodes a YUV 444 image into jpeg.
+    *
+    * @param sourceImage  the YUV 444 image
+    * @param encodedImage pointer to the jpeg image output
+    */
+   public void encodeYUV444(Mat sourceImage, BytePointer encodedImage)
+   {
+      // Split the source image into its planes
+      MatVector sourceImagePlanes = new MatVector();
+      opencv_core.split(sourceImage, sourceImagePlanes);
+
+      // Get the pointers to the planes
+      Pointer[] planePointers = new Pointer[(int) sourceImagePlanes.size()];
+      long[] planePitches = new long[(int) sourceImagePlanes.size()];
+      for (int i = 0; i < sourceImagePlanes.size(); ++i)
+      {
+         planePointers[i] = sourceImagePlanes.get(i).data();
+         planePitches[i] = sourceImagePlanes.get(i).step();
+      }
+
+      // Encode the image
+      encodeYUV444(planePointers, planePitches, sourceImage.cols(), sourceImage.rows(), encodedImage);
+
+      // Free resources
+      for (int i = 0; i < sourceImagePlanes.size(); ++i)
+         planePointers[i].close();
+      sourceImagePlanes.close();
+   }
+
+   /**
+    * Encodes a YUV 444 image into jpeg.
+    *
+    * @param sourceImage  the YUV 444 image
+    * @param encodedImage pointer to the jpeg image output
+    */
+   public void encodeYUV444(GpuMat sourceImage, BytePointer encodedImage)
+   {
+      // Split the source image into its planes
+      GpuMatVector sourceImagePlanes = new GpuMatVector();
+      opencv_cudaarithm.split(sourceImage, sourceImagePlanes);
+
+      // Get the pointers to the planes
+      Pointer[] planePointers = new Pointer[(int) sourceImagePlanes.size()];
+      long[] planePitches = new long[(int) sourceImagePlanes.size()];
+      for (int i = 0; i < sourceImagePlanes.size(); ++i)
+      {
+         planePointers[i] = sourceImagePlanes.get(i).data();
+         planePitches[i] = sourceImagePlanes.get(i).step();
+      }
+
+      // Encode the image
+      encodeYUV444(planePointers, planePitches, sourceImage.cols(), sourceImage.rows(), encodedImage);
+
+      // Free resources
+      for (int i = 0; i < sourceImagePlanes.size(); ++i)
+         planePointers[i].close();
+      sourceImagePlanes.close();
+   }
+
+   private void encodeYUV444(Pointer[] sourceImagePlanes, long[] planePitches, int width, int height, BytePointer encodedImage)
+   {
+      // Create the nvjpeg image
+      nvjpegImage_t nvjpegImage = new nvjpegImage_t();
+
+      // Copy planes data into it
+      for (int i = 0; i < 3; ++i)
+      {
+         BytePointer plane = new BytePointer();
+         cudaMallocAsync(plane, (long) width * height, cudaStream);
+         cudaMemcpy2DAsync(plane, width, sourceImagePlanes[i], planePitches[i], width, height, cudaMemcpyDefault, cudaStream);
+         nvjpegImage.channel(i, plane).pitch(i, width);
+      }
+
+      // Encode the iamge
+      encodeYUV(nvjpegImage, width, height, NVJPEG_CSS_444, encodedImage);
+
+      // Free resources
+      for (int i = 0; i < 3; ++i)
+         checkCUDAError(cudaFree(nvjpegImage.channel(i)));
+      nvjpegImage.close();
+   }
+
+   public void encodeYUV(nvjpegImage_t imageToEncode, int width, int height, int chromaSubSampling, BytePointer encodedImage)
    {
       // Set sampling factor
       checkNVJPEGError(nvjpegEncoderParamsSetSamplingFactors(encoderParameters, chromaSubSampling, cudaStream));
 
-      // Create nvjpeg image
-      nvjpegImage_t nvjpegImage = new nvjpegImage_t();
-      for (int i = 0; i < imageToEncode.size() && i < 4; ++i)
-      {
-         GpuMat plane = imageToEncode.get(i);
-         nvjpegImage.pitch(i, plane.step());
-         nvjpegImage.channel(i, plane.data());
-      }
-
-      GpuMat lumaPlane = imageToEncode.get(0);
-      checkNVJPEGError(nvjpegEncodeYUV(nvjpegHandle,
-                                       encoderState,
-                                       encoderParameters,
-                                       nvjpegImage,
-                                       chromaSubSampling,
-                                       lumaPlane.cols(),
-                                       lumaPlane.rows(),
-                                       cudaStream));
+      // Encode the image
+      checkNVJPEGError(nvjpegEncodeYUV(nvjpegHandle, encoderState, encoderParameters, imageToEncode, chromaSubSampling, width, height, cudaStream));
 
       // Get compressed image size
       SizeTPointer jpegSize = new SizeTPointer(1);
@@ -161,7 +257,6 @@ public class CUDAJPEGProcessor
 
       // Close everything
       jpegSize.close();
-      nvjpegImage.close();
    }
 
    public void encodeBGR(Mat imageToEncode, BytePointer encodedImage)
@@ -287,9 +382,10 @@ public class CUDAJPEGProcessor
 
    /**
     * Decodes a jpeg encoded image to BGR format.
-    * @param encodedImage INPUT: An encoded multi-channel image.
+    *
+    * @param encodedImage     INPUT: An encoded multi-channel image.
     * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage OUTPUT: The decoded image.
+    * @param decodedImage     OUTPUT: The decoded image.
     */
    public void decodeToBGR(BytePointer encodedImage, long encodedImageSize, Mat decodedImage)
    {
@@ -317,9 +413,10 @@ public class CUDAJPEGProcessor
 
    /**
     * Decodes a jpeg encoded image to BGR format.
-    * @param encodedImage INPUT: An encoded multi-channel image.
+    *
+    * @param encodedImage     INPUT: An encoded multi-channel image.
     * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage OUTPUT: The decoded image.
+    * @param decodedImage     OUTPUT: The decoded image.
     */
    public void decodeToBGR(BytePointer encodedImage, long encodedImageSize, GpuMat decodedImage)
    {
@@ -345,13 +442,14 @@ public class CUDAJPEGProcessor
 
    /**
     * Decodes a jpeg encoded image to YUV I420 format.
-    * @param encodedImage INPUT: An encoded multi-channel image.
+    *
+    * @param encodedImage     INPUT: An encoded multi-channel image.
     * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage OUTPUT: The decoded image.
+    * @param decodedImage     OUTPUT: The decoded image.
     * @apiNote Despite the name, this method does not work when the passed in encoded image is in an OpenCV YUV format.
-    * To decode an OpenCV YUV_I420 image, use {@link CUDAJPEGProcessor#decodeUnchanged(BytePointer, long, Mat)}.
-    * While this method returns an image when the input is an OpenCV YUV image, the colors are incorrect.
-    * TODO: Find out why the colors are incorrect when providing an OpenCV YUV image.
+    *       To decode an OpenCV YUV_I420 image, use {@link CUDAJPEGProcessor#decodeUnchanged(BytePointer, long, Mat)}.
+    *       While this method returns an image when the input is an OpenCV YUV image, the colors are incorrect.
+    *       TODO: Find out why the colors are incorrect when providing an OpenCV YUV image.
     */
    public void decodeToYUV(BytePointer encodedImage, long encodedImageSize, Mat decodedImage)
    {
@@ -375,15 +473,26 @@ public class CUDAJPEGProcessor
       try (Mat yPlane = new Mat(imageInfo.height(0), imageInfo.width(0), opencv_core.CV_8UC1, decodedChannels.get(0));
            Mat uPlane = new Mat(imageInfo.height(1), imageInfo.width(1), opencv_core.CV_8UC1, decodedChannels.get(1));
            Mat vPlane = new Mat(imageInfo.height(2), imageInfo.width(2), opencv_core.CV_8UC1, decodedChannels.get(2));
-           Mat yuvI420CombinedImage = new Mat(imageInfo.height(0) + imageInfo.height(1), imageInfo.width(0), opencv_core.CV_8UC1))
+           MatVector planesVector = new MatVector(yPlane, uPlane, vPlane);
+           Mat yuvCombinedImage = new Mat())
       {
-         // Pack the YUV planes into their respective locations
-         yPlane.copyTo(yuvI420CombinedImage.rowRange(0, imageInfo.height(0)));
-         uPlane.copyTo(yuvI420CombinedImage.rowRange(imageInfo.height(0), imageInfo.height(0) + imageInfo.height(1)).colRange(0, imageInfo.width(1)));
-         vPlane.copyTo(yuvI420CombinedImage.rowRange(imageInfo.height(0), imageInfo.height(0) + imageInfo.height(2))
-                                           .colRange(imageInfo.width(1), imageInfo.width(1) + imageInfo.width(2)));
+         switch (imageInfo.subSamplingType(0))
+         {
+            case NVJPEG_CSS_420 ->
+            {
+               // Create the I420 image with correct size
+               yuvCombinedImage.create(imageInfo.height(0) + imageInfo.height(1), imageInfo.width(0), opencv_core.CV_8UC1);
+               // Pack the YUV planes into their respective locations
+               Pointer.memcpy(yuvCombinedImage.ptr(), yPlane.ptr(), OpenCVTools.dataSize(yPlane));
+               Pointer.memcpy(yuvCombinedImage.ptr(imageInfo.height(0), 0), uPlane.ptr(), OpenCVTools.dataSize(uPlane));
+               Pointer.memcpy(yuvCombinedImage.ptr(imageInfo.height(0) + imageInfo.height(1) / 2, 0), vPlane.ptr(), OpenCVTools.dataSize(vPlane));
+            }
+            case NVJPEG_CSS_444 -> opencv_core.merge(planesVector, yuvCombinedImage);
+            default -> throw new NotImplementedException("Tomasz didn't have enough time to write code for this YUV format. Maybe you could?");
+         }
+
          // Copy the YUV image into the output image
-         yuvI420CombinedImage.copyTo(decodedImage);
+         yuvCombinedImage.copyTo(decodedImage);
       }
 
       // Free all memory
@@ -444,9 +553,10 @@ public class CUDAJPEGProcessor
     * Decodes a jpeg encoded image, leaving the jpeg's format as is.
     * If the jpeg has multiple channels, the output format is likely to be YUV.
     * If the jpeg has a single channel, the output format will be gray scale.
-    * @param encodedImage INPUT: An encoded multi-channel image.
+    *
+    * @param encodedImage     INPUT: An encoded multi-channel image.
     * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage OUTPUT: The decoded image.
+    * @param decodedImage     OUTPUT: The decoded image.
     */
    public void decodeUnchanged(BytePointer encodedImage, long encodedImageSize, Mat decodedImage)
    {
@@ -489,9 +599,10 @@ public class CUDAJPEGProcessor
     * Decodes a jpeg encoded image, leaving the jpeg's format as is.
     * If the jpeg has multiple channels, the output format is likely to be YUV.
     * If the jpeg has a single channel, the output format will be gray scale.
-    * @param encodedImage INPUT: An encoded multi-channel image.
+    *
+    * @param encodedImage     INPUT: An encoded multi-channel image.
     * @param encodedImageSize INPUT: Number of bytes of the encoded image.
-    * @param decodedImage OUTPUT: The decoded image.
+    * @param decodedImage     OUTPUT: The decoded image.
     */
    public void decodeUnchanged(BytePointer encodedImage, long encodedImageSize, GpuMat decodedImage)
    {
@@ -532,17 +643,19 @@ public class CUDAJPEGProcessor
 
    /**
     * Decodes a jpeg encoded image into the specified output type.
-    * @param encodedImage INPUT: An encoded multi-channel image.
+    *
+    * @param encodedImage     INPUT: An encoded multi-channel image.
     * @param encodedImageSize INPUT: Number of bytes of the encoded image.
     * @param decodedImageInfo INPUT: {@link NVJPEGImageInfo} about the passed in image
     * @param nvjpegOutputType INPUT: One of NVJPEG_OUTPUT_* types
-    * @param decodedChannels OUTPUT: List of decoded image channels. Memory must be pre-allocated. This method does not allocate memory for the output pointers.
+    * @param decodedChannels  OUTPUT: List of decoded image channels. Memory must be pre-allocated. This method does not allocate memory for the output
+    *                         pointers.
     */
    private void decodeImage(BytePointer encodedImage,
-                           long encodedImageSize,
-                           NVJPEGImageInfo decodedImageInfo,
-                           int nvjpegOutputType,
-                           List<BytePointer> decodedChannels)
+                            long encodedImageSize,
+                            NVJPEGImageInfo decodedImageInfo,
+                            int nvjpegOutputType,
+                            List<BytePointer> decodedChannels)
    {
       // Create NVJPEG image and allocate memory for decoded image
       int channelsToDecode = getNumberOfOutputChannels(nvjpegOutputType, decodedImageInfo);
@@ -607,17 +720,13 @@ public class CUDAJPEGProcessor
       long[] decodedChannelSizes = new long[channelsToDecode];
       switch (nvjpegOutputType)
       {
-         case NVJPEG_OUTPUT_Y -> decodedChannelSizes[0] = imageInfo.width(0) * imageInfo.height(0);
+         case NVJPEG_OUTPUT_Y -> decodedChannelSizes[0] = (long) imageInfo.width(0) * imageInfo.height(0);
          case NVJPEG_OUTPUT_YUV, NVJPEG_OUTPUT_UNCHANGED ->
          {
             for (int i = 0; i < channelsToDecode; ++i)
-               decodedChannelSizes[i] = imageInfo.width(i) * imageInfo.height(i);
+               decodedChannelSizes[i] = (long) imageInfo.width(i) * imageInfo.height(i);
          }
-         case NVJPEG_OUTPUT_RGB, NVJPEG_OUTPUT_BGR ->
-         {
-            for (int i = 0; i < channelsToDecode; ++i)
-               decodedChannelSizes[i] = imageInfo.width(0) * imageInfo.height(0);
-         }
+         case NVJPEG_OUTPUT_RGB, NVJPEG_OUTPUT_BGR -> Arrays.fill(decodedChannelSizes, (long) imageInfo.width(0) * imageInfo.height(0));
          case NVJPEG_OUTPUT_RGBI, NVJPEG_OUTPUT_BGRI -> decodedChannelSizes[0] = 3L * imageInfo.width(0) * imageInfo.height(0);
          case NVJPEG_OUTPUT_UNCHANGEDI_U16 ->
                throw new UnsupportedOperationException("NVJPEG_OUTPUT_UNCHANGEDI_U16 is currently unsupported. Please feel free to implement it!");
@@ -643,11 +752,7 @@ public class CUDAJPEGProcessor
             for (int i = 0; i < channelsToDecode; ++i)
                channelPitches[i] = imageInfo.width(i);
          }
-         case NVJPEG_OUTPUT_RGB, NVJPEG_OUTPUT_BGR ->
-         {
-            for (int i = 0; i < channelsToDecode; ++i)
-               channelPitches[i] = imageInfo.width(0);
-         }
+         case NVJPEG_OUTPUT_RGB, NVJPEG_OUTPUT_BGR -> Arrays.fill(channelPitches, imageInfo.width(0));
          case NVJPEG_OUTPUT_RGBI, NVJPEG_OUTPUT_BGRI -> channelPitches[0] = 3L * imageInfo.width(0);
          case NVJPEG_OUTPUT_UNCHANGEDI_U16 ->
                throw new UnsupportedOperationException("NVJPEG_OUTPUT_UNCHANGEDI_U16 is currently unsupported. Please feel free to implement it!");
@@ -706,25 +811,8 @@ public class CUDAJPEGProcessor
    /**
     * Helper class for storing and passing around data obtained through nvjpegGetImageInfo().
     */
-   private class NVJPEGImageInfo
+   private record NVJPEGImageInfo(int numberOfComponents, int[] subSamplingTypes, int[] widths, int[] heights)
    {
-      private final int numberOfComponents;
-      private final int[] subSamplingTypes;
-      private final int[] widths;
-      private final int[] heights;
-
-      private NVJPEGImageInfo(int numberOfComponents, int[] subSamplingTypes, int[] widths, int[] heights)
-      {
-         this.numberOfComponents = numberOfComponents;
-         this.subSamplingTypes = subSamplingTypes;
-         this.widths = widths;
-         this.heights = heights;
-      }
-
-      private int numberOfComponents()
-      {
-         return numberOfComponents;
-      }
 
       private int subSamplingType(int channel)
       {

--- a/ihmc-perception/src/main/java/us/ihmc/perception/imageMessage/ImageMessageDecoder.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/imageMessage/ImageMessageDecoder.java
@@ -95,9 +95,6 @@ public class ImageMessageDecoder
             else
             {  // Otherwise use OpenCV
                opencv_imgcodecs.imdecode(messageDataExtractor.getInputMat(), opencv_imgcodecs.IMREAD_UNCHANGED, imageToPack);
-               // RGBA or BGRA will lose the alpha channel in jpeg encoding, so we give it back
-               if (lastImagePixelFormat.elementsPerPixel == 4 && imageToPack.channels() == 3)
-                  opencv_imgproc.cvtColor(imageToPack, imageToPack, opencv_imgproc.COLOR_BGR2BGRA);
             }
             lastImagePixelFormat = PixelFormat.BGR8;
          }

--- a/ihmc-perception/src/main/java/us/ihmc/perception/tools/PerceptionDebugTools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/tools/PerceptionDebugTools.java
@@ -290,6 +290,19 @@ public class PerceptionDebugTools
       return matString.toString();
    }
 
+   public static void display(String tag, MatVector images, int delay)
+   {
+      display(tag, images, delay, -1);
+   }
+
+   public static void display(String tag, MatVector images, int delay, int screenSize)
+   {
+      Mat combinedImage = new Mat();
+      opencv_core.vconcat(images, combinedImage);
+      display(tag, combinedImage, delay, screenSize);
+      combinedImage.close();
+   }
+
    public static void display(String tag, Mat image, int delay)
    {
       display(tag, image, delay, -1);

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
@@ -1,0 +1,183 @@
+package us.ihmc.perception.cuda;
+
+import org.apache.commons.io.IOUtils;
+import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.opencv.global.opencv_core;
+import org.bytedeco.opencv.global.opencv_imgproc;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.junit.jupiter.api.Test;
+import us.ihmc.commons.Assertions;
+import us.ihmc.log.LogTools;
+import us.ihmc.perception.RawImageTest;
+import us.ihmc.perception.opencv.OpenCVTools;
+import us.ihmc.perception.tools.PerceptionDebugTools;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Objects;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CUDAJPEGProcessorTest
+{
+   @Test
+   public void testEncodeBGRDecodeBGR()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         jpegProcessor.encodeBGR(bgrImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+
+         jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
+         LogTools.info("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeRGBDecodeBGR()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat rgbImage = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, rgbImage, opencv_imgproc.COLOR_BGR2RGB);
+
+         jpegProcessor.encodeRGB(rgbImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+
+         jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
+         LogTools.info("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeBGRDecodeGray()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat grayImage = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, grayImage, opencv_imgproc.COLOR_BGR2GRAY);
+
+         jpegProcessor.encodeBGR(bgrImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+
+         jpegProcessor.decodeToGray(encodedImage, encodedImage.limit(), decodedImage);
+         double averageDifference = OpenCVTools.averagePixelDifference(grayImage, decodedImage);
+         LogTools.info("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeYUVDecodeBGR()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat yuvImage = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV);
+
+         jpegProcessor.encodeYUV444(yuvImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+
+         jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
+         LogTools.info("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeYUVDecodeUnchanged()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat yuvImage = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV);
+
+         jpegProcessor.encodeYUV444(yuvImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+
+         jpegProcessor.decodeUnchanged(encodedImage, encodedImage.limit(), decodedImage);
+         double averageDifference = OpenCVTools.averagePixelDifference(yuvImage, decodedImage);
+         LogTools.info("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void tesEncodeYUV420DecodeUnchanged()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat yuvImage = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV_I420);
+
+         jpegProcessor.encodeYUV420(yuvImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+
+         jpegProcessor.decodeUnchanged(encodedImage, encodedImage.limit(), decodedImage);
+         double averageDifference = OpenCVTools.averagePixelDifference(yuvImage, decodedImage);
+         LogTools.info("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   private Mat readBGRImage()
+   {
+      try
+      {
+         URL imageURL = RawImageTest.class.getResource("zedColorBGR.raw");
+         byte[] imageBytes = IOUtils.toByteArray(Objects.requireNonNull(imageURL));
+         return new Mat(720, 1280, opencv_core.CV_8UC3, new BytePointer(imageBytes));
+      }
+      catch (IOException e)
+      {
+         throw new RuntimeException(e);
+      }
+   }
+}

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
@@ -5,8 +5,8 @@ import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_imgproc;
 import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.MatVector;
 import org.junit.jupiter.api.Test;
-import us.ihmc.commons.Assertions;
 import us.ihmc.log.LogTools;
 import us.ihmc.perception.RawImageTest;
 import us.ihmc.perception.opencv.OpenCVTools;
@@ -34,6 +34,8 @@ public class CUDAJPEGProcessorTest
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
          jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
+
          double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
          LogTools.info("Average Pixel Difference: {}", averageDifference);
          assertTrue(averageDifference < 5.0);
@@ -59,6 +61,8 @@ public class CUDAJPEGProcessorTest
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
          jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
+
          double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
          LogTools.info("Average Pixel Difference: {}", averageDifference);
          assertTrue(averageDifference < 5.0);
@@ -84,6 +88,8 @@ public class CUDAJPEGProcessorTest
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
          jpegProcessor.decodeToGray(encodedImage, encodedImage.limit(), decodedImage);
+         PerceptionDebugTools.display("Original vs Processed", new MatVector(grayImage, decodedImage), 1000);
+
          double averageDifference = OpenCVTools.averagePixelDifference(grayImage, decodedImage);
          LogTools.info("Average Pixel Difference: {}", averageDifference);
          assertTrue(averageDifference < 5.0);
@@ -109,6 +115,8 @@ public class CUDAJPEGProcessorTest
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
          jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
+
          double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
          LogTools.info("Average Pixel Difference: {}", averageDifference);
          assertTrue(averageDifference < 5.0);
@@ -118,7 +126,7 @@ public class CUDAJPEGProcessorTest
    }
 
    @Test
-   public void testEncodeYUVDecodeUnchanged()
+   public void testEncodeYUV444DecodeYUV()
    {
       CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
 
@@ -133,7 +141,9 @@ public class CUDAJPEGProcessorTest
          jpegProcessor.encodeYUV444(yuvImage, encodedImage);
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
-         jpegProcessor.decodeUnchanged(encodedImage, encodedImage.limit(), decodedImage);
+         jpegProcessor.decodeToYUV(encodedImage, encodedImage.limit(), decodedImage);
+         PerceptionDebugTools.display("Original vs Processed", new MatVector(yuvImage, decodedImage), 1000);
+
          double averageDifference = OpenCVTools.averagePixelDifference(yuvImage, decodedImage);
          LogTools.info("Average Pixel Difference: {}", averageDifference);
          assertTrue(averageDifference < 5.0);
@@ -143,7 +153,7 @@ public class CUDAJPEGProcessorTest
    }
 
    @Test
-   public void tesEncodeYUV420DecodeUnchanged()
+   public void tesEncodeYUV420DecodeYUVI()
    {
       CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
 
@@ -155,13 +165,42 @@ public class CUDAJPEGProcessorTest
       {
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV_I420);
 
-         jpegProcessor.encodeYUV420(yuvImage, encodedImage);
+         jpegProcessor.encodeYUVI420(yuvImage, encodedImage);
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
-         jpegProcessor.decodeUnchanged(encodedImage, encodedImage.limit(), decodedImage);
+         jpegProcessor.decodeToYUV(encodedImage, encodedImage.limit(), decodedImage);
+         PerceptionDebugTools.display("Original vs Processed", new MatVector(yuvImage, decodedImage), 10000);
+
          double averageDifference = OpenCVTools.averagePixelDifference(yuvImage, decodedImage);
          LogTools.info("Average Pixel Difference: {}", averageDifference);
          assertTrue(averageDifference < 5.0);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void tesEncodeYUVI420DecodeBGR()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat yuvImage = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV_I420);
+
+         jpegProcessor.encodeYUVI420(yuvImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+
+         jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 10000);
+
+         double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
+         LogTools.info("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 10.0);
       }
 
       jpegProcessor.destroy();

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
@@ -3,6 +3,7 @@ package us.ihmc.perception.cuda;
 import org.apache.commons.io.IOUtils;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.opencv.global.opencv_core;
+import org.bytedeco.opencv.global.opencv_imgcodecs;
 import org.bytedeco.opencv.global.opencv_imgproc;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.MatVector;
@@ -20,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.*;
 
 public class CUDAJPEGProcessorTest
 {
+   private static final boolean SHOW_COMPARISON = false;
+
    @Test
    public void testEncodeBGRDecodeBGR()
    {
@@ -34,11 +37,12 @@ public class CUDAJPEGProcessorTest
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
          jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
-         PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
 
          double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
-         LogTools.info("Average Pixel Difference: {}", averageDifference);
-         assertTrue(averageDifference < 5.0);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
       }
 
       jpegProcessor.destroy();
@@ -58,14 +62,15 @@ public class CUDAJPEGProcessorTest
          opencv_imgproc.cvtColor(bgrImage, rgbImage, opencv_imgproc.COLOR_BGR2RGB);
 
          jpegProcessor.encodeRGB(rgbImage, encodedImage);
-         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(rgbImage));
 
          jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
-         PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
 
          double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
-         LogTools.info("Average Pixel Difference: {}", averageDifference);
-         assertTrue(averageDifference < 5.0);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
       }
 
       jpegProcessor.destroy();
@@ -88,11 +93,12 @@ public class CUDAJPEGProcessorTest
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
          jpegProcessor.decodeToGray(encodedImage, encodedImage.limit(), decodedImage);
-         PerceptionDebugTools.display("Original vs Processed", new MatVector(grayImage, decodedImage), 1000);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(grayImage, decodedImage), 1000);
 
          double averageDifference = OpenCVTools.averagePixelDifference(grayImage, decodedImage);
-         LogTools.info("Average Pixel Difference: {}", averageDifference);
-         assertTrue(averageDifference < 5.0);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
       }
 
       jpegProcessor.destroy();
@@ -112,14 +118,15 @@ public class CUDAJPEGProcessorTest
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV);
 
          jpegProcessor.encodeYUV444(yuvImage, encodedImage);
-         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(yuvImage));
 
          jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
-         PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
 
          double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
-         LogTools.info("Average Pixel Difference: {}", averageDifference);
-         assertTrue(averageDifference < 5.0);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
       }
 
       jpegProcessor.destroy();
@@ -139,21 +146,22 @@ public class CUDAJPEGProcessorTest
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV);
 
          jpegProcessor.encodeYUV444(yuvImage, encodedImage);
-         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(yuvImage));
 
          jpegProcessor.decodeToYUV(encodedImage, encodedImage.limit(), decodedImage);
-         PerceptionDebugTools.display("Original vs Processed", new MatVector(yuvImage, decodedImage), 1000);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(yuvImage, decodedImage), 1000);
 
          double averageDifference = OpenCVTools.averagePixelDifference(yuvImage, decodedImage);
-         LogTools.info("Average Pixel Difference: {}", averageDifference);
-         assertTrue(averageDifference < 5.0);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
       }
 
       jpegProcessor.destroy();
    }
 
    @Test
-   public void tesEncodeYUV420DecodeYUVI()
+   public void testEncodeYUVI420DecodeYUV()
    {
       CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
 
@@ -166,14 +174,15 @@ public class CUDAJPEGProcessorTest
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV_I420);
 
          jpegProcessor.encodeYUVI420(yuvImage, encodedImage);
-         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(yuvImage));
 
          jpegProcessor.decodeToYUV(encodedImage, encodedImage.limit(), decodedImage);
-         PerceptionDebugTools.display("Original vs Processed", new MatVector(yuvImage, decodedImage), 10000);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(yuvImage, decodedImage), 1000);
 
          double averageDifference = OpenCVTools.averagePixelDifference(yuvImage, decodedImage);
-         LogTools.info("Average Pixel Difference: {}", averageDifference);
-         assertTrue(averageDifference < 5.0);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
       }
 
       jpegProcessor.destroy();
@@ -193,14 +202,180 @@ public class CUDAJPEGProcessorTest
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV_I420);
 
          jpegProcessor.encodeYUVI420(yuvImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(yuvImage));
+
+         jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
+
+         double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 10.0, "Average Pixel Difference: " + averageDifference);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void tesEncodeGrayDecodeGray()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat grayImage = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, grayImage, opencv_imgproc.COLOR_BGR2GRAY);
+
+         jpegProcessor.encodeGray(grayImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(grayImage));
+
+         jpegProcessor.decodeToGray(encodedImage, encodedImage.limit(), decodedImage);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(grayImage, decodedImage), 1000);
+
+         double averageDifference = OpenCVTools.averagePixelDifference(grayImage, decodedImage);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeGrayDecodeBGR()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat grayBGRImage = new Mat();
+           Mat grayImage = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, grayImage, opencv_imgproc.COLOR_BGR2GRAY);
+         opencv_imgproc.cvtColor(grayImage, grayBGRImage, opencv_imgproc.COLOR_GRAY2BGR);
+
+         jpegProcessor.encodeGray(grayImage, encodedImage);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(grayImage));
+
+         jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(grayBGRImage, decodedImage), 1000);
+
+         double averageDifference = OpenCVTools.averagePixelDifference(grayBGRImage, decodedImage);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeOpenCVYUVI420DecodeNVJPEGGray()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat yuv420Image = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, yuv420Image, opencv_imgproc.COLOR_BGR2YUV_I420);
+         opencv_imgcodecs.imencode(".jpg", yuv420Image, encodedImage, OpenCVTools.compressionParametersJPG);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(yuv420Image));
+
+         jpegProcessor.decodeToGray(encodedImage, encodedImage.limit(), decodedImage);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(yuv420Image, decodedImage), 1000);
+
+         double averageDifference = OpenCVTools.averagePixelDifference(yuv420Image, decodedImage);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 5.0, "Average Pixel Difference: " + averageDifference);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeOpenCVBGRDecodeNVJPEGYUV()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat yuvI420Image = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, yuvI420Image, opencv_imgproc.COLOR_BGR2YUV_I420);
+         opencv_imgcodecs.imencode(".jpg", bgrImage, encodedImage, OpenCVTools.compressionParametersJPG);
+         assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
+
+         jpegProcessor.decodeToYUV(encodedImage, encodedImage.limit(), decodedImage);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(yuvI420Image, decodedImage), 1000);
+
+         double averageDifference = OpenCVTools.averagePixelDifference(yuvI420Image, decodedImage);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 10.0, "Average Pixel Difference: " + averageDifference);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeOpenCVBGRDecodeNVJPEGBGR()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
+           Mat decodedImage = new Mat())
+
+      {
+         opencv_imgcodecs.imencode(".jpg", bgrImage, encodedImage, OpenCVTools.compressionParametersJPG);
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
 
          jpegProcessor.decodeToBGR(encodedImage, encodedImage.limit(), decodedImage);
-         PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 10000);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
 
          double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
-         LogTools.info("Average Pixel Difference: {}", averageDifference);
-         assertTrue(averageDifference < 10.0);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 10.0, "Average Pixel Difference: " + averageDifference);
+      }
+
+      jpegProcessor.destroy();
+   }
+
+   @Test
+   public void testEncodeNVJPEGDecodeOpenCV()
+   {
+      CUDAJPEGProcessor jpegProcessor = new CUDAJPEGProcessor(100);
+
+      try (Mat bgrImage = readBGRImage();
+           Mat yuv420Image = new Mat();
+           BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage)))
+
+      {
+         opencv_imgproc.cvtColor(bgrImage, yuv420Image, opencv_imgproc.COLOR_BGR2YUV_I420);
+         jpegProcessor.encodeYUVI420(yuv420Image, encodedImage);
+
+         Mat jpegMat = new Mat(1, (int) encodedImage.limit(), opencv_core.CV_8UC1, encodedImage);
+         Mat decodedImage = opencv_imgcodecs.imdecode(jpegMat, opencv_imgcodecs.IMREAD_UNCHANGED);
+         if (SHOW_COMPARISON)
+            PerceptionDebugTools.display("Original vs Processed", new MatVector(bgrImage, decodedImage), 1000);
+
+         double averageDifference = OpenCVTools.averagePixelDifference(bgrImage, decodedImage);
+         LogTools.debug("Average Pixel Difference: {}", averageDifference);
+         assertTrue(averageDifference < 10.0, "Average Pixel Difference: " + averageDifference);
+
+         decodedImage.close();
       }
 
       jpegProcessor.destroy();

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
@@ -31,7 +31,6 @@ public class CUDAJPEGProcessorTest
       try (Mat bgrImage = readBGRImage();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          jpegProcessor.encodeBGR(bgrImage, encodedImage);
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
@@ -57,7 +56,6 @@ public class CUDAJPEGProcessorTest
            Mat rgbImage = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, rgbImage, opencv_imgproc.COLOR_BGR2RGB);
 
@@ -85,7 +83,6 @@ public class CUDAJPEGProcessorTest
            Mat grayImage = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, grayImage, opencv_imgproc.COLOR_BGR2GRAY);
 
@@ -113,7 +110,6 @@ public class CUDAJPEGProcessorTest
            Mat yuvImage = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV);
 
@@ -141,7 +137,6 @@ public class CUDAJPEGProcessorTest
            Mat yuvImage = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV);
 
@@ -169,7 +164,6 @@ public class CUDAJPEGProcessorTest
            Mat yuvImage = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV_I420);
 
@@ -197,7 +191,6 @@ public class CUDAJPEGProcessorTest
            Mat yuvImage = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, yuvImage, opencv_imgproc.COLOR_BGR2YUV_I420);
 
@@ -225,7 +218,6 @@ public class CUDAJPEGProcessorTest
            Mat grayImage = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, grayImage, opencv_imgproc.COLOR_BGR2GRAY);
 
@@ -254,7 +246,6 @@ public class CUDAJPEGProcessorTest
            Mat grayImage = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, grayImage, opencv_imgproc.COLOR_BGR2GRAY);
          opencv_imgproc.cvtColor(grayImage, grayBGRImage, opencv_imgproc.COLOR_GRAY2BGR);
@@ -283,7 +274,6 @@ public class CUDAJPEGProcessorTest
            Mat yuv420Image = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, yuv420Image, opencv_imgproc.COLOR_BGR2YUV_I420);
          opencv_imgcodecs.imencode(".jpg", yuv420Image, encodedImage, OpenCVTools.compressionParametersJPG);
@@ -310,7 +300,6 @@ public class CUDAJPEGProcessorTest
            Mat yuvI420Image = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgproc.cvtColor(bgrImage, yuvI420Image, opencv_imgproc.COLOR_BGR2YUV_I420);
          opencv_imgcodecs.imencode(".jpg", bgrImage, encodedImage, OpenCVTools.compressionParametersJPG);
@@ -336,7 +325,6 @@ public class CUDAJPEGProcessorTest
       try (Mat bgrImage = readBGRImage();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage));
            Mat decodedImage = new Mat())
-
       {
          opencv_imgcodecs.imencode(".jpg", bgrImage, encodedImage, OpenCVTools.compressionParametersJPG);
          assertTrue(encodedImage.limit() < OpenCVTools.dataSize(bgrImage));
@@ -361,7 +349,6 @@ public class CUDAJPEGProcessorTest
       try (Mat bgrImage = readBGRImage();
            Mat yuv420Image = new Mat();
            BytePointer encodedImage = new BytePointer(OpenCVTools.dataSize(bgrImage)))
-
       {
          opencv_imgproc.cvtColor(bgrImage, yuv420Image, opencv_imgproc.COLOR_BGR2YUV_I420);
          jpegProcessor.encodeYUVI420(yuv420Image, encodedImage);


### PR DESCRIPTION
I had misunderstood how YUV images are stored in OpenCV and NVJPEG land, so they were kinda usable with JPEG. This PR handles the YUV images properly, so we can actually make use of them with JPEG. 

This is a (soft) prerequisite to more depth streaming, as the colorized depth images are in YUV format. 