### PR TITLE
[Feature/Bugfix] Clear CUDA Kernel Parameters After Run

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDADepthColorizer.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDADepthColorizer.java
@@ -49,7 +49,6 @@ public class CUDADepthColorizer
       try (dim3 gridSize = new dim3(gridSizeX, gridSizeY, 1);
            dim3 blockSize = new dim3(BLOCK_DIM_XY, BLOCK_DIM_XY, 1))
       {
-         encoder.clearParameters();
          encoder.withPointer(depthImage.data()).withLong(depthImage.step())
                 .withPointer(colorizedDepth.data()).withLong(colorizedDepth.step())
                 .withInt(depthImage.rows()).withInt(depthImage.cols())
@@ -78,7 +77,6 @@ public class CUDADepthColorizer
       try (dim3 gridSize = new dim3(gridSizeX, gridSizeY, 1);
            dim3 blockSize = new dim3(BLOCK_DIM_XY, BLOCK_DIM_XY, 1))
       {
-         decoder.clearParameters();
          decoder.withPointer(colorizedDepthImage.data()).withLong(colorizedDepthImage.step())
                 .withPointer(deColorizedDepth.data()).withLong(deColorizedDepth.step())
                 .withInt(colorizedDepthImage.rows()).withInt(colorizedDepthImage.cols())

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAKernel.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAKernel.java
@@ -24,6 +24,7 @@ public class CUDAKernel implements AutoCloseable
 {
    private final CUfunc_st kernelFunction = new CUfunc_st();
    private final List<Pointer> parameters = new ArrayList<>();
+   private boolean retainParameters = false;
 
    private int error;
 
@@ -33,12 +34,17 @@ public class CUDAKernel implements AutoCloseable
       throwCUDAError(error);
    }
 
+   public void retainParameters(boolean retainParameters)
+   {
+      this.retainParameters = retainParameters;
+   }
+
    /**
-    * Launches the CUDA kernel.
+    * Launches the CUDA kernel. The parameters used for this launch are cleared unless {@code retainParameters == true}.
     *
-    * @param stream CUDA stream on which the kernel will be synchronized.
-    * @param gridSize Grid size of the kernel execution.
-    * @param blockSize Block size of the kernel execution. Should not exceed maximum block size of the device.
+    * @param stream           CUDA stream on which the kernel will be synchronized.
+    * @param gridSize         Grid size of the kernel execution.
+    * @param blockSize        Block size of the kernel execution. Should not exceed maximum block size of the device.
     * @param sharedMemorySize Size, in byte, of the memory shared by threads in each block.
     */
    public void run(CUstream_st stream, dim3 gridSize, dim3 blockSize, int sharedMemorySize)
@@ -59,6 +65,9 @@ public class CUDAKernel implements AutoCloseable
                              parametersPointer,
                              new PointerPointer<>());
       CUDATools.checkCUDAError(error);
+
+      if (!retainParameters)
+         clearParameters();
       parametersPointer.close();
    }
 

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAProgramTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAProgramTest.java
@@ -90,7 +90,6 @@ public class CUDAProgramTest
          {
             for (int b = 0; b < runs; ++b)
             {
-               additionKernel.clearParameters();
                additionKernel.withInt(a).withInt(b).withPointer(deviceSum);
                additionKernel.run(stream, new dim3(), new dim3(), 0);
 


### PR DESCRIPTION
When running the kernels in a loop, we usually want to clear the parameters after each run (though there might be cases where we don't want to). It's easy to forget to call the `clearParameters` method, which has caused some bugs. This PR makes the `CUDAKernel` clear its parameters after each run by default. 

This also fixes a bug with the CUDA height map!