### PR TITLE
Lower ZED confidence threshold

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
@@ -81,7 +81,7 @@ public class ZEDImageSensor extends ImageSensor
       // Set runtime parameters to default values
       zedRuntimeParameters.reference_frame(SL_REFERENCE_FRAME_CAMERA);
       zedRuntimeParameters.enable_depth(true);
-      zedRuntimeParameters.confidence_threshold(100);
+      zedRuntimeParameters.confidence_threshold(70);
       zedRuntimeParameters.texture_confidence_threshold(100);
       zedRuntimeParameters.remove_saturated_areas(true);
       zedRuntimeParameters.enable_fill_mode(false);


### PR DESCRIPTION
This reduces (and basically completely removes) flying points and makes the image much cleaner.