### PR TITLE
Direct CoM Streaming

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/networkProcessor/kinemtaticsStreamingToolboxModule/KSTTools.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/networkProcessor/kinemtaticsStreamingToolboxModule/KSTTools.java
@@ -99,6 +99,7 @@ public class KSTTools
    private final YoBoolean isNeckJointspaceOutputEnabled;
    private final YoBoolean isChestTaskspaceOutputEnabled;
    private final YoBoolean isPelvisTaskspaceOutputEnabled;
+   private final YoBoolean isCenterOfMassOutputEnabled;
    private final SideDependentList<YoBoolean> areHandTaskspaceOutputsEnabled = new SideDependentList<>();
    private final SideDependentList<YoBoolean> areArmJointspaceOutputsEnabled = new SideDependentList<>();
 
@@ -210,6 +211,7 @@ public class KSTTools
       isNeckJointspaceOutputEnabled = new YoBoolean("isNeckJointspaceOutputEnabled", registry);
       isChestTaskspaceOutputEnabled = new YoBoolean("isChestTaskspaceOutputEnabled", registry);
       isPelvisTaskspaceOutputEnabled = new YoBoolean("isPelvisTaskspaceOutputEnabled", registry);
+      isCenterOfMassOutputEnabled = new YoBoolean("isCenterOfMassOutputEnabled", registry);
 
       for (RobotSide robotSide : RobotSide.values)
       {
@@ -239,6 +241,7 @@ public class KSTTools
       isNeckJointspaceOutputEnabled.set(configurationCommand.isNeckJointspaceEnabled());
       isChestTaskspaceOutputEnabled.set(configurationCommand.isChestTaskspaceEnabled());
       isPelvisTaskspaceOutputEnabled.set(configurationCommand.isPelvisTaskspaceEnabled());
+      isCenterOfMassOutputEnabled.set(configurationCommand.isCenterOfMassTrajectoryEnabled());
 
       for (RobotSide robotSide : RobotSide.values)
       {
@@ -427,6 +430,8 @@ public class KSTTools
          streamingMessageFactory.computeChestStreamingMessage(configurationCommand.getChestTrajectoryFrameId());
       if (isPelvisTaskspaceOutputEnabled.getValue())
          streamingMessageFactory.computePelvisStreamingMessage(configurationCommand.getPelvisTrajectoryFrameId());
+      if (isCenterOfMassOutputEnabled.getValue())
+         streamingMessageFactory.computeCenterOfMassStreamingMessage();
 
       currentMessageId.increment();
       return streamingMessageFactory.getOutput();
@@ -487,6 +492,8 @@ public class KSTTools
          trajectoryMessageFactory.computeChestTrajectoryMessage();
       if (isPelvisTaskspaceOutputEnabled.getValue())
          trajectoryMessageFactory.computePelvisTrajectoryMessage();
+      if (isCenterOfMassOutputEnabled.getValue())
+         trajectoryMessageFactory.computeCenterOfMassTrajectoryMessage();
 
       wholeBodyTrajectoryMessage.getPelvisTrajectoryMessage().setEnableUserPelvisControl(false);
       HumanoidMessageTools.configureForOverriding(wholeBodyTrajectoryMessage);

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/capturePoint/BalanceManager.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/capturePoint/BalanceManager.java
@@ -78,6 +78,7 @@ public class BalanceManager implements SCS2YoGraphicHolder
    private static final boolean USE_ERROR_BASED_STEP_ADJUSTMENT = true;
    private static final ReferenceFrame worldFrame = ReferenceFrame.getWorldFrame();
    private static final boolean viewCoPHistory = false;
+   private static final FrameVector2D zeroVector = new FrameVector2D();
 
    private final YoRegistry registry = new YoRegistry(getClass().getSimpleName());
 
@@ -104,6 +105,12 @@ public class BalanceManager implements SCS2YoGraphicHolder
    private final YoFramePoint3D yoFinalDesiredCoM = new YoFramePoint3D("finalDesiredCoM", worldFrame, registry);
    private final YoFrameVector3D yoFinalDesiredCoMVelocity = new YoFrameVector3D("finalDesiredCoMVelocity", worldFrame, registry);
    private final YoFrameVector3D yoFinalDesiredCoMAcceleration = new YoFrameVector3D("finalDesiredCoMAcceleration", worldFrame, registry);
+
+   private final YoBoolean isUsingPrecomputedTrajectory = new YoBoolean("isUsingPrecomputedTrajectory", registry);
+   private final FramePoint2D previousDesiredCapturePointPrecomputed = new FramePoint2D();
+   private final FrameVector2D previousDesiredCapturePointVelocityPrecomputed = new FrameVector2D();
+   private final FramePoint2D previousDesiredCenterOfPressurePrecomputed = new FramePoint2D();
+   private final YoDouble previousPrecomputedTrajectoryTime = new YoDouble("previousPrecomputedICPTime", registry);
 
    private final TimeAdjustmentCalculator timeAdjustmentCalculator = new TimeAdjustmentCalculator();
    private final ICPControllerParameters.FeedbackAlphaCalculator feedbackAlphaCalculator;
@@ -309,6 +316,8 @@ public class BalanceManager implements SCS2YoGraphicHolder
       flamingoCopTrajectory = new FlamingoCoPTrajectoryGenerator(copTrajectoryParameters, registry);
       flamingoCopTrajectory.registerState(copTrajectoryState);
 
+      previousPrecomputedTrajectoryTime.setToNaN();
+
       if (USE_ERROR_BASED_STEP_ADJUSTMENT)
       {
          stepAdjustmentController = new ErrorBasedStepAdjustmentController(walkingControllerParameters,
@@ -478,8 +487,8 @@ public class BalanceManager implements SCS2YoGraphicHolder
             else
             {
             */
-               feedbackAlpha = 0.5 * (currentFeedbackAlpha.getDoubleValue() + maxAlpha);
-//            }
+            feedbackAlpha = 0.5 * (currentFeedbackAlpha.getDoubleValue() + maxAlpha);
+            //            }
             feedbackAlpha = MathTools.clamp(feedbackAlpha, 0.0, 1.0);
          }
          else
@@ -559,11 +568,27 @@ public class BalanceManager implements SCS2YoGraphicHolder
       {
          if (blendICPTrajectories.getBooleanValue())
          {
-            precomputedICPPlanner.computeAndBlend(yoTime.getDoubleValue(), desiredCapturePoint2d, desiredCapturePointVelocity2d, perfectCMP2d);
+            isUsingPrecomputedTrajectory.set(precomputedICPPlanner.computeAndBlend(yoTime.getDoubleValue(), desiredCapturePoint2d, desiredCapturePointVelocity2d, perfectCMP2d));
          }
          else
          {
-            precomputedICPPlanner.compute(yoTime.getDoubleValue(), desiredCapturePoint2d, desiredCapturePointVelocity2d, perfectCMP2d);
+            isUsingPrecomputedTrajectory.set(precomputedICPPlanner.compute(yoTime.getDoubleValue(), desiredCapturePoint2d, desiredCapturePointVelocity2d, perfectCMP2d));
+         }
+
+         if (isUsingPrecomputedTrajectory.getValue())
+         {
+            previousDesiredCapturePointPrecomputed.set(desiredCapturePoint2d);
+            previousDesiredCapturePointVelocityPrecomputed.set(desiredCapturePointVelocity2d);
+            previousDesiredCenterOfPressurePrecomputed.set(perfectCMP2d);
+            previousPrecomputedTrajectoryTime.set(yoTime.getValue());
+         }
+         else if (!Double.isNaN(previousPrecomputedTrajectoryTime.getDoubleValue()) && precomputedICPPlanner.getBlendingDuration() > 0.0
+                  && yoTime.getValue() - previousPrecomputedTrajectoryTime.getValue() < precomputedICPPlanner.getBlendingDuration())
+         {
+            double alphaPrecomputed = 1.0 - (yoTime.getValue() - previousPrecomputedTrajectoryTime.getValue()) / precomputedICPPlanner.getBlendingDuration();
+            desiredCapturePoint2d.interpolate(previousDesiredCapturePointPrecomputed, alphaPrecomputed);
+            desiredCapturePointVelocity2d.interpolate(zeroVector, alphaPrecomputed);
+            perfectCMP2d.interpolate(previousDesiredCenterOfPressurePrecomputed, alphaPrecomputed);
          }
       }
 
@@ -1023,9 +1048,9 @@ public class BalanceManager implements SCS2YoGraphicHolder
       icpError2d.changeFrame(leadingSoleZUpFrame);
       boolean isICPErrorToTheInside = transferToSide == RobotSide.RIGHT ? icpError2d.getY() > 0.0 : icpError2d.getY() < 0.0;
       double maxICPErrorBeforeSingleSupportX = icpError2d.getX() > 0.0 ? maxICPErrorBeforeSingleSupportForwardX.getValue()
-                                                                       : maxICPErrorBeforeSingleSupportBackwardX.getValue();
+            : maxICPErrorBeforeSingleSupportBackwardX.getValue();
       double maxICPErrorBeforeSingleSupportY = isICPErrorToTheInside ? maxICPErrorBeforeSingleSupportInnerY.getValue()
-                                                                     : maxICPErrorBeforeSingleSupportOuterY.getValue();
+            : maxICPErrorBeforeSingleSupportOuterY.getValue();
       normalizedICPError.set(MathTools.square(icpError2d.getX() / maxICPErrorBeforeSingleSupportX)
                              + MathTools.square(icpError2d.getY() / maxICPErrorBeforeSingleSupportY));
    }

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/capturePoint/PrecomputedICPPlanner.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/capturePoint/PrecomputedICPPlanner.java
@@ -194,12 +194,14 @@ public class PrecomputedICPPlanner implements SCS2YoGraphicHolder
       yoDesiredCMPPosition.set(desiredCMPPosition);
    }
 
-   public void compute(double time,
+   public boolean compute(double time,
                        FramePoint2DBasics desiredCapturePoint2dToPack,
                        FrameVector2DBasics desiredCapturePointVelocity2dToPack,
                        FramePoint2DBasics desiredCoP2DToPack)
    {
-      if (isWithinInterval(time))
+      boolean withinTimeInterval = isWithinInterval(time);
+
+      if (withinTimeInterval)
       {
          compute(time);
          desiredCapturePoint2dToPack.setIncludingFrame(ReferenceFrame.getWorldFrame(), desiredICPPosition);
@@ -214,9 +216,10 @@ public class PrecomputedICPPlanner implements SCS2YoGraphicHolder
 
       centerOfMassTrajectoryHandler.clearPointsInPast();
       momentumTrajectoryHandler.clearPointsInPast();
+      return withinTimeInterval;
    }
 
-   public void computeAndBlend(double time,
+   public boolean computeAndBlend(double time,
                                FixedFramePoint2DBasics desiredCapturePoint2dToPack,
                                FixedFrameVector2DBasics desiredCapturePointVelocity2dToPack,
                                FixedFramePoint2DBasics desiredCenterOfPressure2dToPack)
@@ -225,7 +228,8 @@ public class PrecomputedICPPlanner implements SCS2YoGraphicHolder
       desiredCapturePointVelocity2dToPack.checkReferenceFrameMatch(ReferenceFrame.getWorldFrame());
       desiredCenterOfPressure2dToPack.checkReferenceFrameMatch(ReferenceFrame.getWorldFrame());
 
-      if (isWithinInterval(time))
+      boolean withinTimeInterval = isWithinInterval(time);
+      if (withinTimeInterval)
       {
          compute(time);
          if (!currentlyBlendingICPTrajectories.getBooleanValue())
@@ -254,6 +258,7 @@ public class PrecomputedICPPlanner implements SCS2YoGraphicHolder
 
       centerOfMassTrajectoryHandler.clearPointsInPast();
       momentumTrajectoryHandler.clearPointsInPast();
+      return withinTimeInterval;
    }
 
    public boolean isWithinInterval(double time)
@@ -303,5 +308,10 @@ public class PrecomputedICPPlanner implements SCS2YoGraphicHolder
       group.addChild(newYoGraphicPoint2D("Desired CoP Precomputed", yoDesiredCoPPosition, 0.010, ColorDefinitions.BlueViolet(), DIAMOND));
       group.addChild(newYoGraphicPoint2D("Desired CMP Precomputed", yoDesiredCMPPosition, 0.010, ColorDefinitions.BlueViolet(), CIRCLE));
       return group;
+   }
+
+   public double getBlendingDuration()
+   {
+      return blendingDuration.getDoubleValue();
    }
 }

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/messageHandlers/EuclideanTrajectoryHandler.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/messageHandlers/EuclideanTrajectoryHandler.java
@@ -1,12 +1,19 @@
 package us.ihmc.commonWalkingControlModules.messageHandlers;
 
+import us.ihmc.euclid.tuple3D.Point3D;
+import us.ihmc.log.LogTools;
+
+import us.ihmc.commons.Conversions;
 import us.ihmc.commons.PrintTools;
 import us.ihmc.commons.lists.RecyclingIterator;
 import us.ihmc.commons.lists.RecyclingLinkedList;
+import us.ihmc.communication.packets.ExecutionMode;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.interfaces.FramePoint3DReadOnly;
 import us.ihmc.euclid.referenceFrame.interfaces.FrameVector3DReadOnly;
 import us.ihmc.humanoidRobotics.communication.controllerAPI.command.EuclideanTrajectoryControllerCommand;
+import us.ihmc.robotics.math.trajectories.trajectorypoints.FrameEuclideanTrajectoryPoint;
+import us.ihmc.robotics.math.trajectories.trajectorypoints.lists.FrameEuclideanTrajectoryPointList;
 import us.ihmc.robotics.math.trajectories.yoVariables.YoPolynomial;
 import us.ihmc.robotics.math.trajectories.trajectorypoints.EuclideanTrajectoryPoint;
 import us.ihmc.robotics.math.trajectories.trajectorypoints.interfaces.EuclideanTrajectoryPointBasics;
@@ -15,6 +22,7 @@ import us.ihmc.yoVariables.euclid.referenceFrame.YoFrameVector3D;
 import us.ihmc.yoVariables.providers.DoubleProvider;
 import us.ihmc.yoVariables.registry.YoRegistry;
 import us.ihmc.yoVariables.variable.YoInteger;
+import us.ihmc.yoVariables.variable.YoDouble;
 import us.ihmc.yoVariables.variable.YoVariable;
 
 /**
@@ -32,10 +40,11 @@ public class EuclideanTrajectoryHandler
    private final EuclideanTrajectoryPointBasics firstPoint = new EuclideanTrajectoryPoint();
    private final EuclideanTrajectoryPointBasics secondPoint = new EuclideanTrajectoryPoint();
    private final EuclideanTrajectoryPointBasics tempPoint = new EuclideanTrajectoryPoint();
+   private final Point3D integratedPosition = new Point3D();
 
    private final RecyclingLinkedList<EuclideanTrajectoryPointBasics> trajectoryPoints = new RecyclingLinkedList<>(defaultMaxNumberOfPoints,
-                                                                                                                     EuclideanTrajectoryPoint::new,
-                                                                                                                     EuclideanTrajectoryPointBasics::set);
+                                                                                                                  EuclideanTrajectoryPoint::new,
+                                                                                                                  EuclideanTrajectoryPointBasics::set);
    private final RecyclingIterator<EuclideanTrajectoryPointBasics> trajectoryIterator = trajectoryPoints.createForwardIterator();
 
    private final DoubleProvider yoTime;
@@ -44,6 +53,12 @@ public class EuclideanTrajectoryHandler
    private final YoFrameVector3D velocity;
    private final YoFrameVector3D acceleration;
    private final YoInteger numberOfPoints;
+   /**
+    * Used when streaming to account for time variations occurring during the transport of the message
+    * over the network.
+    */
+   private final YoDouble streamTimestampOffset;
+   private final YoDouble streamTimestampSource;
 
    private long lastMessageID = -1L;
 
@@ -64,6 +79,11 @@ public class EuclideanTrajectoryHandler
       velocity = new YoFrameVector3D(name + "Velocity", ReferenceFrame.getWorldFrame(), registry);
       acceleration = new YoFrameVector3D(name + "Acceleration", ReferenceFrame.getWorldFrame(), registry);
       numberOfPoints = new YoInteger(name + "NumberOfPoints", registry);
+
+      streamTimestampOffset = new YoDouble(name + "StreamTimestampOffset", registry);
+      streamTimestampOffset.setToNaN();
+      streamTimestampSource = new YoDouble(name + "StreamTimestampSource", registry);
+      streamTimestampSource.setToNaN();
 
       parentRegistry.addChild(registry);
    }
@@ -90,47 +110,151 @@ public class EuclideanTrajectoryHandler
 
    protected void handleTrajectory(EuclideanTrajectoryControllerCommand command)
    {
+      double streamTimeOffset = 0.0;
+      double streamTimestampOffset = this.streamTimestampOffset.getValue();
+      double streamTimestampSource = this.streamTimestampSource.getValue();
+
+      if (command.getExecutionMode() == ExecutionMode.STREAM)
+      { // Need to do time checks before moving on.
+         if (command.getTimestamp() <= 0 || !isWithinInterval(yoTime.getValue()))
+         {
+            streamTimestampOffset = Double.NaN;
+            streamTimestampSource = Double.NaN;
+         }
+         else
+         {
+            double senderTime = Conversions.nanosecondsToSeconds(command.getTimestamp());
+
+            if (!Double.isNaN(streamTimestampSource) && senderTime < streamTimestampSource)
+            {
+               // Messages are out of order which is fine, we just don't want to handle the new message.
+               return;
+            }
+
+            streamTimestampSource = senderTime;
+
+            streamTimeOffset = yoTime.getValue() - senderTime;
+
+            if (Double.isNaN(streamTimestampOffset))
+            {
+               streamTimestampOffset = streamTimeOffset;
+            }
+            else
+            {
+               /*
+                * Update to the smallest time offset, which is closer to the true offset between the sender CPU and
+                * control CPU. If the change in offset is too large though, we always set the streamTimestampOffset
+                * for safety.
+                */
+               if (Math.abs(streamTimeOffset - streamTimestampOffset) > 0.5)
+                  streamTimestampOffset = streamTimeOffset;
+               else
+                  streamTimestampOffset = Math.min(streamTimeOffset, streamTimestampOffset);
+            }
+         }
+      }
+
       switch (command.getExecutionMode())
       {
-      case OVERRIDE:
-         command.addTimeOffset(yoTime.getValue());
-         while (!trajectoryPoints.isEmpty())
+         case OVERRIDE:
+            command.addTimeOffset(yoTime.getValue());
+            while (!trajectoryPoints.isEmpty())
+            {
+               trajectoryPoints.removeFirst();
+            }
+            break;
+         case QUEUE:
+            if (trajectoryPoints.isEmpty())
+            {
+               PrintTools.warn("Can not queue without points");
+               return;
+            }
+            if (command.getTrajectoryPoint(0).getTime() <= 0.0)
+            {
+               PrintTools.warn("Can not queue trajectory with initial time 0.0");
+               return;
+            }
+            if (command.getPreviousCommandId() != lastMessageID)
+            {
+               PrintTools.warn("Invalid message ID.");
+               return;
+            }
+            trajectoryPoints.peekLast(lastPoint);
+            double lastTime = lastPoint.getTime();
+            command.addTimeOffset(lastTime);
+            break;
+         case STREAM:
          {
-            trajectoryPoints.removeFirst();
+            this.streamTimestampOffset.set(streamTimestampOffset);
+            this.streamTimestampSource.set(streamTimestampSource);
+
+            int numberOfTrajectoryPoints = command.getNumberOfTrajectoryPoints();
+            if (command.getNumberOfTrajectoryPoints() == 0 || numberOfTrajectoryPoints > 2)
+            {
+               LogTools.warn("When streaming, trajectories should contain either 1 or 2 trajectory point(s), was: " + command.getNumberOfTrajectoryPoints());
+               return;
+            }
+
+            FrameEuclideanTrajectoryPointList streamingTrajectoryPoints = command.getTrajectoryPointList();
+
+            FrameEuclideanTrajectoryPoint streamingFirstPoint = streamingTrajectoryPoints.getTrajectoryPoint(0);
+
+            if (streamingFirstPoint.getTime() != 0.0)
+            {
+               LogTools.warn("When streaming, the trajectory point should have a time of zero, was: " + streamingFirstPoint.getTime());
+               return;
+            }
+
+            this.firstPoint.set(streamingFirstPoint);
+            firstPoint.setTime(yoTime.getValue());
+
+            if (!Double.isNaN(streamTimestampOffset))
+               this.firstPoint.addTimeOffset(streamTimestampOffset - streamTimeOffset);
+
+            if (streamingTrajectoryPoints.getNumberOfTrajectoryPoints() == 1)
+            { // No extrapolation provided, so we do it here.
+               this.secondPoint.set(firstPoint);
+               integratedPosition.scaleAdd(command.getStreamIntegrationDuration(), secondPoint.getLinearVelocity(), secondPoint.getPosition());
+               secondPoint.getPosition().set(integratedPosition);
+            }
+            else
+            {
+               FrameEuclideanTrajectoryPoint secondPoint = streamingTrajectoryPoints.getTrajectoryPoint(1);
+
+               if (secondPoint.getTime() != command.getStreamIntegrationDuration())
+               {
+                  LogTools.warn("When streaming, the second trajectory point should have a time equal to the integration duration, was: " + secondPoint.getTime());
+                  return;
+               }
+
+               this.secondPoint.set(secondPoint);
+            }
+
+            this.secondPoint.setTime(command.getStreamIntegrationDuration() + this.firstPoint.getTime());
+
+            while (!trajectoryPoints.isEmpty())
+               trajectoryPoints.removeFirst();
+
+            trajectoryPoints.addLast(firstPoint);
+            trajectoryPoints.addLast(secondPoint);
+
+            break;
          }
-         break;
-      case QUEUE:
-         if (trajectoryPoints.isEmpty())
-         {
-            PrintTools.warn("Can not queue without points");
-            return;
-         }
-         if (command.getTrajectoryPoint(0).getTime() <= 0.0)
-         {
-            PrintTools.warn("Can not queue trajectory with initial time 0.0");
-            return;
-         }
-         if (command.getPreviousCommandId() != lastMessageID)
-         {
-            PrintTools.warn("Invalid message ID.");
-            return;
-         }
-         trajectoryPoints.peekLast(lastPoint);
-         double lastTime = lastPoint.getTime();
-         command.addTimeOffset(lastTime);
-         break;
-      default:
-         throw new RuntimeException("Unhadled execution mode.");
+         default:
+            throw new RuntimeException("Unhadled execution mode.");
       }
 
       lastMessageID = command.getCommandId();
 
-      for (int idx = 0; idx < command.getNumberOfTrajectoryPoints(); idx++)
+      if (command.getExecutionMode() != ExecutionMode.STREAM)
       {
-         trajectoryPoints.addLast(command.getTrajectoryPoint(idx));
-      }
+         for (int idx = 0; idx < command.getNumberOfTrajectoryPoints(); idx++)
+         {
+            trajectoryPoints.addLast(command.getTrajectoryPoint(idx));
+         }
 
-      numberOfPoints.set(trajectoryPoints.size());
+         numberOfPoints.set(trajectoryPoints.size());
+      }
    }
 
    /**

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/staticEquilibrium/CenterOfMassStabilityMarginOptimizationModule.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/staticEquilibrium/CenterOfMassStabilityMarginOptimizationModule.java
@@ -54,9 +54,9 @@ import java.util.List;
  * <br>
  *
  * <pre>
- * max<sub>x,f</sub> c · x                           (max com displacement)
+ * max<sub>x,f</sub> c^T x                           (max com displacement)
  *    s.t.  mg + &Sigma f = 0                  (lin static equilibrium)
- *          &Sigma x × f + x × mg = 0          (ang static equilibrium)
+ *          &Sigma (x) x (f) + (x) x (mg) = 0          (ang static equilibrium)
  *          f is friction constrained
  *          &tau<sub>min</sub> <= G - J^T f <= &tau<sub>max</sub>      (actuation constraints)
  * </pre>

--- a/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/kinematicsStreamingToolboxAPI/KinematicsStreamingToolboxConfigurationCommand.java
+++ b/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/kinematicsStreamingToolboxAPI/KinematicsStreamingToolboxConfigurationCommand.java
@@ -23,6 +23,7 @@ public class KinematicsStreamingToolboxConfigurationCommand
    private boolean enableRightHandTaskspace = true;
    private boolean enableChestTaskspace = true;
    private boolean enablePelvisTaskspace = true;
+   private boolean enableCenterOfMassTrajectory = false;
 
    private long leftHandTrajectoryFrameId = WORLD_FRAME_ID;
    private long rightHandTrajectoryFrameId = WORLD_FRAME_ID;
@@ -48,6 +49,7 @@ public class KinematicsStreamingToolboxConfigurationCommand
       enableRightHandTaskspace = true;
       enableChestTaskspace = true;
       enablePelvisTaskspace = true;
+      enableCenterOfMassTrajectory = false;
 
       leftHandTrajectoryFrameId = WORLD_FRAME_ID;
       rightHandTrajectoryFrameId = WORLD_FRAME_ID;
@@ -70,6 +72,7 @@ public class KinematicsStreamingToolboxConfigurationCommand
       enableRightHandTaskspace = other.enableRightHandTaskspace;
       enableChestTaskspace = other.enableChestTaskspace;
       enablePelvisTaskspace = other.enablePelvisTaskspace;
+      enableCenterOfMassTrajectory = other.enableCenterOfMassTrajectory;
 
       leftHandTrajectoryFrameId = other.leftHandTrajectoryFrameId;
       rightHandTrajectoryFrameId = other.rightHandTrajectoryFrameId;
@@ -95,6 +98,7 @@ public class KinematicsStreamingToolboxConfigurationCommand
       enableRightHandTaskspace = message.getEnableRightHandTaskspace();
       enableChestTaskspace = message.getEnableChestTaskspace();
       enablePelvisTaskspace = message.getEnablePelvisTaskspace();
+      enableCenterOfMassTrajectory = message.getEnableCenterOfMassControl();
 
       leftHandTrajectoryFrameId = message.getLeftHandTrajectoryFrameId();
       rightHandTrajectoryFrameId = message.getRightHandTrajectoryFrameId();
@@ -161,6 +165,11 @@ public class KinematicsStreamingToolboxConfigurationCommand
    public boolean isPelvisTaskspaceEnabled()
    {
       return enablePelvisTaskspace;
+   }
+
+   public boolean isCenterOfMassTrajectoryEnabled()
+   {
+      return enableCenterOfMassTrajectory;
    }
 
    public long getHandTrajectoryFrameId(RobotSide robotSide)

--- a/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/packets/KinematicsToolboxOutputConverter.java
+++ b/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/packets/KinematicsToolboxOutputConverter.java
@@ -13,6 +13,8 @@ import us.ihmc.euclid.referenceFrame.FrameQuaternion;
 import us.ihmc.euclid.referenceFrame.FrameVector3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.interfaces.FrameVector3DBasics;
+import us.ihmc.euclid.referenceFrame.interfaces.FrameVector3DReadOnly;
+import us.ihmc.euclid.tuple3D.interfaces.Point3DReadOnly;
 import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
 import us.ihmc.humanoidRobotics.frames.HumanoidReferenceFrames;
 import us.ihmc.idl.IDLSequence.Object;
@@ -278,6 +280,26 @@ public class KinematicsToolboxOutputConverter
       packSE3TrajectoryPointMessage(trajectoryTime, desiredPose, desiredSpatialVelocity, taskspaceTrajectoryPoints.add());
    }
 
+   public void computeCenterOfMassTrajectoryMessage()
+   {
+      checkIfDataHasBeenSet();
+
+      desiredPose.setToZero(referenceFrames.getCenterOfMassFrame());
+      desiredPose.changeFrame(worldFrame);
+
+      spatialVelocity((MovingReferenceFrame) referenceFrames.getCenterOfMassFrame(), worldFrame, enableVelocity, desiredSpatialVelocity);
+
+      CenterOfMassTrajectoryMessage centerOfMassTrajectoryMessage = output.getCenterOfMassTrajectoryMessage();
+      EuclideanTrajectoryMessage euclideanTrajectory = centerOfMassTrajectoryMessage.getEuclideanTrajectory();
+      euclideanTrajectory.getFrameInformation().setTrajectoryReferenceFrameId(worldFrame.getFrameNameHashCode());
+      euclideanTrajectory.getFrameInformation().setDataReferenceFrameId(worldFrame.getFrameNameHashCode());
+
+      Object<EuclideanTrajectoryPointMessage> taskspaceTrajectoryPoints = euclideanTrajectory.getTaskspaceTrajectoryPoints();
+      taskspaceTrajectoryPoints.clear();
+
+      packEuclideanTrajectoryPointMessage(trajectoryTime, desiredPose.getPosition(), desiredSpatialVelocity.getLinearPart(), taskspaceTrajectoryPoints.add());
+   }
+
    public void computeFootTrajectoryMessages()
    {
       for (RobotSide robotSide : RobotSide.values)
@@ -379,6 +401,16 @@ public class KinematicsToolboxOutputConverter
       messageToPack.getOrientation().set(pose.getOrientation());
       messageToPack.getLinearVelocity().set(spatialVelocity.getLinearPart());
       messageToPack.getAngularVelocity().set(spatialVelocity.getAngularPart());
+   }
+
+   public static void packEuclideanTrajectoryPointMessage(double time,
+                                                          Point3DReadOnly position,
+                                                          FrameVector3DReadOnly linearVelocity,
+                                                          EuclideanTrajectoryPointMessage messageToPack)
+   {
+      messageToPack.setTime(time);
+      messageToPack.getPosition().set(position);
+      messageToPack.getLinearVelocity().set(linearVelocity);
    }
 
    public FullHumanoidRobotModel getFullRobotModel()

--- a/ihmc-interfaces/src/main/generated-idl/controller_msgs/msg/WholeBodyStreamingMessage_.idl
+++ b/ihmc-interfaces/src/main/generated-idl/controller_msgs/msg/WholeBodyStreamingMessage_.idl
@@ -2,6 +2,7 @@
 #define __controller_msgs__msg__WholeBodyStreamingMessage__idl__
 
 #include "controller_msgs/msg/./JointspaceStreamingMessage_.idl"
+#include "ihmc_common_msgs/msg/./EuclideanStreamingMessage_.idl"
 #include "ihmc_common_msgs/msg/./SE3StreamingMessage_.idl"
 #include "ihmc_common_msgs/msg/./SO3StreamingMessage_.idl"
 module controller_msgs
@@ -67,6 +68,11 @@ module controller_msgs
          */
         boolean enable_user_pelvis_control;
         ihmc_common_msgs::msg::dds::SE3StreamingMessage pelvis_streaming_message;
+        /**
+         * Information for the CoM
+         */
+        boolean has_center_of_mass_trajectory_message;
+        ihmc_common_msgs::msg::dds::EuclideanStreamingMessage center_of_mass_trajectory_message;
         /**
          * Information for the neck joints
          */

--- a/ihmc-interfaces/src/main/generated-idl/controller_msgs/msg/WholeBodyTrajectoryMessage_.idl
+++ b/ihmc-interfaces/src/main/generated-idl/controller_msgs/msg/WholeBodyTrajectoryMessage_.idl
@@ -2,6 +2,7 @@
 #define __controller_msgs__msg__WholeBodyTrajectoryMessage__idl__
 
 #include "controller_msgs/msg/./ArmTrajectoryMessage_.idl"
+#include "controller_msgs/msg/./CenterOfMassTrajectoryMessage_.idl"
 #include "controller_msgs/msg/./ChestTrajectoryMessage_.idl"
 #include "controller_msgs/msg/./FootTrajectoryMessage_.idl"
 #include "controller_msgs/msg/./HandTrajectoryMessage_.idl"
@@ -80,6 +81,10 @@ module controller_msgs
          * Trajectory for the head
          */
         controller_msgs::msg::dds::HeadTrajectoryMessage head_trajectory_message;
+        /**
+         * Trajectory for the CoM
+         */
+        controller_msgs::msg::dds::CenterOfMassTrajectoryMessage center_of_mass_trajectory_message;
       };
     };
   };

--- a/ihmc-interfaces/src/main/generated-idl/ihmc_common_msgs/msg/EuclideanStreamingMessage_.idl
+++ b/ihmc-interfaces/src/main/generated-idl/ihmc_common_msgs/msg/EuclideanStreamingMessage_.idl
@@ -30,13 +30,17 @@ module ihmc_common_msgs
          */
         geometry_msgs::msg::dds::Pose control_frame_pose;
         /**
-         * Define the desired 3D position to be reached.
+         * Define the desired 3D position, expressed in world frame, to be reached.
          */
         geometry_msgs::msg::dds::Point position;
         /**
-         * Define the desired 3D linear velocity to be reached.
+         * Define the desired 3D linear velocity, expressed in world frame, to be reached.
          */
         geometry_msgs::msg::dds::Vector3 linear_velocity;
+        /**
+         * Define the desired 3D linear acceleration, expressed in world frame, to be reached.
+         */
+        geometry_msgs::msg::dds::Vector3 linear_acceleration;
       };
     };
   };

--- a/ihmc-interfaces/src/main/generated-idl/toolbox_msgs/msg/KinematicsStreamingToolboxConfigurationMessage_.idl
+++ b/ihmc-interfaces/src/main/generated-idl/toolbox_msgs/msg/KinematicsStreamingToolboxConfigurationMessage_.idl
@@ -77,6 +77,11 @@ module toolbox_msgs
         @defaultValue(value=True)
         boolean enable_pelvis_taskspace;
         /**
+         * Whether center of mass should be controlled.
+         * Default value is false.
+         */
+        boolean enable_center_of_mass_control;
+        /**
          * Reference frame in which the controller should be tracking the pose for the left hand as computed by the whole-body IK.
          * Default value is WORLD_FRAME, see FrameInformation for useful frame ids.
          */

--- a/ihmc-interfaces/src/main/generated-java/controller_msgs/msg/dds/WholeBodyStreamingMessage.java
+++ b/ihmc-interfaces/src/main/generated-java/controller_msgs/msg/dds/WholeBodyStreamingMessage.java
@@ -62,6 +62,11 @@ public class WholeBodyStreamingMessage extends Packet<WholeBodyStreamingMessage>
    public boolean enable_user_pelvis_control_;
    public ihmc_common_msgs.msg.dds.SE3StreamingMessage pelvis_streaming_message_;
    /**
+            * Information for the CoM
+            */
+   public boolean has_center_of_mass_trajectory_message_;
+   public ihmc_common_msgs.msg.dds.EuclideanStreamingMessage center_of_mass_trajectory_message_;
+   /**
             * Information for the neck joints
             */
    public boolean has_neck_streaming_message_;
@@ -75,6 +80,7 @@ public class WholeBodyStreamingMessage extends Packet<WholeBodyStreamingMessage>
       right_arm_streaming_message_ = new controller_msgs.msg.dds.JointspaceStreamingMessage();
       chest_streaming_message_ = new ihmc_common_msgs.msg.dds.SO3StreamingMessage();
       pelvis_streaming_message_ = new ihmc_common_msgs.msg.dds.SE3StreamingMessage();
+      center_of_mass_trajectory_message_ = new ihmc_common_msgs.msg.dds.EuclideanStreamingMessage();
       neck_streaming_message_ = new controller_msgs.msg.dds.JointspaceStreamingMessage();
    }
 
@@ -112,6 +118,9 @@ public class WholeBodyStreamingMessage extends Packet<WholeBodyStreamingMessage>
       enable_user_pelvis_control_ = other.enable_user_pelvis_control_;
 
       ihmc_common_msgs.msg.dds.SE3StreamingMessagePubSubType.staticCopy(other.pelvis_streaming_message_, pelvis_streaming_message_);
+      has_center_of_mass_trajectory_message_ = other.has_center_of_mass_trajectory_message_;
+
+      ihmc_common_msgs.msg.dds.EuclideanStreamingMessagePubSubType.staticCopy(other.center_of_mass_trajectory_message_, center_of_mass_trajectory_message_);
       has_neck_streaming_message_ = other.has_neck_streaming_message_;
 
       controller_msgs.msg.dds.JointspaceStreamingMessagePubSubType.staticCopy(other.neck_streaming_message_, neck_streaming_message_);
@@ -310,6 +319,27 @@ public class WholeBodyStreamingMessage extends Packet<WholeBodyStreamingMessage>
    }
 
    /**
+            * Information for the CoM
+            */
+   public void setHasCenterOfMassTrajectoryMessage(boolean has_center_of_mass_trajectory_message)
+   {
+      has_center_of_mass_trajectory_message_ = has_center_of_mass_trajectory_message;
+   }
+   /**
+            * Information for the CoM
+            */
+   public boolean getHasCenterOfMassTrajectoryMessage()
+   {
+      return has_center_of_mass_trajectory_message_;
+   }
+
+
+   public ihmc_common_msgs.msg.dds.EuclideanStreamingMessage getCenterOfMassTrajectoryMessage()
+   {
+      return center_of_mass_trajectory_message_;
+   }
+
+   /**
             * Information for the neck joints
             */
    public void setHasNeckStreamingMessage(boolean has_neck_streaming_message)
@@ -374,6 +404,9 @@ public class WholeBodyStreamingMessage extends Packet<WholeBodyStreamingMessage>
       if (!us.ihmc.idl.IDLTools.epsilonEqualsBoolean(this.enable_user_pelvis_control_, other.enable_user_pelvis_control_, epsilon)) return false;
 
       if (!this.pelvis_streaming_message_.epsilonEquals(other.pelvis_streaming_message_, epsilon)) return false;
+      if (!us.ihmc.idl.IDLTools.epsilonEqualsBoolean(this.has_center_of_mass_trajectory_message_, other.has_center_of_mass_trajectory_message_, epsilon)) return false;
+
+      if (!this.center_of_mass_trajectory_message_.epsilonEquals(other.center_of_mass_trajectory_message_, epsilon)) return false;
       if (!us.ihmc.idl.IDLTools.epsilonEqualsBoolean(this.has_neck_streaming_message_, other.has_neck_streaming_message_, epsilon)) return false;
 
       if (!this.neck_streaming_message_.epsilonEquals(other.neck_streaming_message_, epsilon)) return false;
@@ -416,6 +449,9 @@ public class WholeBodyStreamingMessage extends Packet<WholeBodyStreamingMessage>
       if(this.enable_user_pelvis_control_ != otherMyClass.enable_user_pelvis_control_) return false;
 
       if (!this.pelvis_streaming_message_.equals(otherMyClass.pelvis_streaming_message_)) return false;
+      if(this.has_center_of_mass_trajectory_message_ != otherMyClass.has_center_of_mass_trajectory_message_) return false;
+
+      if (!this.center_of_mass_trajectory_message_.equals(otherMyClass.center_of_mass_trajectory_message_)) return false;
       if(this.has_neck_streaming_message_ != otherMyClass.has_neck_streaming_message_) return false;
 
       if (!this.neck_streaming_message_.equals(otherMyClass.neck_streaming_message_)) return false;
@@ -461,6 +497,10 @@ public class WholeBodyStreamingMessage extends Packet<WholeBodyStreamingMessage>
       builder.append(this.enable_user_pelvis_control_);      builder.append(", ");
       builder.append("pelvis_streaming_message=");
       builder.append(this.pelvis_streaming_message_);      builder.append(", ");
+      builder.append("has_center_of_mass_trajectory_message=");
+      builder.append(this.has_center_of_mass_trajectory_message_);      builder.append(", ");
+      builder.append("center_of_mass_trajectory_message=");
+      builder.append(this.center_of_mass_trajectory_message_);      builder.append(", ");
       builder.append("has_neck_streaming_message=");
       builder.append(this.has_neck_streaming_message_);      builder.append(", ");
       builder.append("neck_streaming_message=");

--- a/ihmc-interfaces/src/main/generated-java/controller_msgs/msg/dds/WholeBodyStreamingMessagePubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/controller_msgs/msg/dds/WholeBodyStreamingMessagePubSubType.java
@@ -15,7 +15,7 @@ public class WholeBodyStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
    @Override
    public final java.lang.String getDefinitionChecksum()
    {
-   		return "649905c27e24fb3e73d77ff49867be3a4744d4d8dc1b536d1e9f7f11a192c6d5";
+   		return "2bc0b69b27903f8c287db6257198a34daf6af535f33de7ea2a0ff6e140f4aad3";
    }
    
    @Override
@@ -86,6 +86,10 @@ public class WholeBodyStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
 
       current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
 
+      current_alignment += ihmc_common_msgs.msg.dds.EuclideanStreamingMessagePubSubType.getMaxCdrSerializedSize(current_alignment);
+
+      current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
+
       current_alignment += controller_msgs.msg.dds.JointspaceStreamingMessagePubSubType.getMaxCdrSerializedSize(current_alignment);
 
 
@@ -146,6 +150,11 @@ public class WholeBodyStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
       current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
 
 
+      current_alignment += ihmc_common_msgs.msg.dds.EuclideanStreamingMessagePubSubType.getCdrSerializedSize(data.getCenterOfMassTrajectoryMessage(), current_alignment);
+
+      current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
+
+
       current_alignment += controller_msgs.msg.dds.JointspaceStreamingMessagePubSubType.getCdrSerializedSize(data.getNeckStreamingMessage(), current_alignment);
 
 
@@ -180,6 +189,9 @@ public class WholeBodyStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
       cdr.write_type_7(data.getEnableUserPelvisControl());
 
       ihmc_common_msgs.msg.dds.SE3StreamingMessagePubSubType.write(data.getPelvisStreamingMessage(), cdr);
+      cdr.write_type_7(data.getHasCenterOfMassTrajectoryMessage());
+
+      ihmc_common_msgs.msg.dds.EuclideanStreamingMessagePubSubType.write(data.getCenterOfMassTrajectoryMessage(), cdr);
       cdr.write_type_7(data.getHasNeckStreamingMessage());
 
       controller_msgs.msg.dds.JointspaceStreamingMessagePubSubType.write(data.getNeckStreamingMessage(), cdr);
@@ -213,6 +225,9 @@ public class WholeBodyStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
       data.setEnableUserPelvisControl(cdr.read_type_7());
       	
       ihmc_common_msgs.msg.dds.SE3StreamingMessagePubSubType.read(data.getPelvisStreamingMessage(), cdr);	
+      data.setHasCenterOfMassTrajectoryMessage(cdr.read_type_7());
+      	
+      ihmc_common_msgs.msg.dds.EuclideanStreamingMessagePubSubType.read(data.getCenterOfMassTrajectoryMessage(), cdr);	
       data.setHasNeckStreamingMessage(cdr.read_type_7());
       	
       controller_msgs.msg.dds.JointspaceStreamingMessagePubSubType.read(data.getNeckStreamingMessage(), cdr);	
@@ -244,6 +259,9 @@ public class WholeBodyStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
       ser.write_type_7("enable_user_pelvis_control", data.getEnableUserPelvisControl());
       ser.write_type_a("pelvis_streaming_message", new ihmc_common_msgs.msg.dds.SE3StreamingMessagePubSubType(), data.getPelvisStreamingMessage());
 
+      ser.write_type_7("has_center_of_mass_trajectory_message", data.getHasCenterOfMassTrajectoryMessage());
+      ser.write_type_a("center_of_mass_trajectory_message", new ihmc_common_msgs.msg.dds.EuclideanStreamingMessagePubSubType(), data.getCenterOfMassTrajectoryMessage());
+
       ser.write_type_7("has_neck_streaming_message", data.getHasNeckStreamingMessage());
       ser.write_type_a("neck_streaming_message", new controller_msgs.msg.dds.JointspaceStreamingMessagePubSubType(), data.getNeckStreamingMessage());
 
@@ -273,6 +291,9 @@ public class WholeBodyStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
       data.setHasPelvisStreamingMessage(ser.read_type_7("has_pelvis_streaming_message"));
       data.setEnableUserPelvisControl(ser.read_type_7("enable_user_pelvis_control"));
       ser.read_type_a("pelvis_streaming_message", new ihmc_common_msgs.msg.dds.SE3StreamingMessagePubSubType(), data.getPelvisStreamingMessage());
+
+      data.setHasCenterOfMassTrajectoryMessage(ser.read_type_7("has_center_of_mass_trajectory_message"));
+      ser.read_type_a("center_of_mass_trajectory_message", new ihmc_common_msgs.msg.dds.EuclideanStreamingMessagePubSubType(), data.getCenterOfMassTrajectoryMessage());
 
       data.setHasNeckStreamingMessage(ser.read_type_7("has_neck_streaming_message"));
       ser.read_type_a("neck_streaming_message", new controller_msgs.msg.dds.JointspaceStreamingMessagePubSubType(), data.getNeckStreamingMessage());

--- a/ihmc-interfaces/src/main/generated-java/controller_msgs/msg/dds/WholeBodyTrajectoryMessage.java
+++ b/ihmc-interfaces/src/main/generated-java/controller_msgs/msg/dds/WholeBodyTrajectoryMessage.java
@@ -68,6 +68,10 @@ public class WholeBodyTrajectoryMessage extends Packet<WholeBodyTrajectoryMessag
             * Trajectory for the head
             */
    public controller_msgs.msg.dds.HeadTrajectoryMessage head_trajectory_message_;
+   /**
+            * Trajectory for the CoM
+            */
+   public controller_msgs.msg.dds.CenterOfMassTrajectoryMessage center_of_mass_trajectory_message_;
 
    public WholeBodyTrajectoryMessage()
    {
@@ -84,6 +88,7 @@ public class WholeBodyTrajectoryMessage extends Packet<WholeBodyTrajectoryMessag
       right_leg_trajectory_message_ = new controller_msgs.msg.dds.LegTrajectoryMessage();
       neck_trajectory_message_ = new controller_msgs.msg.dds.NeckTrajectoryMessage();
       head_trajectory_message_ = new controller_msgs.msg.dds.HeadTrajectoryMessage();
+      center_of_mass_trajectory_message_ = new controller_msgs.msg.dds.CenterOfMassTrajectoryMessage();
    }
 
    public WholeBodyTrajectoryMessage(WholeBodyTrajectoryMessage other)
@@ -109,6 +114,7 @@ public class WholeBodyTrajectoryMessage extends Packet<WholeBodyTrajectoryMessag
       controller_msgs.msg.dds.LegTrajectoryMessagePubSubType.staticCopy(other.right_leg_trajectory_message_, right_leg_trajectory_message_);
       controller_msgs.msg.dds.NeckTrajectoryMessagePubSubType.staticCopy(other.neck_trajectory_message_, neck_trajectory_message_);
       controller_msgs.msg.dds.HeadTrajectoryMessagePubSubType.staticCopy(other.head_trajectory_message_, head_trajectory_message_);
+      controller_msgs.msg.dds.CenterOfMassTrajectoryMessagePubSubType.staticCopy(other.center_of_mass_trajectory_message_, center_of_mass_trajectory_message_);
    }
 
    /**
@@ -244,6 +250,15 @@ public class WholeBodyTrajectoryMessage extends Packet<WholeBodyTrajectoryMessag
    }
 
 
+   /**
+            * Trajectory for the CoM
+            */
+   public controller_msgs.msg.dds.CenterOfMassTrajectoryMessage getCenterOfMassTrajectoryMessage()
+   {
+      return center_of_mass_trajectory_message_;
+   }
+
+
    public static Supplier<WholeBodyTrajectoryMessagePubSubType> getPubSubType()
    {
       return WholeBodyTrajectoryMessagePubSubType::new;
@@ -276,6 +291,7 @@ public class WholeBodyTrajectoryMessage extends Packet<WholeBodyTrajectoryMessag
       if (!this.right_leg_trajectory_message_.epsilonEquals(other.right_leg_trajectory_message_, epsilon)) return false;
       if (!this.neck_trajectory_message_.epsilonEquals(other.neck_trajectory_message_, epsilon)) return false;
       if (!this.head_trajectory_message_.epsilonEquals(other.head_trajectory_message_, epsilon)) return false;
+      if (!this.center_of_mass_trajectory_message_.epsilonEquals(other.center_of_mass_trajectory_message_, epsilon)) return false;
 
       return true;
    }
@@ -304,6 +320,7 @@ public class WholeBodyTrajectoryMessage extends Packet<WholeBodyTrajectoryMessag
       if (!this.right_leg_trajectory_message_.equals(otherMyClass.right_leg_trajectory_message_)) return false;
       if (!this.neck_trajectory_message_.equals(otherMyClass.neck_trajectory_message_)) return false;
       if (!this.head_trajectory_message_.equals(otherMyClass.head_trajectory_message_)) return false;
+      if (!this.center_of_mass_trajectory_message_.equals(otherMyClass.center_of_mass_trajectory_message_)) return false;
 
       return true;
    }
@@ -341,7 +358,9 @@ public class WholeBodyTrajectoryMessage extends Packet<WholeBodyTrajectoryMessag
       builder.append("neck_trajectory_message=");
       builder.append(this.neck_trajectory_message_);      builder.append(", ");
       builder.append("head_trajectory_message=");
-      builder.append(this.head_trajectory_message_);
+      builder.append(this.head_trajectory_message_);      builder.append(", ");
+      builder.append("center_of_mass_trajectory_message=");
+      builder.append(this.center_of_mass_trajectory_message_);
       builder.append("}");
       return builder.toString();
    }

--- a/ihmc-interfaces/src/main/generated-java/controller_msgs/msg/dds/WholeBodyTrajectoryMessagePubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/controller_msgs/msg/dds/WholeBodyTrajectoryMessagePubSubType.java
@@ -15,7 +15,7 @@ public class WholeBodyTrajectoryMessagePubSubType implements us.ihmc.pubsub.Topi
    @Override
    public final java.lang.String getDefinitionChecksum()
    {
-   		return "cea61ce82fca486915eb1265c9a0ddcc401968cf6a156d157dd5c6e6b31c2bf1";
+   		return "39fc419efb1bbde0721677c6492bf6a15072ee537b1251b76273d34d13852c35";
    }
    
    @Override
@@ -80,6 +80,8 @@ public class WholeBodyTrajectoryMessagePubSubType implements us.ihmc.pubsub.Topi
 
       current_alignment += controller_msgs.msg.dds.HeadTrajectoryMessagePubSubType.getMaxCdrSerializedSize(current_alignment);
 
+      current_alignment += controller_msgs.msg.dds.CenterOfMassTrajectoryMessagePubSubType.getMaxCdrSerializedSize(current_alignment);
+
 
       return current_alignment - initial_alignment;
    }
@@ -122,6 +124,8 @@ public class WholeBodyTrajectoryMessagePubSubType implements us.ihmc.pubsub.Topi
 
       current_alignment += controller_msgs.msg.dds.HeadTrajectoryMessagePubSubType.getCdrSerializedSize(data.getHeadTrajectoryMessage(), current_alignment);
 
+      current_alignment += controller_msgs.msg.dds.CenterOfMassTrajectoryMessagePubSubType.getCdrSerializedSize(data.getCenterOfMassTrajectoryMessage(), current_alignment);
+
 
       return current_alignment - initial_alignment;
    }
@@ -143,6 +147,7 @@ public class WholeBodyTrajectoryMessagePubSubType implements us.ihmc.pubsub.Topi
       controller_msgs.msg.dds.LegTrajectoryMessagePubSubType.write(data.getRightLegTrajectoryMessage(), cdr);
       controller_msgs.msg.dds.NeckTrajectoryMessagePubSubType.write(data.getNeckTrajectoryMessage(), cdr);
       controller_msgs.msg.dds.HeadTrajectoryMessagePubSubType.write(data.getHeadTrajectoryMessage(), cdr);
+      controller_msgs.msg.dds.CenterOfMassTrajectoryMessagePubSubType.write(data.getCenterOfMassTrajectoryMessage(), cdr);
    }
 
    public static void read(controller_msgs.msg.dds.WholeBodyTrajectoryMessage data, us.ihmc.idl.CDR cdr)
@@ -162,6 +167,7 @@ public class WholeBodyTrajectoryMessagePubSubType implements us.ihmc.pubsub.Topi
       controller_msgs.msg.dds.LegTrajectoryMessagePubSubType.read(data.getRightLegTrajectoryMessage(), cdr);	
       controller_msgs.msg.dds.NeckTrajectoryMessagePubSubType.read(data.getNeckTrajectoryMessage(), cdr);	
       controller_msgs.msg.dds.HeadTrajectoryMessagePubSubType.read(data.getHeadTrajectoryMessage(), cdr);	
+      controller_msgs.msg.dds.CenterOfMassTrajectoryMessagePubSubType.read(data.getCenterOfMassTrajectoryMessage(), cdr);	
 
    }
 
@@ -195,6 +201,8 @@ public class WholeBodyTrajectoryMessagePubSubType implements us.ihmc.pubsub.Topi
 
       ser.write_type_a("head_trajectory_message", new controller_msgs.msg.dds.HeadTrajectoryMessagePubSubType(), data.getHeadTrajectoryMessage());
 
+      ser.write_type_a("center_of_mass_trajectory_message", new controller_msgs.msg.dds.CenterOfMassTrajectoryMessagePubSubType(), data.getCenterOfMassTrajectoryMessage());
+
    }
 
    @Override
@@ -226,6 +234,8 @@ public class WholeBodyTrajectoryMessagePubSubType implements us.ihmc.pubsub.Topi
       ser.read_type_a("neck_trajectory_message", new controller_msgs.msg.dds.NeckTrajectoryMessagePubSubType(), data.getNeckTrajectoryMessage());
 
       ser.read_type_a("head_trajectory_message", new controller_msgs.msg.dds.HeadTrajectoryMessagePubSubType(), data.getHeadTrajectoryMessage());
+
+      ser.read_type_a("center_of_mass_trajectory_message", new controller_msgs.msg.dds.CenterOfMassTrajectoryMessagePubSubType(), data.getCenterOfMassTrajectoryMessage());
 
    }
 

--- a/ihmc-interfaces/src/main/generated-java/ihmc_common_msgs/msg/dds/EuclideanStreamingMessage.java
+++ b/ihmc-interfaces/src/main/generated-java/ihmc_common_msgs/msg/dds/EuclideanStreamingMessage.java
@@ -23,13 +23,17 @@ public class EuclideanStreamingMessage extends Packet<EuclideanStreamingMessage>
             */
    public us.ihmc.euclid.geometry.Pose3D control_frame_pose_;
    /**
-            * Define the desired 3D position to be reached.
+            * Define the desired 3D position, expressed in world frame, to be reached.
             */
    public us.ihmc.euclid.tuple3D.Point3D position_;
    /**
-            * Define the desired 3D linear velocity to be reached.
+            * Define the desired 3D linear velocity, expressed in world frame, to be reached.
             */
    public us.ihmc.euclid.tuple3D.Vector3D linear_velocity_;
+   /**
+            * Define the desired 3D linear acceleration, expressed in world frame, to be reached.
+            */
+   public us.ihmc.euclid.tuple3D.Vector3D linear_acceleration_;
 
    public EuclideanStreamingMessage()
    {
@@ -37,6 +41,7 @@ public class EuclideanStreamingMessage extends Packet<EuclideanStreamingMessage>
       control_frame_pose_ = new us.ihmc.euclid.geometry.Pose3D();
       position_ = new us.ihmc.euclid.tuple3D.Point3D();
       linear_velocity_ = new us.ihmc.euclid.tuple3D.Vector3D();
+      linear_acceleration_ = new us.ihmc.euclid.tuple3D.Vector3D();
    }
 
    public EuclideanStreamingMessage(EuclideanStreamingMessage other)
@@ -53,6 +58,7 @@ public class EuclideanStreamingMessage extends Packet<EuclideanStreamingMessage>
       geometry_msgs.msg.dds.PosePubSubType.staticCopy(other.control_frame_pose_, control_frame_pose_);
       geometry_msgs.msg.dds.PointPubSubType.staticCopy(other.position_, position_);
       geometry_msgs.msg.dds.Vector3PubSubType.staticCopy(other.linear_velocity_, linear_velocity_);
+      geometry_msgs.msg.dds.Vector3PubSubType.staticCopy(other.linear_acceleration_, linear_acceleration_);
    }
 
 
@@ -88,7 +94,7 @@ public class EuclideanStreamingMessage extends Packet<EuclideanStreamingMessage>
 
 
    /**
-            * Define the desired 3D position to be reached.
+            * Define the desired 3D position, expressed in world frame, to be reached.
             */
    public us.ihmc.euclid.tuple3D.Point3D getPosition()
    {
@@ -97,11 +103,20 @@ public class EuclideanStreamingMessage extends Packet<EuclideanStreamingMessage>
 
 
    /**
-            * Define the desired 3D linear velocity to be reached.
+            * Define the desired 3D linear velocity, expressed in world frame, to be reached.
             */
    public us.ihmc.euclid.tuple3D.Vector3D getLinearVelocity()
    {
       return linear_velocity_;
+   }
+
+
+   /**
+            * Define the desired 3D linear acceleration, expressed in world frame, to be reached.
+            */
+   public us.ihmc.euclid.tuple3D.Vector3D getLinearAcceleration()
+   {
+      return linear_acceleration_;
    }
 
 
@@ -128,6 +143,7 @@ public class EuclideanStreamingMessage extends Packet<EuclideanStreamingMessage>
       if (!this.control_frame_pose_.epsilonEquals(other.control_frame_pose_, epsilon)) return false;
       if (!this.position_.epsilonEquals(other.position_, epsilon)) return false;
       if (!this.linear_velocity_.epsilonEquals(other.linear_velocity_, epsilon)) return false;
+      if (!this.linear_acceleration_.epsilonEquals(other.linear_acceleration_, epsilon)) return false;
 
       return true;
    }
@@ -147,6 +163,7 @@ public class EuclideanStreamingMessage extends Packet<EuclideanStreamingMessage>
       if (!this.control_frame_pose_.equals(otherMyClass.control_frame_pose_)) return false;
       if (!this.position_.equals(otherMyClass.position_)) return false;
       if (!this.linear_velocity_.equals(otherMyClass.linear_velocity_)) return false;
+      if (!this.linear_acceleration_.equals(otherMyClass.linear_acceleration_)) return false;
 
       return true;
    }
@@ -166,7 +183,9 @@ public class EuclideanStreamingMessage extends Packet<EuclideanStreamingMessage>
       builder.append("position=");
       builder.append(this.position_);      builder.append(", ");
       builder.append("linear_velocity=");
-      builder.append(this.linear_velocity_);
+      builder.append(this.linear_velocity_);      builder.append(", ");
+      builder.append("linear_acceleration=");
+      builder.append(this.linear_acceleration_);
       builder.append("}");
       return builder.toString();
    }

--- a/ihmc-interfaces/src/main/generated-java/ihmc_common_msgs/msg/dds/EuclideanStreamingMessagePubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/ihmc_common_msgs/msg/dds/EuclideanStreamingMessagePubSubType.java
@@ -15,7 +15,7 @@ public class EuclideanStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
    @Override
    public final java.lang.String getDefinitionChecksum()
    {
-   		return "81d04be4ae512d97ae0d2f7408ab01efae887afcddda97d534a85923f690b1a0";
+   		return "0db68034bf81995f60c1709e965459149dc13a9703ed84245a87bda7147a9c55";
    }
    
    @Override
@@ -62,6 +62,8 @@ public class EuclideanStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
 
       current_alignment += geometry_msgs.msg.dds.Vector3PubSubType.getMaxCdrSerializedSize(current_alignment);
 
+      current_alignment += geometry_msgs.msg.dds.Vector3PubSubType.getMaxCdrSerializedSize(current_alignment);
+
 
       return current_alignment - initial_alignment;
    }
@@ -86,6 +88,8 @@ public class EuclideanStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
 
       current_alignment += geometry_msgs.msg.dds.Vector3PubSubType.getCdrSerializedSize(data.getLinearVelocity(), current_alignment);
 
+      current_alignment += geometry_msgs.msg.dds.Vector3PubSubType.getCdrSerializedSize(data.getLinearAcceleration(), current_alignment);
+
 
       return current_alignment - initial_alignment;
    }
@@ -98,6 +102,7 @@ public class EuclideanStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
       geometry_msgs.msg.dds.PosePubSubType.write(data.getControlFramePose(), cdr);
       geometry_msgs.msg.dds.PointPubSubType.write(data.getPosition(), cdr);
       geometry_msgs.msg.dds.Vector3PubSubType.write(data.getLinearVelocity(), cdr);
+      geometry_msgs.msg.dds.Vector3PubSubType.write(data.getLinearAcceleration(), cdr);
    }
 
    public static void read(ihmc_common_msgs.msg.dds.EuclideanStreamingMessage data, us.ihmc.idl.CDR cdr)
@@ -108,6 +113,7 @@ public class EuclideanStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
       geometry_msgs.msg.dds.PosePubSubType.read(data.getControlFramePose(), cdr);	
       geometry_msgs.msg.dds.PointPubSubType.read(data.getPosition(), cdr);	
       geometry_msgs.msg.dds.Vector3PubSubType.read(data.getLinearVelocity(), cdr);	
+      geometry_msgs.msg.dds.Vector3PubSubType.read(data.getLinearAcceleration(), cdr);	
 
    }
 
@@ -123,6 +129,8 @@ public class EuclideanStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
 
       ser.write_type_a("linear_velocity", new geometry_msgs.msg.dds.Vector3PubSubType(), data.getLinearVelocity());
 
+      ser.write_type_a("linear_acceleration", new geometry_msgs.msg.dds.Vector3PubSubType(), data.getLinearAcceleration());
+
    }
 
    @Override
@@ -136,6 +144,8 @@ public class EuclideanStreamingMessagePubSubType implements us.ihmc.pubsub.Topic
       ser.read_type_a("position", new geometry_msgs.msg.dds.PointPubSubType(), data.getPosition());
 
       ser.read_type_a("linear_velocity", new geometry_msgs.msg.dds.Vector3PubSubType(), data.getLinearVelocity());
+
+      ser.read_type_a("linear_acceleration", new geometry_msgs.msg.dds.Vector3PubSubType(), data.getLinearAcceleration());
 
    }
 

--- a/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/KinematicsPlanningToolboxOutputStatusPubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/KinematicsPlanningToolboxOutputStatusPubSubType.java
@@ -15,7 +15,7 @@ public class KinematicsPlanningToolboxOutputStatusPubSubType implements us.ihmc.
    @Override
    public final java.lang.String getDefinitionChecksum()
    {
-   		return "b7150431167c7d4df1ade321a9c59b1dee99ad51a43599253eeddead54fa96fc";
+   		return "a503326897dee5045f25aa53a759d78ab1301ea0b64e652c49ff3c85ee497579";
    }
    
    @Override

--- a/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/KinematicsStreamingToolboxConfigurationMessage.java
+++ b/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/KinematicsStreamingToolboxConfigurationMessage.java
@@ -67,6 +67,11 @@ public class KinematicsStreamingToolboxConfigurationMessage extends Packet<Kinem
             */
    public boolean enable_pelvis_taskspace_ = true;
    /**
+            * Whether center of mass should be controlled.
+            * Default value is false.
+            */
+   public boolean enable_center_of_mass_control_;
+   /**
             * Reference frame in which the controller should be tracking the pose for the left hand as computed by the whole-body IK.
             * Default value is WORLD_FRAME, see FrameInformation for useful frame ids.
             */
@@ -118,6 +123,8 @@ public class KinematicsStreamingToolboxConfigurationMessage extends Packet<Kinem
       enable_chest_taskspace_ = other.enable_chest_taskspace_;
 
       enable_pelvis_taskspace_ = other.enable_pelvis_taskspace_;
+
+      enable_center_of_mass_control_ = other.enable_center_of_mass_control_;
 
       left_hand_trajectory_frame_id_ = other.left_hand_trajectory_frame_id_;
 
@@ -308,6 +315,23 @@ public class KinematicsStreamingToolboxConfigurationMessage extends Packet<Kinem
    }
 
    /**
+            * Whether center of mass should be controlled.
+            * Default value is false.
+            */
+   public void setEnableCenterOfMassControl(boolean enable_center_of_mass_control)
+   {
+      enable_center_of_mass_control_ = enable_center_of_mass_control;
+   }
+   /**
+            * Whether center of mass should be controlled.
+            * Default value is false.
+            */
+   public boolean getEnableCenterOfMassControl()
+   {
+      return enable_center_of_mass_control_;
+   }
+
+   /**
             * Reference frame in which the controller should be tracking the pose for the left hand as computed by the whole-body IK.
             * Default value is WORLD_FRAME, see FrameInformation for useful frame ids.
             */
@@ -413,6 +437,8 @@ public class KinematicsStreamingToolboxConfigurationMessage extends Packet<Kinem
 
       if (!us.ihmc.idl.IDLTools.epsilonEqualsBoolean(this.enable_pelvis_taskspace_, other.enable_pelvis_taskspace_, epsilon)) return false;
 
+      if (!us.ihmc.idl.IDLTools.epsilonEqualsBoolean(this.enable_center_of_mass_control_, other.enable_center_of_mass_control_, epsilon)) return false;
+
       if (!us.ihmc.idl.IDLTools.epsilonEqualsPrimitive(this.left_hand_trajectory_frame_id_, other.left_hand_trajectory_frame_id_, epsilon)) return false;
 
       if (!us.ihmc.idl.IDLTools.epsilonEqualsPrimitive(this.right_hand_trajectory_frame_id_, other.right_hand_trajectory_frame_id_, epsilon)) return false;
@@ -454,6 +480,8 @@ public class KinematicsStreamingToolboxConfigurationMessage extends Packet<Kinem
 
       if(this.enable_pelvis_taskspace_ != otherMyClass.enable_pelvis_taskspace_) return false;
 
+      if(this.enable_center_of_mass_control_ != otherMyClass.enable_center_of_mass_control_) return false;
+
       if(this.left_hand_trajectory_frame_id_ != otherMyClass.left_hand_trajectory_frame_id_) return false;
 
       if(this.right_hand_trajectory_frame_id_ != otherMyClass.right_hand_trajectory_frame_id_) return false;
@@ -492,6 +520,8 @@ public class KinematicsStreamingToolboxConfigurationMessage extends Packet<Kinem
       builder.append(this.enable_chest_taskspace_);      builder.append(", ");
       builder.append("enable_pelvis_taskspace=");
       builder.append(this.enable_pelvis_taskspace_);      builder.append(", ");
+      builder.append("enable_center_of_mass_control=");
+      builder.append(this.enable_center_of_mass_control_);      builder.append(", ");
       builder.append("left_hand_trajectory_frame_id=");
       builder.append(this.left_hand_trajectory_frame_id_);      builder.append(", ");
       builder.append("right_hand_trajectory_frame_id=");

--- a/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/KinematicsStreamingToolboxConfigurationMessagePubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/KinematicsStreamingToolboxConfigurationMessagePubSubType.java
@@ -15,7 +15,7 @@ public class KinematicsStreamingToolboxConfigurationMessagePubSubType implements
    @Override
    public final java.lang.String getDefinitionChecksum()
    {
-   		return "d51bf2c63f634f7397e40ed2d51858204b851ed2c9642464683ce4b2e2267551";
+   		return "12c19c5d8e16609b02d593cfb2510fa58c63822608160d642a0f31a98d898293";
    }
    
    @Override
@@ -53,6 +53,8 @@ public class KinematicsStreamingToolboxConfigurationMessagePubSubType implements
       int initial_alignment = current_alignment;
 
       current_alignment += 8 + us.ihmc.idl.CDR.alignment(current_alignment, 8);
+
+      current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
 
       current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
 
@@ -123,6 +125,9 @@ public class KinematicsStreamingToolboxConfigurationMessagePubSubType implements
       current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
 
 
+      current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
+
+
       current_alignment += 8 + us.ihmc.idl.CDR.alignment(current_alignment, 8);
 
 
@@ -161,6 +166,8 @@ public class KinematicsStreamingToolboxConfigurationMessagePubSubType implements
 
       cdr.write_type_7(data.getEnablePelvisTaskspace());
 
+      cdr.write_type_7(data.getEnableCenterOfMassControl());
+
       cdr.write_type_11(data.getLeftHandTrajectoryFrameId());
 
       cdr.write_type_11(data.getRightHandTrajectoryFrameId());
@@ -193,6 +200,8 @@ public class KinematicsStreamingToolboxConfigurationMessagePubSubType implements
       	
       data.setEnablePelvisTaskspace(cdr.read_type_7());
       	
+      data.setEnableCenterOfMassControl(cdr.read_type_7());
+      	
       data.setLeftHandTrajectoryFrameId(cdr.read_type_11());
       	
       data.setRightHandTrajectoryFrameId(cdr.read_type_11());
@@ -217,6 +226,7 @@ public class KinematicsStreamingToolboxConfigurationMessagePubSubType implements
       ser.write_type_7("enable_right_hand_taskspace", data.getEnableRightHandTaskspace());
       ser.write_type_7("enable_chest_taskspace", data.getEnableChestTaskspace());
       ser.write_type_7("enable_pelvis_taskspace", data.getEnablePelvisTaskspace());
+      ser.write_type_7("enable_center_of_mass_control", data.getEnableCenterOfMassControl());
       ser.write_type_11("left_hand_trajectory_frame_id", data.getLeftHandTrajectoryFrameId());
       ser.write_type_11("right_hand_trajectory_frame_id", data.getRightHandTrajectoryFrameId());
       ser.write_type_11("chest_trajectory_frame_id", data.getChestTrajectoryFrameId());
@@ -236,6 +246,7 @@ public class KinematicsStreamingToolboxConfigurationMessagePubSubType implements
       data.setEnableRightHandTaskspace(ser.read_type_7("enable_right_hand_taskspace"));
       data.setEnableChestTaskspace(ser.read_type_7("enable_chest_taskspace"));
       data.setEnablePelvisTaskspace(ser.read_type_7("enable_pelvis_taskspace"));
+      data.setEnableCenterOfMassControl(ser.read_type_7("enable_center_of_mass_control"));
       data.setLeftHandTrajectoryFrameId(ser.read_type_11("left_hand_trajectory_frame_id"));
       data.setRightHandTrajectoryFrameId(ser.read_type_11("right_hand_trajectory_frame_id"));
       data.setChestTrajectoryFrameId(ser.read_type_11("chest_trajectory_frame_id"));

--- a/ihmc-interfaces/src/main/messages/ihmc_interfaces/controller_msgs/msg/WholeBodyStreamingMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ihmc_interfaces/controller_msgs/msg/WholeBodyStreamingMessage.msg
@@ -36,6 +36,10 @@ bool has_pelvis_streaming_message
 bool enable_user_pelvis_control false
 ihmc_common_msgs/SE3StreamingMessage pelvis_streaming_message
 
+# Information for the CoM
+bool has_center_of_mass_trajectory_message
+ihmc_common_msgs/EuclideanStreamingMessage center_of_mass_trajectory_message
+
 # Information for the neck joints
 bool has_neck_streaming_message
 JointspaceStreamingMessage neck_streaming_message

--- a/ihmc-interfaces/src/main/messages/ihmc_interfaces/controller_msgs/msg/WholeBodyTrajectoryMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ihmc_interfaces/controller_msgs/msg/WholeBodyTrajectoryMessage.msg
@@ -37,3 +37,6 @@ LegTrajectoryMessage right_leg_trajectory_message
 NeckTrajectoryMessage neck_trajectory_message
 # Trajectory for the head
 HeadTrajectoryMessage head_trajectory_message
+
+# Trajectory for the CoM
+controller_msgs/CenterOfMassTrajectoryMessage center_of_mass_trajectory_message

--- a/ihmc-interfaces/src/main/messages/ihmc_interfaces/ihmc_common_msgs/msg/EuclideanStreamingMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ihmc_interfaces/ihmc_common_msgs/msg/EuclideanStreamingMessage.msg
@@ -8,7 +8,9 @@ bool use_custom_control_frame false
 # This is the frame attached to the rigid body that the taskspace trajectory is defined for.
 geometry_msgs/Pose control_frame_pose
 
-# Define the desired 3D position to be reached.
+# Define the desired 3D position, expressed in world frame, to be reached.
 geometry_msgs/Point position
-# Define the desired 3D linear velocity to be reached.
+# Define the desired 3D linear velocity, expressed in world frame, to be reached.
 geometry_msgs/Vector3 linear_velocity
+# Define the desired 3D linear acceleration, expressed in world frame, to be reached.
+geometry_msgs/Vector3 linear_acceleration

--- a/ihmc-interfaces/src/main/messages/ihmc_interfaces/toolbox_msgs/msg/KinematicsStreamingToolboxConfigurationMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ihmc_interfaces/toolbox_msgs/msg/KinematicsStreamingToolboxConfigurationMessage.msg
@@ -44,6 +44,10 @@ bool enable_chest_taskspace true
 # Default value is true.
 bool enable_pelvis_taskspace true
 
+# Whether center of mass should be controlled.
+# Default value is false.
+bool enable_center_of_mass_control false
+
 # Reference frame in which the controller should be tracking the pose for the left hand as computed by the whole-body IK.
 # Default value is WORLD_FRAME, see FrameInformation for useful frame ids.
 int64 left_hand_trajectory_frame_id 83766130

--- a/ihmc-interfaces/src/main/messages/ros1/controller_msgs/msg/WholeBodyStreamingMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ros1/controller_msgs/msg/WholeBodyStreamingMessage.msg
@@ -46,6 +46,11 @@ bool enable_user_pelvis_control
 
 ihmc_common_msgs/SE3StreamingMessage pelvis_streaming_message
 
+# Information for the CoM
+bool has_center_of_mass_trajectory_message
+
+ihmc_common_msgs/EuclideanStreamingMessage center_of_mass_trajectory_message
+
 # Information for the neck joints
 bool has_neck_streaming_message
 

--- a/ihmc-interfaces/src/main/messages/ros1/controller_msgs/msg/WholeBodyTrajectoryMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ros1/controller_msgs/msg/WholeBodyTrajectoryMessage.msg
@@ -43,4 +43,7 @@ controller_msgs/NeckTrajectoryMessage neck_trajectory_message
 # Trajectory for the head
 controller_msgs/HeadTrajectoryMessage head_trajectory_message
 
+# Trajectory for the CoM
+controller_msgs/CenterOfMassTrajectoryMessage center_of_mass_trajectory_message
+
 

--- a/ihmc-interfaces/src/main/messages/ros1/ihmc_common_msgs/msg/EuclideanStreamingMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ros1/ihmc_common_msgs/msg/EuclideanStreamingMessage.msg
@@ -10,10 +10,13 @@ bool use_custom_control_frame
 # This is the frame attached to the rigid body that the taskspace trajectory is defined for.
 geometry_msgs/Pose control_frame_pose
 
-# Define the desired 3D position to be reached.
+# Define the desired 3D position, expressed in world frame, to be reached.
 geometry_msgs/Point position
 
-# Define the desired 3D linear velocity to be reached.
+# Define the desired 3D linear velocity, expressed in world frame, to be reached.
 geometry_msgs/Vector3 linear_velocity
+
+# Define the desired 3D linear acceleration, expressed in world frame, to be reached.
+geometry_msgs/Vector3 linear_acceleration
 
 

--- a/ihmc-interfaces/src/main/messages/ros1/toolbox_msgs/msg/KinematicsStreamingToolboxConfigurationMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ros1/toolbox_msgs/msg/KinematicsStreamingToolboxConfigurationMessage.msg
@@ -52,6 +52,10 @@ bool enable_chest_taskspace
 # Field default value True
 bool enable_pelvis_taskspace
 
+# Whether center of mass should be controlled.
+# Default value is false.
+bool enable_center_of_mass_control
+
 # Reference frame in which the controller should be tracking the pose for the left hand as computed by the whole-body IK.
 # Default value is WORLD_FRAME, see FrameInformation for useful frame ids.
 # Field default value 83766130


### PR DESCRIPTION
Currently when sending CoM setpoints to the KST, they get heavily filtered on the controller side via integrating up error in the pelvis position. This sets up a direct pipeline to stream CoM setpoints to the controller via the precomputed ICP trajectory. It's disabled by default. Not sure how useful it will be because the latency is likely preferable, but figured it's nice to have.