### PR TITLE
RDX Multi-Contact Integration

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/graphics/RDXMultiContactRegionGraphic.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/graphics/RDXMultiContactRegionGraphic.java
@@ -1,0 +1,166 @@
+package us.ihmc.rdx.ui.graphics;
+
+import com.badlogic.gdx.graphics.Color;
+import com.badlogic.gdx.graphics.Mesh;
+import com.badlogic.gdx.graphics.Texture;
+import com.badlogic.gdx.graphics.g3d.Material;
+import com.badlogic.gdx.graphics.g3d.Model;
+import com.badlogic.gdx.graphics.g3d.ModelInstance;
+import com.badlogic.gdx.graphics.g3d.Renderable;
+import com.badlogic.gdx.graphics.g3d.RenderableProvider;
+import com.badlogic.gdx.graphics.g3d.model.MeshPart;
+import com.badlogic.gdx.graphics.g3d.utils.ModelBuilder;
+import com.badlogic.gdx.utils.Array;
+import com.badlogic.gdx.utils.Pool;
+import net.mgsx.gltf.scene3d.attributes.PBRTextureAttribute;
+import org.lwjgl.opengl.GL41;
+import toolbox_msgs.msg.dds.KinematicsToolboxOutputStatus;
+import us.ihmc.euclid.geometry.ConvexPolygon2D;
+import us.ihmc.euclid.geometry.tools.EuclidGeometryTools;
+import us.ihmc.euclid.referenceFrame.FramePoint3D;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.tuple2D.interfaces.Point2DReadOnly;
+import us.ihmc.euclid.tuple3D.Point3D;
+import us.ihmc.idl.IDLSequence.Object;
+import us.ihmc.mecano.frames.CenterOfMassReferenceFrame;
+import us.ihmc.rdx.mesh.RDXMultiColorMeshBuilder;
+import us.ihmc.robotModels.FullHumanoidRobotModel;
+import us.ihmc.robotics.referenceFrames.MidFrameZUpFrame;
+import us.ihmc.robotics.robotSide.RobotSide;
+
+public class RDXMultiContactRegionGraphic implements RenderableProvider
+{
+   private static final Color POLYGON_GRAPHIC_COLOR = Color.valueOf("DEE933");
+   private static final double STABILITY_GRAPHIC_HEIGHT = 2.0;
+
+   private final ConvexPolygon2D multiContactSupportRegion = new ConvexPolygon2D();
+
+   private final FramePoint3D comCurrent = new FramePoint3D();
+   private final FramePoint3D comXYAtFootHeight = new FramePoint3D();
+   private final ConvexPolygon2D closestProximityEdge = new ConvexPolygon2D();
+
+   private int minimumEdgeIndex;
+   private double minimumEdgeDistance;
+
+   private final ModelBuilder modelBuilder = new ModelBuilder();
+   private final RDXMultiColorMeshBuilder meshBuilder = new RDXMultiColorMeshBuilder();
+   private final FullHumanoidRobotModel ghostFullRobotModel;
+   private final CenterOfMassReferenceFrame centerOfMassFrame;
+   private final MidFrameZUpFrame midFeetZUpFrame;
+   private final RigidBodyTransform transform = new RigidBodyTransform();
+
+   private ModelInstance modelInstance;
+   private Model lastModel;
+
+   public RDXMultiContactRegionGraphic(FullHumanoidRobotModel ghostFullRobotModel)
+   {
+      this.ghostFullRobotModel = ghostFullRobotModel;
+      this.centerOfMassFrame = new CenterOfMassReferenceFrame("ghostCoMFrame", ReferenceFrame.getWorldFrame(), ghostFullRobotModel.getRootBody());
+      this.midFeetZUpFrame = new MidFrameZUpFrame("midFeedZUpWhost",
+                                                  ReferenceFrame.getWorldFrame(),
+                                                  ghostFullRobotModel.getSoleFrame(RobotSide.LEFT),
+                                                  ghostFullRobotModel.getSoleFrame(RobotSide.RIGHT));
+   }
+
+   public void update(KinematicsToolboxOutputStatus kinematicsToolboxOutputStatus)
+   {
+      multiContactSupportRegion.clear();
+      Object<Point3D> supportRegion = kinematicsToolboxOutputStatus.getSupportRegion();
+
+      for (int i = 0; i < supportRegion.size(); i++)
+      {
+         multiContactSupportRegion.addVertex(supportRegion.get(i));
+      }
+
+      multiContactSupportRegion.update();
+
+      if (multiContactSupportRegion.getNumberOfVertices() < 3)
+      {
+         modelInstance = null;
+         lastModel = null;
+         return;
+      }
+
+      meshBuilder.clear();
+
+      centerOfMassFrame.update();
+      midFeetZUpFrame.update();
+      updateMinimumEdge();
+
+      FramePoint3D midFoot = new FramePoint3D(midFeetZUpFrame);
+      midFoot.changeFrame(ReferenceFrame.getWorldFrame());
+      double footZ = midFoot.getZ();
+
+      transform.setTranslationAndIdentityRotation(0.0, 0.0, footZ);
+
+      for (int i = 0; i < multiContactSupportRegion.getNumberOfVertices(); i++)
+      {
+         Point2DReadOnly v0 = multiContactSupportRegion.getVertex(i);
+         Point2DReadOnly v1 = multiContactSupportRegion.getNextVertex(i);
+
+         Color color = i == minimumEdgeIndex ? Color.RED : POLYGON_GRAPHIC_COLOR;
+         meshBuilder.addLine(v0.getX(), v0.getY(), footZ, v1.getX(), v1.getY(), footZ, 0.01f, color);
+      }
+
+      meshBuilder.addPolygon(transform, multiContactSupportRegion, POLYGON_GRAPHIC_COLOR);
+
+      comCurrent.setToZero(centerOfMassFrame);
+      comCurrent.changeFrame(ReferenceFrame.getWorldFrame());
+
+      meshBuilder.addSphere(0.03f, comCurrent, Color.BLACK);
+
+      comXYAtFootHeight.setIncludingFrame(comCurrent);
+      comXYAtFootHeight.setZ(footZ);
+      meshBuilder.addSphere(0.03f, comXYAtFootHeight, Color.BLACK);
+
+      FramePoint3D comXYElevated = new FramePoint3D(comXYAtFootHeight);
+      comXYElevated.addZ(STABILITY_GRAPHIC_HEIGHT);
+      meshBuilder.addLine(comXYAtFootHeight, comXYElevated, 0.005f, Color.BLACK);
+
+      modelBuilder.begin();
+      Mesh mesh = meshBuilder.generateMesh();
+
+      MeshPart meshPart = new MeshPart("xyz", mesh, 0, mesh.getNumIndices(), GL41.GL_TRIANGLES);
+      Material material = new Material();
+      Texture paletteTexture = RDXMultiColorMeshBuilder.loadPaletteTexture();
+      material.set(PBRTextureAttribute.createBaseColorTexture(paletteTexture));
+
+      modelBuilder.part(meshPart, material);
+
+      if (lastModel != null)
+         lastModel.dispose();
+
+      lastModel = modelBuilder.end();
+      modelInstance = new ModelInstance(lastModel);
+   }
+
+   private void updateMinimumEdge()
+   {
+      minimumEdgeDistance = Double.POSITIVE_INFINITY;
+
+      for (int i = 0; i < multiContactSupportRegion.getNumberOfVertices(); i++)
+      {
+         Point2DReadOnly v0 = multiContactSupportRegion.getVertex(i);
+         Point2DReadOnly v1 = multiContactSupportRegion.getNextVertex(i);
+
+         double margin = EuclidGeometryTools.distanceFromPoint2DToLine2D(comXYAtFootHeight.getX(), comXYAtFootHeight.getY(), v0, v1);
+         if (margin < minimumEdgeDistance)
+         {
+            minimumEdgeDistance = margin;
+            minimumEdgeIndex = i;
+         }
+      }
+   }
+
+   @Override
+   public void getRenderables(Array<Renderable> renderables, Pool<Renderable> pool)
+   {
+      if (multiContactSupportRegion.isEmpty())
+      {
+         return;
+      }
+
+      modelInstance.getRenderables(renderables, pool);
+   }
+}

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXHandControlMode.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXHandControlMode.java
@@ -1,0 +1,11 @@
+package us.ihmc.rdx.ui.vr;
+
+public enum RDXHandControlMode
+{
+   /* No hand is present on this side: a VR hand action does nothing */
+   NONE,
+   /* Gripper is present on this side: a VR hand action toggles the gripper state */
+   GRIPPER,
+   /* The arm is load bearing on this side: a VR hand action loads/unloads the arm */
+   LOAD_BEARING
+}

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXVRKinematicsStreamingMode.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXVRKinematicsStreamingMode.java
@@ -3,9 +3,13 @@ package us.ihmc.rdx.ui.vr;
 import com.badlogic.gdx.graphics.g3d.Renderable;
 import com.badlogic.gdx.utils.Array;
 import com.badlogic.gdx.utils.Pool;
+import controller_msgs.msg.dds.CapturabilityBasedStatus;
+import controller_msgs.msg.dds.HandLoadBearingMessage;
 import imgui.ImGui;
 import imgui.type.ImBoolean;
+import org.apache.commons.lang.mutable.MutableBoolean;
 import org.lwjgl.openvr.InputDigitalActionData;
+import toolbox_msgs.msg.dds.HumanoidKinematicsToolboxConfigurationMessage;
 import toolbox_msgs.msg.dds.KinematicsStreamingToolboxInputMessage;
 import toolbox_msgs.msg.dds.KinematicsToolboxCenterOfMassMessage;
 import toolbox_msgs.msg.dds.KinematicsToolboxConfigurationMessage;
@@ -18,15 +22,19 @@ import us.ihmc.avatar.drcRobot.ROS2SyncedRobotModel;
 import us.ihmc.avatar.networkProcessor.kinemtaticsStreamingToolboxModule.KinematicsStreamingToolboxModule;
 import us.ihmc.avatar.networkProcessor.kinemtaticsStreamingToolboxModule.KinematicsStreamingToolboxParameters;
 import us.ihmc.avatar.ros2.ROS2ControllerHelper;
+import us.ihmc.avatar.sakeGripper.SakeHandPreset;
 import us.ihmc.behaviors.tools.walkingController.ControllerStatusTracker;
 import us.ihmc.commons.UnitConversions;
 import us.ihmc.commons.thread.Notification;
 import us.ihmc.commons.thread.Throttler;
 import us.ihmc.communication.OldHandAPI;
+import us.ihmc.communication.controllerAPI.ControllerAPI;
 import us.ihmc.communication.packets.MessageTools;
 import us.ihmc.communication.packets.ToolboxState;
 import us.ihmc.euclid.geometry.Pose3D;
+import us.ihmc.euclid.referenceFrame.FramePoint3D;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
+import us.ihmc.euclid.referenceFrame.FrameVector3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.tuple3D.Vector3D;
@@ -46,7 +54,9 @@ import us.ihmc.rdx.sceneManager.RDXSceneLevel;
 import us.ihmc.rdx.ui.RDXBaseUI;
 import us.ihmc.rdx.ui.affordances.RDXManualFootstepPlacement;
 import us.ihmc.rdx.ui.graphics.RDXMultiBodyGraphic;
+import us.ihmc.rdx.ui.graphics.RDXMultiContactRegionGraphic;
 import us.ihmc.rdx.ui.graphics.RDXReferenceFrameGraphic;
+import us.ihmc.rdx.ui.teleoperation.RDXHandConfigurationManager;
 import us.ihmc.rdx.ui.tools.KinematicsRecordReplay;
 import us.ihmc.rdx.vr.RDXVRContext;
 import us.ihmc.rdx.vr.RDXVRControllerModel;
@@ -73,6 +83,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static us.ihmc.communication.packets.MessageTools.toFrameId;
 import static us.ihmc.motionRetargeting.VRTrackedSegmentType.*;
@@ -90,6 +101,7 @@ public class RDXVRKinematicsStreamingMode
    private final ImGuiUniqueLabelMap labels = new ImGuiUniqueLabelMap(getClass());
    private final ImBoolean enabled = new ImBoolean(false);
    private ROS2Input<KinematicsToolboxOutputStatus> status;
+   private ROS2Input<CapturabilityBasedStatus> capturabilityBasedStatus;
    private final double streamPeriod = UnitConversions.hertzToSeconds(120.0);
    private final Throttler toolboxInputStreamRateLimiter = new Throttler();
    private final FramePose3D tempFramePose = new FramePose3D();
@@ -113,6 +125,7 @@ public class RDXVRKinematicsStreamingMode
    private final RDXVRContext vrContext;
    private final ControllerStatusTracker controllerStatusTracker;
    private final RDXManualFootstepPlacement footstepPlacer;
+   private final RDXHandConfigurationManager handManager;
    private boolean pausedForWalking = false;
    private final SideDependentList<Float> gripButtonsValue = new SideDependentList<>();
    @Nullable
@@ -135,6 +148,12 @@ public class RDXVRKinematicsStreamingMode
    private final HandConfiguration[] handConfigurations = {HandConfiguration.HALF_CLOSE, HandConfiguration.CRUSH, HandConfiguration.CLOSE};
    private int leftIndex = -1;
    private int rightIndex = -1;
+   private RDXMultiContactRegionGraphic multiContactStabilityGraphic;
+   private final HumanoidKinematicsToolboxConfigurationMessage ikHumanoidSolverConfigurationMessage = new HumanoidKinematicsToolboxConfigurationMessage();
+
+   private SideDependentList<MutableBoolean> handsAreOpen = new SideDependentList<>(new MutableBoolean(false), new MutableBoolean(false));
+   private final SideDependentList<Boolean> handsAreLoaded = new SideDependentList<>(false, false);
+   private final SideDependentList<RDXHandControlMode> handControlModes = new SideDependentList<>(RDXHandControlMode.GRIPPER, RDXHandControlMode.GRIPPER);
 
    public RDXVRKinematicsStreamingMode(ROS2SyncedRobotModel syncedRobot,
                                        ROS2ControllerHelper ros2ControllerHelper,
@@ -142,7 +161,8 @@ public class RDXVRKinematicsStreamingMode
                                        RetargetingParameters retargetingParameters,
                                        SceneGraph sceneGraph,
                                        ControllerStatusTracker controllerStatusTracker,
-                                       RDXManualFootstepPlacement footstepPlacer)
+                                       RDXManualFootstepPlacement footstepPlacer,
+                                       RDXHandConfigurationManager handManager)
    {
       this.syncedRobot = syncedRobot;
       this.robotModel = syncedRobot.getRobotModel();
@@ -152,6 +172,7 @@ public class RDXVRKinematicsStreamingMode
       this.vrContext = vrContext;
       this.controllerStatusTracker = controllerStatusTracker;
       this.footstepPlacer = footstepPlacer;
+      this.handManager = handManager;
    }
 
    public void create(boolean createToolbox)
@@ -167,6 +188,8 @@ public class RDXVRKinematicsStreamingMode
       ghostRobotGraphic.loadRobotModelAndGraphics(ghostRobotDefinition, ghostFullRobotModel.getElevator());
       ghostRobotGraphic.setActive(true);
       ghostRobotGraphic.create();
+
+      multiContactStabilityGraphic = new RDXMultiContactRegionGraphic(ghostFullRobotModel);
 
       for (RobotSide side : RobotSide.values)
       {
@@ -189,6 +212,7 @@ public class RDXVRKinematicsStreamingMode
       headsetReferenceFrame = new MutableReferenceFrame(vrContext.getHeadset().getXForwardZUpHeadsetFrame());
 
       status = ros2ControllerHelper.subscribe(KinematicsStreamingToolboxModule.getOutputStatusTopic(syncedRobot.getRobotModel().getSimpleRobotName()));
+      capturabilityBasedStatus = ros2ControllerHelper.subscribeToController(CapturabilityBasedStatus.class);
 
       kinematicsRecorder = new KinematicsRecordReplay(sceneGraph, enabled);
       motionRetargeting = new RDXVRMotionRetargeting(syncedRobot, handDesiredControlFrames, trackerReferenceFrames, headsetReferenceFrame, retargetingParameters);
@@ -323,8 +347,7 @@ public class RDXVRKinematicsStreamingMode
          InputDigitalActionData clickTriggerButton = controller.getClickTriggerActionData();
          if (clickTriggerButton.bChanged() && !clickTriggerButton.bState())
          {
-            HandConfiguration handConfiguration = nextHandConfiguration(RobotSide.LEFT);
-            sendHandCommand(RobotSide.LEFT, handConfiguration);
+            performHandAction(RobotSide.LEFT);
             vrContext.loadTrackerRolesFromFile();
          }
 
@@ -359,8 +382,7 @@ public class RDXVRKinematicsStreamingMode
         InputDigitalActionData clickTriggerButton = controller.getClickTriggerActionData();
         if (clickTriggerButton.bChanged() && !clickTriggerButton.bState())
         { // do not want to close grippers while interacting with the panel
-           HandConfiguration handConfiguration = nextHandConfiguration(RobotSide.RIGHT);
-           sendHandCommand(RobotSide.RIGHT, handConfiguration);
+           performHandAction(RobotSide.RIGHT);
 
            // TODO discuss and possibly remap to different button...
 
@@ -726,6 +748,15 @@ public class RDXVRKinematicsStreamingMode
                      ghostOneDoFJointsExcludingHands[i].setQ(latestStatus.getDesiredJointAngles().get(i));
                   }
                   ghostFullRobotModel.getElevator().updateFramesRecursively();
+                  multiContactStabilityGraphic.update(latestStatus);
+               }
+            }
+            if (capturabilityBasedStatus.getMessageNotification().poll())
+            {
+               CapturabilityBasedStatus capturabilityBasedStatus = this.capturabilityBasedStatus.getMessageNotification().read();
+               for (RobotSide robotSide : RobotSide.values)
+               {
+                  handsAreLoaded.put(robotSide, HumanoidMessageTools.isHandLoadBearing(robotSide, capturabilityBasedStatus));
                }
             }
             if (ghostRobotGraphic.isActive())
@@ -910,6 +941,8 @@ public class RDXVRKinematicsStreamingMode
 
    public void getVirtualRenderables(Array<Renderable> renderables, Pool<Renderable> pool, Set<RDXSceneLevel> sceneLevels)
    {
+      multiContactStabilityGraphic.getRenderables(renderables, pool);
+
       if (status.hasReceivedFirstMessage())
       {
          ghostRobotGraphic.getRenderables(renderables, pool, sceneLevels);
@@ -960,20 +993,81 @@ public class RDXVRKinematicsStreamingMode
       }
    }
 
-   public void sendHandCommand(RobotSide robotSide, HandConfiguration desiredHandConfiguration)
+   /**
+    * Performs hand action based on handControlMode:
+    * - GRIPPER: sends a HandConfiguration based on the next entry in handConfigurations.
+    * - LOAD_BEARING: loads the hand at the hand control frame with the normal handContactNormalInMidFeetZUpFrame.
+    * - NONE: you guessed it, nothing.
+    */
+   private void performHandAction(RobotSide robotSide)
    {
-      ros2ControllerHelper.publish(robotName -> OldHandAPI.getHandDesiredConfigurationTopic(robotName),
-                                   HumanoidMessageTools.createHandDesiredConfigurationMessage(robotSide, desiredHandConfiguration));
+      if (handControlModes.get(robotSide) == RDXHandControlMode.GRIPPER)
+      {
+         publishHandCommand(robotSide);
+      }
+      else if (handControlModes.get(robotSide) == RDXHandControlMode.LOAD_BEARING)
+      {
+         if (enabled.get())
+         {
+            LogTools.error("Ignoring hand load bearing message, cannot live-update while IK is running. TODO fixme :)");
+         }
+         else
+         {
+            sendHandLoadBearingMessage(robotSide);
+         }
+      }
    }
 
-   public HandConfiguration nextHandConfiguration(RobotSide robotSide)
+   private void sendHandLoadBearingMessage(RobotSide robotSide)
    {
-      if (robotSide == RobotSide.LEFT)
+      HandLoadBearingMessage handLoadBearingMessage = new HandLoadBearingMessage();
+      handLoadBearingMessage.setRobotSide(robotSide.toByte());
+
+      if (handsAreLoaded.get(robotSide))
       {
-         leftIndex++;
-         return handConfigurations[leftIndex % handConfigurations.length];
+         handLoadBearingMessage.setLoad(false);
+         handsAreLoaded.put(robotSide, false);
+
+         ikHumanoidSolverConfigurationMessage.setHoldCurrentCenterOfMassXyPosition(false);
+         ros2ControllerHelper.publish(ControllerAPI.getTopic(KinematicsStreamingToolboxModule.getInputTopic(robotModel.getSimpleRobotName()), HumanoidKinematicsToolboxConfigurationMessage.class), ikHumanoidSolverConfigurationMessage);
       }
-      rightIndex++;
-      return handConfigurations[rightIndex % handConfigurations.length];
+      else
+      {
+         handLoadBearingMessage.setLoad(true);
+
+         double handCoefficientOfFriction = 0.4;
+         handLoadBearingMessage.setCoefficientOfFriction(handCoefficientOfFriction);
+
+         // Contact point assumed to be at hand control frame and is using the nubs
+         FramePoint3D contactPoint = new FramePoint3D(syncedRobot.getFullRobotModel().getHandControlFrame(robotSide));
+         contactPoint.changeFrame(syncedRobot.getFullRobotModel().getHand(robotSide).getBodyFixedFrame());
+         handLoadBearingMessage.getContactPointInBodyFrame().set(contactPoint);
+
+         // Currently hard-coded. Need to integrate with perception
+         FrameVector3D contactNormal = new FrameVector3D(syncedRobot.getReferenceFrames().getMidFeetZUpFrame(), -1.0, 0.0, 0.0);
+         contactNormal.changeFrame(ReferenceFrame.getWorldFrame());
+         handLoadBearingMessage.getContactNormalInWorld().set(contactNormal);
+
+         handsAreLoaded.put(robotSide, true);
+
+         ikHumanoidSolverConfigurationMessage.setHoldCurrentCenterOfMassXyPosition(false);
+         ros2ControllerHelper.publish(ControllerAPI.getTopic(KinematicsStreamingToolboxModule.getInputTopic(robotModel.getSimpleRobotName()), HumanoidKinematicsToolboxConfigurationMessage.class), ikHumanoidSolverConfigurationMessage);
+      }
+
+      LogTools.info("publishing hand load bearing message " + robotSide + " hand, loading = " + handLoadBearingMessage.getLoad());
+      ros2ControllerHelper.publishToController(handLoadBearingMessage);
+   }
+
+   public void publishHandCommand(RobotSide side)
+   {
+      boolean close = handsAreOpen.get(side).booleanValue();
+      handsAreOpen.get(side).setValue(!close);
+      handManager.publishHandCommand(side, close ? SakeHandPreset.GRIP : SakeHandPreset.OPEN, false, false);
+   }
+
+   public void setVRHandConfiguration(RDXHandControlMode leftHandControlMode, RDXHandControlMode rightHandControlMode)
+   {
+      handControlModes.put(RobotSide.LEFT, leftHandControlMode);
+      handControlModes.put(RobotSide.RIGHT, rightHandControlMode);
    }
 }

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXVRModeManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXVRModeManager.java
@@ -24,6 +24,7 @@ import us.ihmc.rdx.ui.RDXBaseUI;
 import us.ihmc.rdx.ui.RDXJoystickBasedStepping;
 import us.ihmc.rdx.ui.affordances.RDXManualFootstepPlacement;
 import us.ihmc.rdx.ui.graphics.ros2.RDXROS2RobotVisualizer;
+import us.ihmc.rdx.ui.teleoperation.RDXHandConfigurationManager;
 import us.ihmc.rdx.ui.teleoperation.RDXTeleoperationManager;
 import us.ihmc.rdx.vr.RDXVRContext;
 import us.ihmc.robotics.robotSide.RobotSide;
@@ -50,6 +51,7 @@ public class RDXVRModeManager
    private ImBoolean interactablesEnabled;
    private ControllerStatusTracker controllerStatusTracker;
    private RDXManualFootstepPlacement footstepPlacer;
+   private RDXHandConfigurationManager handManager;
 
    public void create(RDXBaseUI baseUI,
                       ROS2SyncedRobotModel syncedRobot,
@@ -94,6 +96,7 @@ public class RDXVRModeManager
             interactablesEnabled = teleoperationPanel.getInteractablesEnabled();
             controllerStatusTracker = teleoperationPanel.getControllerStatusTracker();
             footstepPlacer = teleoperationPanel.getLocomotionManager().getManualFootstepPlacement();
+            handManager = teleoperationPanel.getArmManager().getHandManager();
             break;
          }
       }
@@ -109,7 +112,8 @@ public class RDXVRModeManager
                                                                     retargetingParameters,
                                                                     sceneGraph,
                                                                     controllerStatusTracker,
-                                                                    footstepPlacer);
+                                                                    footstepPlacer,
+                                                                    handManager);
          kinematicsStreamingMode.create(createKinematicsStreamingToolboxModule);
       }
 


### PR DESCRIPTION
Adding front-end support for new KST feature of having the arms be load-bearing. Adds an enum matching NadiaArmConfiguration, in which a hand action either does a gripper action, loads the arm or nothing (if no arm is present). This also swaps to the correct ROS message for the sake gripper. Integration with perception hasn't been done yet, this currently has a fixed contact normal.