### PR TITLE
Don't use IOUtils in favor of Java Files

### DIFF
--- a/ihmc-graphics/src/libgdx/java/us/ihmc/rdx/tools/assimp/AssimpOpenedFile.java
+++ b/ihmc-graphics/src/libgdx/java/us/ihmc/rdx/tools/assimp/AssimpOpenedFile.java
@@ -1,8 +1,13 @@
 package us.ihmc.rdx.tools.assimp;
 
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.mutable.MutableLong;
-import org.lwjgl.assimp.*;
+import org.lwjgl.assimp.AIFile;
+import org.lwjgl.assimp.AIFileFlushProcI;
+import org.lwjgl.assimp.AIFileReadProcI;
+import org.lwjgl.assimp.AIFileSeekI;
+import org.lwjgl.assimp.AIFileTellProcI;
+import org.lwjgl.assimp.AIFileWriteProcI;
+import org.lwjgl.assimp.Assimp;
 import org.lwjgl.system.MemoryUtil;
 import us.ihmc.commons.exception.DefaultExceptionHandler;
 import us.ihmc.commons.exception.ExceptionTools;
@@ -12,6 +17,7 @@ import us.ihmc.tools.string.StringTools;
 
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.function.Supplier;
@@ -36,7 +42,7 @@ public class AssimpOpenedFile
          throw new RuntimeException(message.get());
       }
 
-      byte[] byteArray = ExceptionTools.handle(() -> IOUtils.toByteArray(url), DefaultExceptionHandler.MESSAGE_AND_STACKTRACE);
+      byte[] byteArray = ExceptionTools.handle(() -> Files.readAllBytes(filePath), DefaultExceptionHandler.MESSAGE_AND_STACKTRACE);
 
       final MutableLong position = new MutableLong(0);
 

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDADepthColorizerTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDADepthColorizerTest.java
@@ -1,6 +1,5 @@
 package us.ihmc.perception.cuda;
 
-import org.apache.commons.io.IOUtils;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.opencv_core.GpuMat;
@@ -10,7 +9,10 @@ import us.ihmc.perception.RawImageTest;
 import us.ihmc.perception.opencv.OpenCVTools;
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -52,11 +54,11 @@ public class CUDADepthColorizerTest
    {
       try
       {
-         URL imageURL = RawImageTest.class.getResource("zedDepth16U.raw");
-         byte[] imageBytes = IOUtils.toByteArray(Objects.requireNonNull(imageURL));
+         Path path = Paths.get(Objects.requireNonNull(RawImageTest.class.getResource("zedDepth16U.raw")).toURI());
+         byte[] imageBytes = Files.readAllBytes(path);
          return new Mat(720, 1280, opencv_core.CV_16UC1, new BytePointer(imageBytes));
       }
-      catch (IOException e)
+      catch (IOException | URISyntaxException e)
       {
          throw new RuntimeException(e);
       }

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAJPEGProcessorTest.java
@@ -1,6 +1,5 @@
 package us.ihmc.perception.cuda;
 
-import org.apache.commons.io.IOUtils;
 import org.bytedeco.javacpp.BytePointer;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_imgcodecs;
@@ -14,7 +13,10 @@ import us.ihmc.perception.opencv.OpenCVTools;
 import us.ihmc.perception.tools.PerceptionDebugTools;
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Objects;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -372,11 +374,11 @@ public class CUDAJPEGProcessorTest
    {
       try
       {
-         URL imageURL = RawImageTest.class.getResource("zedColorBGR.raw");
-         byte[] imageBytes = IOUtils.toByteArray(Objects.requireNonNull(imageURL));
+         Path path = Paths.get(Objects.requireNonNull(RawImageTest.class.getResource("zedColorBGR.raw")).toURI());
+         byte[] imageBytes = Files.readAllBytes(path);
          return new Mat(720, 1280, opencv_core.CV_8UC3, new BytePointer(imageBytes));
       }
-      catch (IOException e)
+      catch (IOException | URISyntaxException e)
       {
          throw new RuntimeException(e);
       }


### PR DESCRIPTION
Extracted from https://github.com/ihmcrobotics/ihmc-open-robotics-software/pull/605

This was causing compilation problems for me in a large workspace even before the dependency changes.