### PR TITLE
Fixing world-frame pelvis height dependence

### DIFF
--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/capturePoint/CenterOfMassHeightManager.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/capturePoint/CenterOfMassHeightManager.java
@@ -243,7 +243,9 @@ public class CenterOfMassHeightManager implements SCS2YoGraphicHolder
     */
    public void goHome(double trajectoryTime)
    {
-      stateMachine.getCurrentState().goHome(trajectoryTime);
+      PelvisHeightControlMode walkingControllerState = PelvisHeightControlMode.WALKING_CONTROLLER;
+      requestState(walkingControllerState);
+      stateMachine.getState(walkingControllerState).goHome(trajectoryTime);
    }
 
    public void handleStopAllTrajectoryCommand(StopAllTrajectoryCommand command)

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/controlModules/pelvis/PelvisHeightControlState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/controlModules/pelvis/PelvisHeightControlState.java
@@ -62,6 +62,7 @@ public class PelvisHeightControlState implements PelvisAndCenterOfMassHeightCont
    private final RigidBodyBasics pelvis;
    private final MovingReferenceFrame pelvisFrame;
    private final ReferenceFrame baseFrame;
+   private final ReferenceFrame midFeetZUpFrame;
 
    private final DoubleProvider defaultHeight;
    private final DoubleProvider minHeight;
@@ -105,6 +106,7 @@ public class PelvisHeightControlState implements PelvisAndCenterOfMassHeightCont
       pelvisFrame = referenceFrames.getPelvisFrame();
       // The base frame could be switched to the mid foot frame at some point.
       baseFrame = elevator.getBodyFixedFrame();
+      midFeetZUpFrame = referenceFrames.getMidFeetZUpFrame();
 
       YoDouble yoTime = controllerToolbox.getYoTime();
       YoGraphicsListRegistry graphicsListRegistry = controllerToolbox.getYoGraphicsListRegistry();
@@ -325,8 +327,9 @@ public class PelvisHeightControlState implements PelvisAndCenterOfMassHeightCont
    @Override
    public void goHome(double trajectoryTime)
    {
-      tempPosition.setToZero(baseFrame);
+      tempPosition.setToZero(midFeetZUpFrame);
       tempPosition.setZ(defaultHeight.getValue());
+      tempPosition.changeFrame(baseFrame);
       positionController.goToPositionFromCurrent(tempPosition, trajectoryTime);
    }
 


### PR DESCRIPTION
There was a bug in setting height relative to world-frame z=0. Also having GoHome switch to WALKING_CONTROLLER by default.