### PR TITLE
[Bugfix] Fix ZEDSVOPlaybackSensor Bug

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDSVOPlaybackSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDSVOPlaybackSensor.java
@@ -13,6 +13,7 @@ import static us.ihmc.zed.global.zed.*;
 
 public class ZEDSVOPlaybackSensor extends ZEDImageSensor
 {
+   private final int cameraID;
    private final String svoFileName;
    private final ZEDSVOCurrentFileMessage svoStatusMessage = new ZEDSVOCurrentFileMessage();
    private final RepeatingTaskThread publishInfoThread;
@@ -20,6 +21,7 @@ public class ZEDSVOPlaybackSensor extends ZEDImageSensor
    public ZEDSVOPlaybackSensor(ROS2PublishSubscribeAPI ros2, int cameraID, ZEDModelData zedModel, String svoFileName)
    {
       super(cameraID, zedModel, SL_INPUT_TYPE_SVO);
+      this.cameraID = cameraID;
       this.svoFileName = svoFileName;
 
       if (!Files.exists(Path.of(svoFileName)))
@@ -69,6 +71,12 @@ public class ZEDSVOPlaybackSensor extends ZEDImageSensor
    protected int openCamera()
    {
       return sl_open_camera(getCameraID(), zedInitParameters, 0, svoFileName, "", 0, "", "", "");
+   }
+
+   @Override
+   public boolean isSensorRunning()
+   {
+      return sl_is_opened(cameraID);
    }
 
    @Override


### PR DESCRIPTION
The 1 second timeout in `isSensorRunning` of the `ZEDImageSensor` kinda broke the `YOLOv8PipelineDemo`. It was restarting the sensor every time I asked for a new image. This prevents the unnecessary restarts of the SVO. 