### PR TITLE
ROS 2 logger

### DIFF
--- a/ihmc-communication/build.gradle.kts
+++ b/ihmc-communication/build.gradle.kts
@@ -14,6 +14,7 @@ mainDependencies {
    api("us.ihmc:ihmc-realtime:1.7.0")
    api("us.ihmc:ihmc-video-codecs:2.1.6")
    api("us.ihmc:ros2-library:1.2.1")
+   api("us.ihmc:ihmc-pub-sub-serializers-extra:1.2.1")
    api("commons-net:commons-net:3.6")
    api("org.lz4:lz4-java:1.8.0")
 

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogIOTools.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogIOTools.java
@@ -1,0 +1,167 @@
+package us.ihmc.communication.ros2log;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import gnu.trove.list.array.TLongArrayList;
+import us.ihmc.communication.packets.Packet;
+import us.ihmc.idl.serializers.extra.AbstractSerializer;
+import us.ihmc.log.LogTools;
+import us.ihmc.pubsub.TopicDataType;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2Topic;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * IO helper methods for ROS 2 logging, the log file is timestamped ROS 2 messages with the requested serialization. \
+ * Timestamps are in ms and t=0 is the first message.
+ *
+ * File structure is:
+ * - MessageClassA
+ *    - timestamps
+ *       - t0, t1, t2...
+ *    - messages
+ *       - m0, m1, m2...
+ * - MessageClassB
+ *    - timestamps
+ *       - t0, t1, t2...
+ *    - messages
+ *       - m0, m1, m2...
+ * ...
+ */
+public class ROS2LogIOTools
+{
+   public static final String logDirectory = System.getProperty("user.home") + File.separator + ".ihmc" + File.separator + "logs" + File.separator + "ros2" + File.separator;
+
+   private static final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmss");
+   private static final String timestampKey = "timestamps";
+   private static final String messageKey = "messages";
+
+   static String writeLogFile(List<RecordTopicManager<?>> topicManagers, ROS2LogSerialization serialization)
+   {
+      try
+      {
+         Files.createDirectories(Paths.get(new File(logDirectory).getPath()));
+
+         ObjectMapper objectMapper = serialization.createObjectMapper();
+         ObjectNode rootNode = objectMapper.createObjectNode();
+
+         long firstTimestamp = Long.MAX_VALUE;
+         for (int topic_idx = 0; topic_idx < topicManagers.size(); topic_idx++)
+         {
+            TLongArrayList timestamps = topicManagers.get(topic_idx).getTimestamps();
+            if (timestamps.isEmpty())
+               continue;
+            firstTimestamp = Math.min(timestamps.get(0), firstTimestamp);
+         }
+         if (firstTimestamp == Long.MAX_VALUE)
+         {
+            LogTools.info("Empty ROS 2 log, not writing log file.");
+            return null;
+         }
+
+         for (int topic_idx = 0; topic_idx < topicManagers.size(); topic_idx++)
+         {
+            RecordTopicManager<?> topicManager = topicManagers.get(topic_idx);
+            ROS2Topic<?> topic = topicManager.getTopic();
+            TLongArrayList timestampsToLog = topicManager.getTimestamps();
+            List<?> messagesToLog = topicManager.getMessages();
+
+            if (messagesToLog.isEmpty())
+               continue;
+
+            Packet packet = (Packet) topic.getType().getConstructor().newInstance();
+            TopicDataType<?> topicDataType = (TopicDataType) packet.getPubSubTypePacket().get();
+            AbstractSerializer serializer = serialization.createSerializer(topicDataType);
+
+            ObjectNode topicObject = rootNode.putObject(packet.getClass().getName());
+            ArrayNode timestamps = topicObject.putArray(timestampKey);
+            ArrayNode messages = topicObject.putArray(messageKey);
+
+            for (int message_idx = 0; message_idx < messagesToLog.size(); message_idx++)
+            {
+               timestamps.add((timestampsToLog.get(message_idx) - firstTimestamp));
+               messages.add(serializer.serializeToString(messagesToLog.get(message_idx)));
+            }
+         }
+
+         String fileName = logDirectory + dateFormat.format(new Date()) + "." + serialization.getFilePostfix();
+         FileOutputStream outputStream = new FileOutputStream(fileName);
+         PrintStream printStream = new PrintStream(outputStream);
+         objectMapper.writerWithDefaultPrettyPrinter().writeValue(printStream, rootNode);
+         printStream.close();
+
+         LogTools.info("ROS 2 log record finished: " + fileName);
+         return fileName;
+      }
+      catch (Exception e)
+      {
+         e.printStackTrace();
+         return null;
+      }
+   }
+
+   public static List<ReplayTopicManager<?>> loadLogFile(ROS2Node ros2Node, List<ROS2Topic<?>> loggedTopics, File logFile)
+   {
+      try
+      {
+         ROS2LogSerialization serialization = ROS2LogSerialization.fromFileName(logFile.getName());
+         ObjectMapper objectMapper = serialization.createObjectMapper();
+         FileInputStream inputStream = new FileInputStream(logFile);
+         List<ReplayTopicManager<?>> topicManagers = new ArrayList<>();
+
+         ObjectNode rootNode = (ObjectNode) objectMapper.readTree(inputStream);
+
+         for (int topic_idx = 0; topic_idx < loggedTopics.size(); topic_idx++)
+         {
+            ROS2Topic<?> topic = loggedTopics.get(topic_idx);
+            ReplayTopicManager topicManager = new ReplayTopicManager(topic, ros2Node);
+
+            Packet packet = (Packet) topic.getType().getConstructor().newInstance();
+            TopicDataType<?> topicDataType = (TopicDataType) packet.getPubSubTypePacket().get();
+            AbstractSerializer serializer = serialization.createSerializer(topicDataType);
+
+            ObjectNode topicObject = (ObjectNode) rootNode.get(packet.getClass().getName());
+            if (topicObject == null || topicObject.isEmpty())
+               continue;
+
+            ArrayNode timestamps = (ArrayNode) topicObject.get(timestampKey);
+            ArrayNode messages = (ArrayNode) topicObject.get(messageKey);
+
+            if (timestamps.size() != messages.size())
+            {
+               LogTools.error("Number of timestamps does not match number of messages");
+               return null;
+            }
+
+            for (int message_idx = 0; message_idx < timestamps.size(); message_idx++)
+            {
+               long timestamp = timestamps.get(message_idx).longValue();
+               Object message = serializer.deserialize(messages.get(message_idx).asText());
+
+               topicManager.getTimestamps().add(timestamp);
+               topicManager.getMessages().add(message);
+            }
+
+            topicManagers.add(topicManager);
+         }
+
+         return topicManagers;
+      }
+      catch (Exception e)
+      {
+         e.printStackTrace();
+         return null;
+      }
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogRecord.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogRecord.java
@@ -1,0 +1,100 @@
+package us.ihmc.communication.ros2log;
+
+import toolbox_msgs.msg.dds.ROS2LogMessage;
+import us.ihmc.commons.thread.ThreadTools;
+import us.ihmc.communication.ROS2Tools;
+import us.ihmc.log.LogTools;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2NodeBuilder;
+import us.ihmc.ros2.ROS2Topic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.LongSupplier;
+
+public class ROS2LogRecord
+{
+   private static final String MODULE_NAME = "ros2_log";
+
+   private final ROS2Node ros2Node;
+   private final List<RecordTopicManager<?>> topicManagers = new ArrayList<>();
+   private final AtomicBoolean stopRequested = new AtomicBoolean();
+   private final ROS2LogSerialization serialization;
+
+   private Runnable runnable = null;
+   private ScheduledThreadPoolExecutor executorService;
+
+   public ROS2LogRecord(String robotName, List<ROS2Topic<?>> topicsToLog, ROS2LogTimeSource timeSource, ROS2LogSerialization serialization)
+   {
+      ros2Node = new ROS2NodeBuilder().build("ihmc_ros2_logger");
+      this.serialization = serialization;
+
+      ros2Node.createSubscription(getROS2LogTopic(), s ->
+      {
+         ROS2LoggerRequestedState requestedState = ROS2LoggerRequestedState.fromByte(s.takeNextData().getRequestedState());
+         if (requestedState == ROS2LoggerRequestedState.START)
+            start();
+         else if (requestedState == ROS2LoggerRequestedState.FINISH)
+            stopRequested.set(true);
+      });
+      LongSupplier timestampProvider = timeSource.createTimestampProvider(robotName, ros2Node);
+
+      for (int i = 0; i < topicsToLog.size(); i++)
+      {
+         ROS2Topic<?> ros2Topic = topicsToLog.get(i);
+         topicManagers.add(new RecordTopicManager<>(ros2Topic, ros2Node, timestampProvider));
+      }
+
+      ThreadTools.sleepForever();
+   }
+
+   public void start()
+   {
+      if (runnable != null)
+         return;
+
+      LogTools.info("Starting ROS 2 logger");
+      runnable = this::update;
+      stopRequested.set(false);
+
+      executorService = new ScheduledThreadPoolExecutor(1);
+      executorService.scheduleAtFixedRate(runnable, 0, 1, TimeUnit.MILLISECONDS);
+   }
+
+   public void update()
+   {
+      if (runnable == null)
+         return;
+
+      if (stopRequested.getAndSet(false))
+      {
+         LogTools.info("Stopping ROS 2 logger, writing to file...");
+
+         // write log file
+         ROS2LogIOTools.writeLogFile(topicManagers, serialization);
+         runnable = null;
+         executorService.shutdown();
+
+         // clear old data
+         for (int i = 0; i < topicManagers.size(); i++)
+         {
+            topicManagers.get(i).clear();
+         }
+
+         return;
+      }
+
+      for (int i = 0; i < topicManagers.size(); i++)
+      {
+         topicManagers.get(i).update();
+      }
+   }
+
+   public static ROS2Topic<ROS2LogMessage> getROS2LogTopic()
+   {
+      return ROS2Tools.IHMC_ROOT.withModule(MODULE_NAME).withTypeName(ROS2LogMessage.class);
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogReplay.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogReplay.java
@@ -1,0 +1,57 @@
+package us.ihmc.communication.ros2log;
+
+import com.google.common.base.CaseFormat;
+import us.ihmc.commons.thread.ThreadTools;
+import us.ihmc.log.LogTools;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2NodeBuilder;
+import us.ihmc.ros2.ROS2Topic;
+
+import java.io.File;
+import java.util.List;
+import java.util.function.LongSupplier;
+
+public class ROS2LogReplay
+{
+   public ROS2LogReplay(String robotName, List<ROS2Topic<?>> topicsToLog, File logFile, ROS2LogTimeSource timeSource)
+   {
+      ROS2Node ros2Node = new ROS2NodeBuilder().build("ihmc_" + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, getClass().getSimpleName()));
+      List<ReplayTopicManager<?>> topicManagers = ROS2LogIOTools.loadLogFile(ros2Node, topicsToLog, logFile);
+      if (topicManagers == null)
+         return;
+
+      LongSupplier timestampSupplier = timeSource.createTimestampProvider(robotName, ros2Node);
+      if (timeSource == ROS2LogTimeSource.SIMULATION)
+      {
+         while (timestampSupplier.getAsLong() == -1)
+         {
+            LogTools.info("Waiting for simulation timestamp");
+            ThreadTools.sleep(1000);
+         }
+      }
+
+      LogTools.info("Starting replay of " + logFile.getName());
+      startReplay(topicManagers, timestampSupplier);
+      LogTools.info("Finished replay");
+   }
+
+   private void startReplay(List<ReplayTopicManager<?>> topicManagers, LongSupplier timestampSupplier)
+   {
+      long startTime = timestampSupplier.getAsLong();
+
+      while (true)
+      {
+         long now = timestampSupplier.getAsLong() - startTime;
+         boolean isDone = true;
+
+         for (int topic_idx = 0; topic_idx < topicManagers.size(); topic_idx++)
+         {
+            ReplayTopicManager<?> topicManager = topicManagers.get(topic_idx);
+            isDone = topicManager.update(now) && isDone;
+         }
+
+         if (isDone)
+            break;
+      }
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogSerialization.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogSerialization.java
@@ -1,0 +1,56 @@
+package us.ihmc.communication.ros2log;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import us.ihmc.idl.serializers.extra.AbstractSerializer;
+import us.ihmc.idl.serializers.extra.JSONSerializer;
+import us.ihmc.idl.serializers.extra.YAMLSerializer;
+import us.ihmc.pubsub.TopicDataType;
+
+public enum ROS2LogSerialization
+{
+   JSON, YAML;
+
+   public ObjectMapper createObjectMapper()
+   {
+      switch (this)
+      {
+         case JSON:
+            return new ObjectMapper(new JsonFactory());
+         case YAML:
+            return new ObjectMapper(new YAMLFactory());
+         default:
+            throw new RuntimeException("Unrecognized serialization entry: " + this);
+      }
+   }
+
+   public <T> AbstractSerializer<T> createSerializer(TopicDataType<T> topicDataType)
+   {
+      switch (this)
+      {
+         case JSON:
+            return new JSONSerializer<>(topicDataType);
+         case YAML:
+            return new YAMLSerializer<>(topicDataType);
+         default:
+            throw new RuntimeException("Unrecognized serialization entry: " + this);
+      }
+   }
+
+   public String getFilePostfix()
+   {
+      return name().toLowerCase();
+   }
+
+   public static ROS2LogSerialization fromFileName(String fileName)
+   {
+      for (ROS2LogSerialization serialization : ROS2LogSerialization.values())
+      {
+         if (fileName.endsWith(serialization.getFilePostfix()))
+            return serialization;
+      }
+
+      return null;
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogTimeSource.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LogTimeSource.java
@@ -1,0 +1,38 @@
+package us.ihmc.communication.ros2log;
+
+import controller_msgs.msg.dds.RobotConfigurationData;
+import us.ihmc.commons.Conversions;
+import us.ihmc.communication.HumanoidControllerAPI;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2Topic;
+
+import java.time.Clock;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
+
+public enum ROS2LogTimeSource
+{
+   /* Record/Replay is timestamped by system time */
+   SYSTEM,
+   /* Record/Replay is timestamped by simulation time via RobotConfigurationData#getSyncTimestamp */
+   SIMULATION;
+
+   public LongSupplier createTimestampProvider(String robotName, ROS2Node ros2Node)
+   {
+      if (this == ROS2LogTimeSource.SYSTEM)
+      {
+         return Clock.systemUTC()::millis;
+      }
+      else
+      {
+         AtomicLong timestamp = new AtomicLong(-1);
+
+         ROS2Topic<?> controllerOutputTopic = HumanoidControllerAPI.getOutputTopic(robotName);
+         ROS2Topic<RobotConfigurationData> robotConfigurationData = controllerOutputTopic.withTypeName(RobotConfigurationData.class);
+         ros2Node.createSubscription(robotConfigurationData, s -> timestamp.set(Conversions.nanosecondsToMilliseconds(s.takeNextData().getSyncTimestamp())));
+
+         return timestamp::get;
+      }
+   }
+
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LoggerRequestedState.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ROS2LoggerRequestedState.java
@@ -1,0 +1,24 @@
+package us.ihmc.communication.ros2log;
+
+/**
+ * Verbose way of expressing ROS 2 log state. Setup as enum in case future states are needed.
+ */
+public enum ROS2LoggerRequestedState
+{
+   /* Start recording/replaying */
+   START,
+   /* Finish recording/replaying */
+   FINISH;
+
+   public byte toByte()
+   {
+      return (byte) ordinal();
+   }
+
+   public static ROS2LoggerRequestedState fromByte(byte enumAsByte)
+   {
+      if (enumAsByte == -1)
+         return null;
+      return values()[enumAsByte];
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/RecordTopicManager.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/RecordTopicManager.java
@@ -1,0 +1,72 @@
+package us.ihmc.communication.ros2log;
+
+import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.tuple.Pair;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2Topic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+class RecordTopicManager<T>
+{
+   private final ROS2Topic<T> ros2Topic;
+   private final AtomicReference<Pair<Long, T>> latestData = new AtomicReference<>();
+   private final List<T> messages = new ArrayList<>();
+   private final TLongArrayList timestamps = new TLongArrayList();
+
+   /**
+    * Record constructor. LongSupplier provides a timestamp in milliseconds and should be thread-safe
+    */
+   RecordTopicManager(ROS2Topic<T> ros2Topic, ROS2Node ros2Node, LongSupplier timestampSupplier)
+   {
+      this.ros2Topic = ros2Topic;
+
+      ros2Node.createSubscription(ros2Topic, s ->
+      {
+         long timestamp = timestampSupplier.getAsLong();
+         latestData.set(Pair.of(timestamp, s.takeNextData()));
+      });
+   }
+
+   void update()
+   {
+      Pair<Long, T> data = this.latestData.getAndSet(null);
+
+      if (data != null)
+      {
+         timestamps.add(data.getLeft());
+         messages.add(data.getRight());
+      }
+   }
+
+   void clear()
+   {
+      messages.clear();
+      timestamps.clear();
+      latestData.set(null);
+   }
+
+   ROS2Topic<T> getTopic()
+   {
+      return ros2Topic;
+   }
+
+   List<T> getMessages()
+   {
+      return messages;
+   }
+
+   TLongArrayList getTimestamps()
+   {
+      return timestamps;
+   }
+
+   /* for testing */
+   AtomicReference<Pair<Long,T>> getDataReference()
+   {
+      return latestData;
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ReplayTopicManager.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2log/ReplayTopicManager.java
@@ -1,0 +1,66 @@
+package us.ihmc.communication.ros2log;
+
+import gnu.trove.list.array.TLongArrayList;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2Publisher;
+import us.ihmc.ros2.ROS2Topic;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class ReplayTopicManager<T>
+{
+   private final ROS2Publisher<T> publisher;
+   private final List<T> messages = new ArrayList<>();
+   private final TLongArrayList timestamps = new TLongArrayList();
+
+   private int lastSentIndex = -1;
+   private boolean isDone = false;
+
+   ReplayTopicManager(ROS2Topic<T> ros2Topic, ROS2Node ros2Node)
+   {
+      this.publisher = ros2Node.createPublisher(ros2Topic);
+   }
+
+   boolean update(long currentTime)
+   {
+      if (!isDone)
+         updateInternal(currentTime);
+      return isDone;
+   }
+
+   private void updateInternal(long currentTime)
+   {
+      int latestIndex = getLatestIndex(currentTime);
+
+      if (latestIndex != lastSentIndex)
+      {
+         publisher.publish(messages.get(latestIndex));
+         lastSentIndex = latestIndex;
+      }
+      isDone = latestIndex == timestamps.size() - 1;
+   }
+
+   /**
+    * Highest index timestamp less than the current time
+    */
+   private int getLatestIndex(long currentTime)
+   {
+      int indexToCheck = lastSentIndex + 1;
+      while (indexToCheck < timestamps.size() && timestamps.get(indexToCheck) < currentTime)
+      {
+         indexToCheck++;
+      }
+      return indexToCheck - 1;
+   }
+
+   List<T> getMessages()
+   {
+      return messages;
+   }
+
+   TLongArrayList getTimestamps()
+   {
+      return timestamps;
+   }
+}

--- a/ihmc-communication/src/test/java/us/ihmc/communication/ros2log/ROS2LogTest.java
+++ b/ihmc-communication/src/test/java/us/ihmc/communication/ros2log/ROS2LogTest.java
@@ -1,0 +1,69 @@
+package us.ihmc.communication.ros2log;
+
+import com.google.common.base.CaseFormat;
+import controller_msgs.msg.dds.RobotConfigurationData;
+import gnu.trove.list.array.TLongArrayList;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import us.ihmc.communication.HumanoidControllerAPI;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2NodeBuilder;
+import us.ihmc.ros2.ROS2Topic;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class ROS2LogTest
+{
+   @Test
+   public void testLogExportAndImport()
+   {
+      // Test logging to file
+      String robotName = "Robot";
+
+      for (ROS2LogSerialization serialization : ROS2LogSerialization.values())
+      {
+         ROS2Topic<?> controllerOutputTopic = HumanoidControllerAPI.getOutputTopic(robotName);
+         ROS2Topic<RobotConfigurationData> robotConfigurationData = controllerOutputTopic.withTypeName(RobotConfigurationData.class);
+         ROS2Node ros2Node = new ROS2NodeBuilder().build("ihmc_" + CaseFormat.UPPER_CAMEL.to(CaseFormat.LOWER_UNDERSCORE, "test_node"));
+
+         // Test record/writing
+         List<RecordTopicManager<?>> rosTopicManagers = new ArrayList<>();
+
+         RecordTopicManager topicManagerExport = new RecordTopicManager(robotConfigurationData, ros2Node, System::currentTimeMillis);
+
+         RobotConfigurationData messageExport0 = new RobotConfigurationData();
+         RobotConfigurationData messageExport1 = new RobotConfigurationData();
+         messageExport0.setSequenceId(1);
+         messageExport1.setSequenceId(2);
+
+         topicManagerExport.getDataReference().set(Pair.of(100L, messageExport0));
+         topicManagerExport.update();
+         topicManagerExport.getDataReference().set(Pair.of(200L, messageExport1));
+         topicManagerExport.update();
+
+         rosTopicManagers.add(topicManagerExport);
+         String fileName = ROS2LogIOTools.writeLogFile(rosTopicManagers, serialization);
+         Assertions.assertTrue(fileName != null);
+
+         // Test loading file
+         List<ReplayTopicManager<?>> topicManagers = ROS2LogIOTools.loadLogFile(ros2Node, Arrays.asList(robotConfigurationData), new File(fileName));
+         Assertions.assertTrue(topicManagers.size() == 1);
+
+         ReplayTopicManager<?> topicManagerImport = topicManagers.get(0);
+         TLongArrayList importedTimestamps = topicManagerImport.getTimestamps();
+         List<?> importedMessages = topicManagerImport.getMessages();
+
+         Assertions.assertTrue(importedTimestamps.size() == 2);
+         Assertions.assertTrue(importedTimestamps.get(0) == 0L);
+         Assertions.assertTrue(importedTimestamps.get(1) == 100L);
+
+         Assertions.assertTrue(importedMessages.size() == 2);
+         Assertions.assertTrue(messageExport0.epsilonEquals((RobotConfigurationData) importedMessages.get(0), 1.0e-12));
+         Assertions.assertTrue(messageExport1.epsilonEquals((RobotConfigurationData) importedMessages.get(1), 1.0e-12));
+      }
+   }
+}

--- a/ihmc-interfaces/src/main/generated-idl/toolbox_msgs/msg/ROS2LogMessage_.idl
+++ b/ihmc-interfaces/src/main/generated-idl/toolbox_msgs/msg/ROS2LogMessage_.idl
@@ -1,0 +1,34 @@
+#ifndef __toolbox_msgs__msg__ROS2LogMessage__idl__
+#define __toolbox_msgs__msg__ROS2LogMessage__idl__
+
+module toolbox_msgs
+{
+  module msg
+  {
+    module dds
+    {
+      const octet ROS2_LOG_REQUESTED_STATE_START =
+      0;
+
+      const octet ROS2_LOG_REQUESTED_STATE_FINISH =
+      1;
+
+
+      /**
+       * This message is used to start and stop recording ROS logs.
+       * This is used both for recording and replaying, see ROS2LogRecord and ROS2LogReplay for more information.
+       */
+      @TypeCode(type="toolbox_msgs::msg::dds_::ROS2LogMessage_")
+      struct ROS2LogMessage
+      {
+        /**
+         * Requested state for the ROS 2 log recorder
+         */
+        @defaultValue(value=255)
+        octet requested_state;
+      };
+    };
+  };
+};
+
+#endif

--- a/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/ROS2LogMessage.java
+++ b/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/ROS2LogMessage.java
@@ -1,0 +1,102 @@
+package toolbox_msgs.msg.dds;
+
+import us.ihmc.communication.packets.Packet;
+import us.ihmc.euclid.interfaces.Settable;
+import us.ihmc.euclid.interfaces.EpsilonComparable;
+import java.util.function.Supplier;
+import us.ihmc.pubsub.TopicDataType;
+
+/**
+       * This message is used to start and stop recording ROS logs.
+       * This is used both for recording and replaying, see ROS2LogRecord and ROS2LogReplay for more information.
+       */
+public class ROS2LogMessage extends Packet<ROS2LogMessage> implements Settable<ROS2LogMessage>, EpsilonComparable<ROS2LogMessage>
+{
+   public static final byte ROS2_LOG_REQUESTED_STATE_START = (byte) 0;
+   public static final byte ROS2_LOG_REQUESTED_STATE_FINISH = (byte) 1;
+   /**
+            * Requested state for the ROS 2 log recorder
+            */
+   public byte requested_state_ = (byte) 255;
+
+   public ROS2LogMessage()
+   {
+   }
+
+   public ROS2LogMessage(ROS2LogMessage other)
+   {
+      this();
+      set(other);
+   }
+
+   public void set(ROS2LogMessage other)
+   {
+      requested_state_ = other.requested_state_;
+
+   }
+
+   /**
+            * Requested state for the ROS 2 log recorder
+            */
+   public void setRequestedState(byte requested_state)
+   {
+      requested_state_ = requested_state;
+   }
+   /**
+            * Requested state for the ROS 2 log recorder
+            */
+   public byte getRequestedState()
+   {
+      return requested_state_;
+   }
+
+
+   public static Supplier<ROS2LogMessagePubSubType> getPubSubType()
+   {
+      return ROS2LogMessagePubSubType::new;
+   }
+
+   @Override
+   public Supplier<TopicDataType> getPubSubTypePacket()
+   {
+      return ROS2LogMessagePubSubType::new;
+   }
+
+   @Override
+   public boolean epsilonEquals(ROS2LogMessage other, double epsilon)
+   {
+      if(other == null) return false;
+      if(other == this) return true;
+
+      if (!us.ihmc.idl.IDLTools.epsilonEqualsPrimitive(this.requested_state_, other.requested_state_, epsilon)) return false;
+
+      return true;
+   }
+
+   @Override
+   public boolean equals(Object other)
+   {
+      if(other == null) return false;
+      if(other == this) return true;
+      if(!(other instanceof ROS2LogMessage)) return false;
+
+      ROS2LogMessage otherMyClass = (ROS2LogMessage) other;
+
+      if(this.requested_state_ != otherMyClass.requested_state_) return false;
+
+
+      return true;
+   }
+
+   @Override
+   public java.lang.String toString()
+   {
+      StringBuilder builder = new StringBuilder();
+
+      builder.append("ROS2LogMessage {");
+      builder.append("requested_state=");
+      builder.append(this.requested_state_);
+      builder.append("}");
+      return builder.toString();
+   }
+}

--- a/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/ROS2LogMessagePubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/toolbox_msgs/msg/dds/ROS2LogMessagePubSubType.java
@@ -1,0 +1,143 @@
+package toolbox_msgs.msg.dds;
+
+/**
+* 
+* Topic data type of the struct "ROS2LogMessage" defined in "ROS2LogMessage_.idl". Use this class to provide the TopicDataType to a Participant. 
+*
+* This file was automatically generated from ROS2LogMessage_.idl by us.ihmc.idl.generator.IDLGenerator. 
+* Do not update this file directly, edit ROS2LogMessage_.idl instead.
+*
+*/
+public class ROS2LogMessagePubSubType implements us.ihmc.pubsub.TopicDataType<toolbox_msgs.msg.dds.ROS2LogMessage>
+{
+   public static final java.lang.String name = "toolbox_msgs::msg::dds_::ROS2LogMessage_";
+   
+   @Override
+   public final java.lang.String getDefinitionChecksum()
+   {
+   		return "d7c52a1992eaab3574f9b0120c1cc0955b70717027a483e6445fd9c8d72d28fb";
+   }
+   
+   @Override
+   public final java.lang.String getDefinitionVersion()
+   {
+   		return "local";
+   }
+
+   private final us.ihmc.idl.CDR serializeCDR = new us.ihmc.idl.CDR();
+   private final us.ihmc.idl.CDR deserializeCDR = new us.ihmc.idl.CDR();
+
+   @Override
+   public void serialize(toolbox_msgs.msg.dds.ROS2LogMessage data, us.ihmc.pubsub.common.SerializedPayload serializedPayload) throws java.io.IOException
+   {
+      serializeCDR.serialize(serializedPayload);
+      write(data, serializeCDR);
+      serializeCDR.finishSerialize();
+   }
+
+   @Override
+   public void deserialize(us.ihmc.pubsub.common.SerializedPayload serializedPayload, toolbox_msgs.msg.dds.ROS2LogMessage data) throws java.io.IOException
+   {
+      deserializeCDR.deserialize(serializedPayload);
+      read(data, deserializeCDR);
+      deserializeCDR.finishDeserialize();
+   }
+
+   public static int getMaxCdrSerializedSize()
+   {
+      return getMaxCdrSerializedSize(0);
+   }
+
+   public static int getMaxCdrSerializedSize(int current_alignment)
+   {
+      int initial_alignment = current_alignment;
+
+      current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
+
+
+      return current_alignment - initial_alignment;
+   }
+
+   public final static int getCdrSerializedSize(toolbox_msgs.msg.dds.ROS2LogMessage data)
+   {
+      return getCdrSerializedSize(data, 0);
+   }
+
+   public final static int getCdrSerializedSize(toolbox_msgs.msg.dds.ROS2LogMessage data, int current_alignment)
+   {
+      int initial_alignment = current_alignment;
+
+      current_alignment += 1 + us.ihmc.idl.CDR.alignment(current_alignment, 1);
+
+
+
+      return current_alignment - initial_alignment;
+   }
+
+   public static void write(toolbox_msgs.msg.dds.ROS2LogMessage data, us.ihmc.idl.CDR cdr)
+   {
+      cdr.write_type_9(data.getRequestedState());
+
+   }
+
+   public static void read(toolbox_msgs.msg.dds.ROS2LogMessage data, us.ihmc.idl.CDR cdr)
+   {
+      data.setRequestedState(cdr.read_type_9());
+      	
+
+   }
+
+   @Override
+   public final void serialize(toolbox_msgs.msg.dds.ROS2LogMessage data, us.ihmc.idl.InterchangeSerializer ser)
+   {
+      ser.write_type_9("requested_state", data.getRequestedState());
+   }
+
+   @Override
+   public final void deserialize(us.ihmc.idl.InterchangeSerializer ser, toolbox_msgs.msg.dds.ROS2LogMessage data)
+   {
+      data.setRequestedState(ser.read_type_9("requested_state"));   }
+
+   public static void staticCopy(toolbox_msgs.msg.dds.ROS2LogMessage src, toolbox_msgs.msg.dds.ROS2LogMessage dest)
+   {
+      dest.set(src);
+   }
+
+   @Override
+   public toolbox_msgs.msg.dds.ROS2LogMessage createData()
+   {
+      return new toolbox_msgs.msg.dds.ROS2LogMessage();
+   }
+   @Override
+   public int getTypeSize()
+   {
+      return us.ihmc.idl.CDR.getTypeSize(getMaxCdrSerializedSize());
+   }
+
+   @Override
+   public java.lang.String getName()
+   {
+      return name;
+   }
+   
+   public void serialize(toolbox_msgs.msg.dds.ROS2LogMessage data, us.ihmc.idl.CDR cdr)
+   {
+      write(data, cdr);
+   }
+
+   public void deserialize(toolbox_msgs.msg.dds.ROS2LogMessage data, us.ihmc.idl.CDR cdr)
+   {
+      read(data, cdr);
+   }
+   
+   public void copy(toolbox_msgs.msg.dds.ROS2LogMessage src, toolbox_msgs.msg.dds.ROS2LogMessage dest)
+   {
+      staticCopy(src, dest);
+   }
+
+   @Override
+   public ROS2LogMessagePubSubType newInstance()
+   {
+      return new ROS2LogMessagePubSubType();
+   }
+}

--- a/ihmc-interfaces/src/main/messages/ihmc_interfaces/toolbox_msgs/msg/ROS2LogMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ihmc_interfaces/toolbox_msgs/msg/ROS2LogMessage.msg
@@ -1,0 +1,8 @@
+# This message is used to start and stop recording ROS logs.
+# This is used both for recording and replaying, see ROS2LogRecord and ROS2LogReplay for more information.
+
+byte ROS2_LOG_REQUESTED_STATE_START=0
+byte ROS2_LOG_REQUESTED_STATE_FINISH=1
+
+# Requested state for the ROS 2 log recorder
+byte requested_state 255

--- a/ihmc-interfaces/src/main/messages/ros1/toolbox_msgs/msg/ROS2LogMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ros1/toolbox_msgs/msg/ROS2LogMessage.msg
@@ -1,0 +1,12 @@
+# This message is used to start and stop recording ROS logs.
+# This is used both for recording and replaying, see ROS2LogRecord and ROS2LogReplay for more information.
+
+int8 ROS2_LOG_REQUESTED_STATE_START=0
+
+int8 ROS2_LOG_REQUESTED_STATE_FINISH=1
+
+# Requested state for the ROS 2 log recorder
+# Field default value 255
+int8 requested_state
+
+


### PR DESCRIPTION
ROS 2 logger analogous to ROS 2 bag using our stack. Time source can either be wall or simulation and it uses Jackson for serialization, which is also baked into pub-sub classes. I've done a couple ad-hoc implementation of this but making it more generic here.