### PR TITLE
Scene graph demo improvements

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXDepthStreamingDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXDepthStreamingDemo.java
@@ -21,6 +21,7 @@ import us.ihmc.sensors.zed.ZEDImageSensor;
 import us.ihmc.sensors.zed.ZEDModelData;
 import us.ihmc.sensors.zed.ZEDSVOPlaybackSensor;
 import us.ihmc.tools.IHMCCommonPaths;
+import us.ihmc.zed.global.zed;
 
 public class RDXDepthStreamingDemo
 {
@@ -29,7 +30,7 @@ public class RDXDepthStreamingDemo
    private final ROS2Node ros2Node = new ROS2NodeBuilder().build(RDXDepthStreamingDemo.class.getSimpleName());
    private final ROS2Helper ros2Helper = new ROS2Helper(ros2Node);
 
-   private final ZEDSVOPlaybackSensor zed = new ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, SVO_FILE);
+   private final ZEDSVOPlaybackSensor zedPlaybackSensor = new ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, zed.SL_DEPTH_MODE_PERFORMANCE, SVO_FILE);
 
    private final CUDADepthColorizer depthColorizer = new CUDADepthColorizer();
    private final ROS2SRTSensorStreamer sensorStreamer = new ROS2SRTSensorStreamer(ros2Node);
@@ -45,8 +46,8 @@ public class RDXDepthStreamingDemo
 
    public RDXDepthStreamingDemo() throws Exception
    {
-      zed.useTrackedPose(true);
-      zed.run(true);
+      zedPlaybackSensor.useTrackedPose(true);
+      zedPlaybackSensor.run(true);
       zedPublishThread.startRepeating();
 
       depthSubscriber.addNewFrameConsumer(this::receiveColorizedDepth);
@@ -96,9 +97,9 @@ public class RDXDepthStreamingDemo
    {
       try (Mat rgbMat = new Mat())
       {
-         zed.waitForGrab();
-         RawImage depthImage = zed.getImage(ZEDImageSensor.DEPTH_IMAGE_KEY);
-         RawImage colorImage = zed.getImage(ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);
+         zedPlaybackSensor.waitForGrab();
+         RawImage depthImage = zedPlaybackSensor.getImage(ZEDImageSensor.DEPTH_IMAGE_KEY);
+         RawImage colorImage = zedPlaybackSensor.getImage(ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);
 
          GpuMat colorizedDepth = depthColorizer.colorizeDepth(depthImage.getGpuImageMat());
          RawImage colorizedDepthImage = depthImage.replaceImage(colorizedDepth, PixelFormat.YUV444P);
@@ -141,7 +142,7 @@ public class RDXDepthStreamingDemo
    public void destroy()
    {
       zedPublishThread.blockingKill();
-      zed.close();
+      zedPlaybackSensor.close();
       depthColorizer.destroy();
       sensorStreamer.destroy();
       depthSubscriber.destroy();

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXZEDSVORecorderPanel.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXZEDSVORecorderPanel.java
@@ -21,7 +21,7 @@ public class RDXZEDSVORecorderPanel
    private final ROS2Helper ros2Helper;
    private ZEDSVOCurrentFileMessage latestMessage;
 
-   private final ImInt requestedPosition = new ImInt(0);
+   private final ImInt requestedPosition = new ImInt();
    private boolean holdingOnToTheSlider;
    private boolean paused;
 

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXZEDSVORecorderPanel.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXZEDSVORecorderPanel.java
@@ -4,13 +4,13 @@ import imgui.ImGui;
 import imgui.type.ImInt;
 import perception_msgs.msg.dds.ZEDSVOCurrentFileMessage;
 import std_msgs.msg.dds.Int64;
+import us.ihmc.commons.thread.Throttler;
 import us.ihmc.communication.PerceptionAPI;
 import us.ihmc.communication.ros2.ROS2Helper;
 import us.ihmc.rdx.imgui.ImGuiTools;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
 import us.ihmc.rdx.ui.RDXBaseUI;
 import us.ihmc.sensors.deprecated.ZEDColorDepthImageRetrieverSVO.RecordMode;
-import us.ihmc.commons.thread.Throttler;
 
 public class RDXZEDSVORecorderPanel
 {
@@ -21,7 +21,7 @@ public class RDXZEDSVORecorderPanel
    private final ROS2Helper ros2Helper;
    private ZEDSVOCurrentFileMessage latestMessage;
 
-   private final ImInt requestedPosition = new ImInt();
+   private final ImInt requestedPosition = new ImInt(0);
    private boolean holdingOnToTheSlider;
    private boolean paused;
 
@@ -58,7 +58,7 @@ public class RDXZEDSVORecorderPanel
          if (!holdingOnToTheSlider)
             requestedPosition.set((int) latestMessage.getCurrentPosition());
 
-         if (ImGuiTools.sliderInt(labels.get("Position"), requestedPosition, 0, (int) latestMessage.getLength()))
+         if (ImGuiTools.sliderInt(labels.get("Position"), requestedPosition, 0, Math.max((int) latestMessage.getLength(), 0)))
          {
             holdingOnToTheSlider = true;
 

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
@@ -12,6 +12,7 @@ import us.ihmc.perception.BytedecoImage;
 import us.ihmc.perception.ImageSensorPublishThread;
 import us.ihmc.perception.RawImage;
 import us.ihmc.perception.comms.PerceptionComms;
+import us.ihmc.perception.cuda.CUDATools;
 import us.ihmc.perception.detections.DetectionManager;
 import us.ihmc.perception.detections.yolo.YOLOv8DetectionExecutor;
 import us.ihmc.perception.opencl.OpenCLManager;
@@ -144,6 +145,8 @@ public class RDXSceneGraphDemo
             baseUI.getPrimaryScene().addRenderableProvider(sensorPoseGraphic, RDXSceneLevel.VIRTUAL);
 
             zedSVOPlayer = new ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, SVO_FILE_NAME);
+            boolean disableNeuralMode = !CUDATools.hasCUDADeviceOfAtLeast(CUDATools.getFirstDeviceName(), "RTX 3080");
+            zedSVOPlayer.disableNeuralMode(disableNeuralMode);
             zedSVOPlayer.useTrackedPose(true);
             zedSVOPlayer.run(true);
 

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
@@ -145,7 +145,7 @@ public class RDXSceneGraphDemo
             baseUI.getPrimaryScene().addRenderableProvider(sensorPoseGraphic, RDXSceneLevel.VIRTUAL);
 
             zedSVOPlayer = new ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, SVO_FILE_NAME);
-            boolean disableNeuralMode = !CUDATools.hasCUDADeviceOfAtLeast(CUDATools.getFirstDeviceName(), "RTX 3080");
+            boolean disableNeuralMode = !CUDATools.hasCUDADeviceOfAtLeast(CUDATools.getDeviceName(0), "RTX 3080");
             zedSVOPlayer.disableNeuralMode(disableNeuralMode);
             zedSVOPlayer.useTrackedPose(true);
             zedSVOPlayer.run(true);

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
@@ -49,6 +49,9 @@ import us.ihmc.tools.IHMCCommonPaths;
 
 import java.util.Map;
 
+import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_NEURAL;
+import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
+
 /**
  * A self contained demo and development environment for our scene graph functionality.
  * Requires everything installed from ihmc-perception/README.md
@@ -144,9 +147,8 @@ public class RDXSceneGraphDemo
             sensorPoseGraphic = RDXModelBuilder.createCoordinateFrameInstance(0.1);
             baseUI.getPrimaryScene().addRenderableProvider(sensorPoseGraphic, RDXSceneLevel.VIRTUAL);
 
-            zedSVOPlayer = new ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, SVO_FILE_NAME);
-            boolean disableNeuralMode = !CUDATools.hasCUDADeviceOfAtLeast(CUDATools.getDeviceName(0), "RTX 3080");
-            zedSVOPlayer.disableNeuralMode(disableNeuralMode);
+            boolean enableNeuralMode = CUDATools.hasCUDADeviceOfAtLeast(CUDATools.getDeviceName(0), "RTX 3080");
+            zedSVOPlayer = new ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, enableNeuralMode ? SL_DEPTH_MODE_NEURAL : SL_DEPTH_MODE_PERFORMANCE, SVO_FILE_NAME);
             zedSVOPlayer.useTrackedPose(true);
             zedSVOPlayer.run(true);
 

--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXYOLOv8PipelineDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXYOLOv8PipelineDemo.java
@@ -35,6 +35,7 @@ import us.ihmc.sensors.zed.ZEDImageSensor;
 import us.ihmc.sensors.zed.ZEDModelData;
 import us.ihmc.sensors.zed.ZEDSVOPlaybackSensor;
 import us.ihmc.tools.IHMCCommonPaths;
+import us.ihmc.zed.global.zed;
 
 import java.io.File;
 import java.net.URL;
@@ -56,7 +57,7 @@ public class RDXYOLOv8PipelineDemo
    private final ROS2Node ros2Node = new ROS2NodeBuilder().build(RDXYOLOv8PipelineDemo.class.getSimpleName());
    private final ROS2Helper ros2Helper = new ROS2Helper(ros2Node);
 
-   private final ZEDSVOPlaybackSensor zed = new ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, SVO_FILE);
+   private final ZEDSVOPlaybackSensor zedPlaybackSensor = new ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, zed.SL_DEPTH_MODE_PERFORMANCE, SVO_FILE);
    private RawImage colorImage;
    private final RDXOpenCVVideoVisualizer colorImageVisualizer = new RDXOpenCVVideoVisualizer("ZED Color", "ZED Color", false);
    private RawImage depthImage;
@@ -111,13 +112,13 @@ public class RDXYOLOv8PipelineDemo
          availableModels.add(model.getName());
       }
 
-      zed.useTrackedPose(false);
-      zed.run(true);
+      zedPlaybackSensor.useTrackedPose(false);
+      zedPlaybackSensor.run(true);
       try
       {
-         zed.waitForGrab();
+         zedPlaybackSensor.waitForGrab();
       } catch (InterruptedException ignored) {}
-      zed.run(false);
+      zedPlaybackSensor.run(false);
 
       task = executor.submit(() -> grabFrame(frameToGrab.get()));
 
@@ -178,7 +179,7 @@ public class RDXYOLOv8PipelineDemo
          private void frameSettings()
          {
             ImGui.combo("YOLO Model", selectedDetector, availableModels.toArray(String[]::new));
-            if (ImGui.sliderInt("Frame", frameToGrab.getData(), 0, zed.getLength() - 1))
+            if (ImGui.sliderInt("Frame", frameToGrab.getData(), 0, zedPlaybackSensor.getLength() - 1))
             {
                task = executor.submit(() -> grabFrame(frameToGrab.get()));
                wasDone = false;
@@ -230,22 +231,22 @@ public class RDXYOLOv8PipelineDemo
 
    private void grabFrame(int frameToGrab)
    {
-      zed.setCurrentPosition(frameToGrab);
+      zedPlaybackSensor.setCurrentPosition(frameToGrab);
 
-      zed.run(true);
+      zedPlaybackSensor.run(true);
       try
       {
-         zed.waitForGrab();
+         zedPlaybackSensor.waitForGrab();
       } catch (InterruptedException ignored) {}
-      zed.run(false);
+      zedPlaybackSensor.run(false);
 
       if (colorImage != null)
          colorImage.release();
       if (depthImage != null)
          depthImage.release();
 
-      colorImage = zed.getImage(ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);
-      depthImage = zed.getImage(ZEDImageSensor.DEPTH_IMAGE_KEY);
+      colorImage = zedPlaybackSensor.getImage(ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);
+      depthImage = zedPlaybackSensor.getImage(ZEDImageSensor.DEPTH_IMAGE_KEY);
    }
 
    private void runYOLO()
@@ -472,7 +473,7 @@ public class RDXYOLOv8PipelineDemo
 
       depthImageSegmenter.destroy();
       pointCloudExtractor.close();
-      zed.close();
+      zedPlaybackSensor.close();
       ros2Node.destroy();
    }
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDATools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDATools.java
@@ -65,19 +65,24 @@ public class CUDATools
       return getCUDADeviceCount() > 0;
    }
 
-   public static String getFirstDeviceName()
+   /**
+    * Get the name of a CUDA device
+    * @param device the device number
+    * @return the name of the device
+    */
+   public static String getDeviceName(int device)
    {
-      try (IntPointer device = new IntPointer(1);
+      try (IntPointer devicePointer = new IntPointer(1);
            cudaDeviceProp deviceProperties = new cudaDeviceProp())
       {
-         cudaGetDevice(device);
-         cudaGetDeviceProperties(deviceProperties, device.get());
+         devicePointer.put(device);
+         cudaGetDeviceProperties(deviceProperties, devicePointer.get());
          return deviceProperties.name().getString();
       }
    }
 
    /**
-    * Attempts to score GPUs from a baseline device name (e.g. the minimum could be "RTX 2080 ti")
+    * Attempts to score GPUs from a baseline device name (e.g. the minimum could be "RTX 2080 Ti")
     *
     * @param deviceName        The device name to score
     * @param minimumDeviceName The device name to score against

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDATools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDATools.java
@@ -12,6 +12,8 @@ import org.bytedeco.javacpp.Pointer;
 import us.ihmc.log.LogTools;
 
 import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.bytedeco.cuda.global.cudart.*;
 import static org.bytedeco.cuda.global.nvjpeg.NVJPEG_STATUS_SUCCESS;
@@ -61,6 +63,61 @@ public class CUDATools
    public static boolean hasCUDADevice()
    {
       return getCUDADeviceCount() > 0;
+   }
+
+   public static String getFirstDeviceName()
+   {
+      try (IntPointer device = new IntPointer(1);
+           cudaDeviceProp deviceProperties = new cudaDeviceProp())
+      {
+         cudaGetDevice(device);
+         cudaGetDeviceProperties(deviceProperties, device.get());
+         return deviceProperties.name().getString();
+      }
+   }
+
+   /**
+    * Attempts to score GPUs from a baseline device name (e.g. the minimum could be "RTX 2080 ti")
+    *
+    * @param deviceName        The device name to score
+    * @param minimumDeviceName The device name to score against
+    * @return true if deviceName is equal-to-or-better minimumDeviceName in terms of relative CUDA performance
+    */
+   public static boolean hasCUDADeviceOfAtLeast(String deviceName, String minimumDeviceName)
+   {
+      final double gpuSeriesExp = 0.8; // How much to weight the GPU series
+      final int tiWeight = 5; // If the GPU is a Ti edition
+      final int superWeight = 5; // If the GPU is a SUPER edition
+
+      double minimumDeviceScore = 0.0;
+
+      // Find the device number (e.g. 1080)
+      Pattern numberPattern = Pattern.compile("\\d+");
+      Matcher deviceMatcher = numberPattern.matcher(deviceName);
+      Matcher minumumDeviceMatcher = numberPattern.matcher(minimumDeviceName);
+
+      if (minumumDeviceMatcher.find())
+      {
+         String gpuModel = minumumDeviceMatcher.group();
+         int gpuSeries = gpuModel.length() == 3 ? Integer.parseInt(gpuModel.substring(0, 1)) : Integer.parseInt(gpuModel.substring(0, 2));
+         int gpuTier = gpuModel.length() == 3 ? Integer.parseInt(gpuModel.substring(1, 3)) : Integer.parseInt(gpuModel.substring(2, 4));
+         boolean tiEdition = deviceName.toLowerCase().contains("ti");
+         boolean superEdition = deviceName.toLowerCase().contains("super");
+         minimumDeviceScore = Math.pow(gpuSeries, gpuSeriesExp) + gpuTier + (tiEdition ? tiWeight : 0) + (superEdition ? superWeight : 0);
+      }
+
+      if (deviceMatcher.find() && minimumDeviceScore > 0.0)
+      {
+         String gpuModel = deviceMatcher.group();
+         int gpuSeries = gpuModel.length() == 3 ? Integer.parseInt(gpuModel.substring(0, 1)) : Integer.parseInt(gpuModel.substring(0, 2));
+         int gpuTier = gpuModel.length() == 3 ? Integer.parseInt(gpuModel.substring(1, 3)) : Integer.parseInt(gpuModel.substring(2, 4));
+         boolean tiEdition = deviceName.toLowerCase().contains("ti");
+         boolean superEdition = deviceName.toLowerCase().contains("super");
+         double score = Math.pow(gpuSeries, gpuSeriesExp) + gpuTier + (tiEdition ? tiWeight : 0) + (superEdition ? superWeight : 0);
+         return score >= minimumDeviceScore;
+      }
+
+      return false;
    }
 
    /**

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
@@ -48,6 +48,7 @@ public class ZEDImageSensor extends ImageSensor
    private final int cameraID;
    private final ZEDModelData zedModel;
    private final int slInputType;
+   private final int slDepthMode;
    private final int streamingPort = nextStreamingPort++;
 
    private final RawImage[] grabbedImages = new RawImage[OUTPUT_IMAGE_COUNT];
@@ -73,15 +74,14 @@ public class ZEDImageSensor extends ImageSensor
    private final SL_Quaternion sensorRotation = new SL_Quaternion();
    private final SL_Vector3 sensorTranslation = new SL_Vector3();
 
-   private boolean disableNeuralMode;
-
-   public ZEDImageSensor(int cameraID, ZEDModelData zedModel, int slInputType)
+   public ZEDImageSensor(int cameraID, ZEDModelData zedModel, int slInputType, int slDepthMode)
    {
       super(zedModel.name());
 
       this.cameraID = cameraID;
       this.zedModel = zedModel;
       this.slInputType = slInputType;
+      this.slDepthMode = slDepthMode;
 
       // Set runtime parameters to default values
       zedRuntimeParameters.reference_frame(SL_REFERENCE_FRAME_CAMERA);
@@ -157,11 +157,6 @@ public class ZEDImageSensor extends ImageSensor
       return true;
    }
 
-   public void disableNeuralMode(boolean disableNeuralMode)
-   {
-      this.disableNeuralMode = disableNeuralMode;
-   }
-
    protected void setInitParameters(SL_InitParameters parametersToSet)
    {
       parametersToSet.camera_fps(CAMERA_FPS);
@@ -171,9 +166,9 @@ public class ZEDImageSensor extends ImageSensor
       parametersToSet.camera_image_flip(SL_FLIP_MODE_OFF);
       parametersToSet.camera_disable_self_calib(false);
       parametersToSet.enable_image_enhancement(true);
-      if (!disableNeuralMode)
+      if (slDepthMode == SL_DEPTH_MODE_NEURAL || slDepthMode == SL_DEPTH_MODE_NEURAL_PLUS)
          LogTools.info("ZED SDK will use neural depth mode. This uses significant GPU resources.");
-      parametersToSet.depth_mode(!disableNeuralMode ? SL_DEPTH_MODE_NEURAL : SL_DEPTH_MODE_PERFORMANCE);
+      parametersToSet.depth_mode(slDepthMode);
       parametersToSet.depth_stabilization(1);
       parametersToSet.depth_maximum_distance(zedModel.getMaximumDepthDistance());
       parametersToSet.depth_minimum_distance(zedModel.getMinimumDepthDistance());

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
@@ -73,6 +73,8 @@ public class ZEDImageSensor extends ImageSensor
    private final SL_Quaternion sensorRotation = new SL_Quaternion();
    private final SL_Vector3 sensorTranslation = new SL_Vector3();
 
+   private boolean disableNeuralMode;
+
    public ZEDImageSensor(int cameraID, ZEDModelData zedModel, int slInputType)
    {
       super(zedModel.name());
@@ -155,6 +157,11 @@ public class ZEDImageSensor extends ImageSensor
       return true;
    }
 
+   public void disableNeuralMode(boolean disableNeuralMode)
+   {
+      this.disableNeuralMode = disableNeuralMode;
+   }
+
    protected void setInitParameters(SL_InitParameters parametersToSet)
    {
       parametersToSet.camera_fps(CAMERA_FPS);
@@ -164,7 +171,9 @@ public class ZEDImageSensor extends ImageSensor
       parametersToSet.camera_image_flip(SL_FLIP_MODE_OFF);
       parametersToSet.camera_disable_self_calib(false);
       parametersToSet.enable_image_enhancement(true);
-      parametersToSet.depth_mode(SL_DEPTH_MODE_NEURAL);
+      if (!disableNeuralMode)
+         LogTools.info("ZED SDK will use neural depth mode. This uses significant GPU resources.");
+      parametersToSet.depth_mode(!disableNeuralMode ? SL_DEPTH_MODE_NEURAL : SL_DEPTH_MODE_PERFORMANCE);
       parametersToSet.depth_stabilization(1);
       parametersToSet.depth_maximum_distance(zedModel.getMaximumDepthDistance());
       parametersToSet.depth_minimum_distance(zedModel.getMinimumDepthDistance());

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDSVOPlaybackSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDSVOPlaybackSensor.java
@@ -18,9 +18,9 @@ public class ZEDSVOPlaybackSensor extends ZEDImageSensor
    private final ZEDSVOCurrentFileMessage svoStatusMessage = new ZEDSVOCurrentFileMessage();
    private final RepeatingTaskThread publishInfoThread;
 
-   public ZEDSVOPlaybackSensor(ROS2PublishSubscribeAPI ros2, int cameraID, ZEDModelData zedModel, String svoFileName)
+   public ZEDSVOPlaybackSensor(ROS2PublishSubscribeAPI ros2, int cameraID, ZEDModelData zedModel, int slDepthMode, String svoFileName)
    {
-      super(cameraID, zedModel, SL_INPUT_TYPE_SVO);
+      super(cameraID, zedModel, SL_INPUT_TYPE_SVO, slDepthMode);
       this.cameraID = cameraID;
       this.svoFileName = svoFileName;
 

--- a/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAToolsTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/cuda/CUDAToolsTest.java
@@ -1,0 +1,37 @@
+package us.ihmc.perception.cuda;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class CUDAToolsTest
+{
+   @Test
+   public void testHasCUDADeviceOfAtLeast()
+   {
+      final String minimumDeviceName = "RTX 2080 Ti";
+
+      // Slower GPUs than 2080 Ti
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("GT 710", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("GTX 650 Ti", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("GTX 970", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("GTX 980 Ti", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("GTX 1080 Ti", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("RTX 2060", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("RTX 2060 SUPER", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("RTX 2070 SUPER", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("RTX 3060 Ti", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("RTX 3070", minimumDeviceName));
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("RTX 4060", minimumDeviceName));
+
+      // Faster GPUs than 2080 Ti
+      Assertions.assertTrue(CUDATools.hasCUDADeviceOfAtLeast("RTX 2080 Ti", minimumDeviceName));
+      Assertions.assertTrue(CUDATools.hasCUDADeviceOfAtLeast("RTX 3080", minimumDeviceName));
+      Assertions.assertTrue(CUDATools.hasCUDADeviceOfAtLeast("RTX 3080 Ti", minimumDeviceName));
+      Assertions.assertTrue(CUDATools.hasCUDADeviceOfAtLeast("RTX 4080", minimumDeviceName));
+      Assertions.assertTrue(CUDATools.hasCUDADeviceOfAtLeast("RTX 4080 Ti", minimumDeviceName));
+      Assertions.assertTrue(CUDATools.hasCUDADeviceOfAtLeast("RTX 5090", minimumDeviceName));
+
+      // Check that a 1080 Ti is less powerful than an RTX 4070
+      Assertions.assertFalse(CUDATools.hasCUDADeviceOfAtLeast("GTX 1080 Ti", "RTX 4070"));
+   }
+}


### PR DESCRIPTION
- Fixes a somewhat common crashing bug related to the ZED SVO recorder panel
- Adds a utility for ensuring you have a GPU of some minimum spec (In the RDXSceneGraphDemo, this was problematic because ZED Neural mode takes so much GPU it is super laggy on lower end spec or laptops). This utility could also be useful other places.