### PR TITLE
Manually Freeing CUDA Memory

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/FilteredRapidHeightMapExtractor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/FilteredRapidHeightMapExtractor.java
@@ -77,7 +77,7 @@ public class FilteredRapidHeightMapExtractor
          CUDATools.checkCUDAError(error);
 
          currentIndex = (currentIndex + 1) % layers;
-         return latestGlobalHeightMap;
+         return latestGlobalHeightMap.clone();
       }
 
       GpuMat result = new GpuMat(rows, cols, opencv_core.CV_16UC1);

--- a/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractorCUDA.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractorCUDA.java
@@ -288,7 +288,11 @@ public class RapidHeightMapExtractorCUDA implements RapidHeightMapExtractorInter
       CUDATools.checkCUDAError(error);
 
       if (heightMapParameters.getEnableAlphaFilter())
-         globalHeightMapImage = filteredRapidHeightMapExtractor.update(globalHeightMapImage);
+      {
+         GpuMat filteredHeightMap = filteredRapidHeightMapExtractor.update(globalHeightMapImage);
+         globalHeightMapImage.close();
+         globalHeightMapImage = filteredHeightMap;
+      }
 
       // Run the cropping kernel
       croppingKernel.withPointer(globalHeightMapImage.data()).withLong(globalHeightMapImage.step());


### PR DESCRIPTION
You were creating GpuMats without closing them. Fortunately the JavaCPP deallocator thread closed them properly, but I have trust issues with that thread because it has failed on me in the past. This PR does the memory management without relying on the JavaCPP deallocator thread. 

Before: see how the GPU memory usage fluctuates a bunch
![Before](https://github.com/user-attachments/assets/6a1f4717-c797-4bf1-8928-34d4679bf9e5)

After: GPU memory usage is stable
![After](https://github.com/user-attachments/assets/90c45bab-0005-4ebb-b5a6-e10effa366e5)

This is running the NadiaContinuousHikingKinSim, btw
