### PR TITLE
[Feature] Publish ROS 2 Image Messages

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
@@ -22,8 +22,9 @@ import us.ihmc.perception.tools.PerceptionMessageTools;
 import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Topic;
 
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Instant;
-import java.util.Arrays;
 
 import static us.ihmc.perception.imageMessage.CompressionType.NVJPEG;
 import static us.ihmc.perception.imageMessage.CompressionType.ZSTD_NVJPEG_HYBRID;
@@ -121,7 +122,7 @@ public class RawImagePublisher implements AutoCloseable
       Instant imageAcquisitionTime = imageToPublish.getAcquisitionTime();
       ros2Image.getHeader().getStamp().setSec((int) imageAcquisitionTime.getEpochSecond());
       ros2Image.getHeader().getStamp().setNanosec(imageAcquisitionTime.getNano());
-      ros2Image.getHeader().setFrameId(""); // TODO: Figure out how to do frame ids with RawImage
+      ros2Image.getHeader().setFrameId("world"); // TODO: Figure out how to do frame ids with RawImage
 
       // Set dimensions
       ros2Image.setWidth(imageToPublish.getWidth());
@@ -137,16 +138,19 @@ public class RawImagePublisher implements AutoCloseable
       };
       ros2Image.setEncoding(encoding);
 
+      // Get the message's internal buffer
+      ByteBuffer dataBuffer = ros2Image.getData().getBuffer();
+
       // Set byte order
-      ros2Image.setIsBigendian((byte) 0);
+      ros2Image.setIsBigendian((byte) (dataBuffer.order().equals(ByteOrder.BIG_ENDIAN) ? 1 : 0));
 
       // Set step
       Mat cpuImage = imageToPublish.getCpuImageMat();
       ros2Image.setStep(cpuImage.step());
 
       // Set data
-      Arrays.fill(ros2Image.getData(), (byte) 0);
-      cpuImage.data().get(ros2Image.getData(), 0, (int) OpenCVTools.memorySize(cpuImage));
+      int memorySize = (int) OpenCVTools.memorySize(cpuImage);
+      dataBuffer.position(0).put(cpuImage.data().limit(memorySize).asByteBuffer());
 
       // Publish the image
       ros2Helper.publish(imageTopic, ros2Image);
@@ -154,6 +158,7 @@ public class RawImagePublisher implements AutoCloseable
 
    private String getOpenCVTypeString(int openCVType)
    {
+      // Reverse the opencv_core.CV_MAKETYPE method to get the type depth and number of channels
       int depth = openCVType & opencv_core.CV_MAT_DEPTH_MASK;
       int channels = ((openCVType - depth) >> opencv_core.CV_CN_SHIFT) + 1;
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
@@ -2,21 +2,28 @@ package us.ihmc.perception;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_cudaimgproc;
 import org.bytedeco.opencv.global.opencv_imgproc;
 import org.bytedeco.opencv.opencv_core.GpuMat;
+import org.bytedeco.opencv.opencv_core.Mat;
 import perception_msgs.msg.dds.ImageMessage;
 import perception_msgs.msg.dds.SRTStreamStatus;
+import sensor_msgs.msg.dds.Image;
 import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.ros2.ROS2Helper;
 import us.ihmc.perception.cuda.CUDACompressionTools;
 import us.ihmc.perception.cuda.CUDAJPEGProcessor;
 import us.ihmc.perception.imageMessage.CompressionType;
+import us.ihmc.perception.imageMessage.PixelFormat;
 import us.ihmc.perception.opencv.OpenCVTools;
 import us.ihmc.perception.streaming.ROS2SRTSensorStreamer;
 import us.ihmc.perception.tools.PerceptionMessageTools;
 import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Topic;
+
+import java.time.Instant;
+import java.util.Arrays;
 
 import static us.ihmc.perception.imageMessage.CompressionType.NVJPEG;
 import static us.ihmc.perception.imageMessage.CompressionType.ZSTD_NVJPEG_HYBRID;
@@ -29,6 +36,7 @@ public class RawImagePublisher implements AutoCloseable
 
    private final ROS2Helper ros2Helper;
    private final ImageMessage imageMessage;
+   private final Image ros2Image;
 
    private boolean destroyed = false;
 
@@ -40,6 +48,7 @@ public class RawImagePublisher implements AutoCloseable
 
       ros2Helper = new ROS2Helper(ros2Node);
       imageMessage = new ImageMessage();
+      ros2Image = new Image();
    }
 
    @SuppressWarnings("unchecked") // Trust me bro, I know what I'm doing
@@ -51,6 +60,10 @@ public class RawImagePublisher implements AutoCloseable
       if (imageTopic.getType().equals(ImageMessage.class))
       {  // Topic is an ImageMessage topic -> publish as image message
          publishAsImageMessage((ROS2Topic<ImageMessage>) imageTopic, imageToPublish);
+      }
+      else if (imageTopic.getType().equals(Image.class))
+      {  // Topic is a standard ROS2 Image topic -> publish as standard ROS2 Image message
+         publishAsROS2Image((ROS2Topic<Image>) imageTopic, imageToPublish);
       }
       else if (imageTopic.getType().equals(SRTStreamStatus.class))
       {  // Topic is an SRT stream topic -> stream video over SRT
@@ -100,6 +113,65 @@ public class RawImagePublisher implements AutoCloseable
       // Pack the message and send it off
       PerceptionMessageTools.packImageMessage(imageToPublish, compressedImage, compressionType, imageMessage);
       ros2Helper.publish(imageTopic, imageMessage);
+   }
+
+   private void publishAsROS2Image(ROS2Topic<Image> imageTopic, RawImage imageToPublish)
+   {
+      // Set the header
+      Instant imageAcquisitionTime = imageToPublish.getAcquisitionTime();
+      ros2Image.getHeader().getStamp().setSec((int) imageAcquisitionTime.getEpochSecond());
+      ros2Image.getHeader().getStamp().setNanosec(imageAcquisitionTime.getNano());
+      ros2Image.getHeader().setFrameId(""); // TODO: Figure out how to do frame ids with RawImage
+
+      // Set dimensions
+      ros2Image.setWidth(imageToPublish.getWidth());
+      ros2Image.setHeight(imageToPublish.getHeight());
+
+      // Set encoding
+      PixelFormat pixelFormat = imageToPublish.getPixelFormat();
+      String encoding = switch (pixelFormat)
+      {
+         case BGR8, BGRA8, RGB8, RGBA8 -> pixelFormat.name().toLowerCase();
+         case GRAY8, GRAY16 -> pixelFormat.name().toLowerCase().replace("gray", "mono");
+         default -> getOpenCVTypeString(imageToPublish.getOpenCVType());
+      };
+      ros2Image.setEncoding(encoding);
+
+      // Set byte order
+      ros2Image.setIsBigendian((byte) 0);
+
+      // Set step
+      Mat cpuImage = imageToPublish.getCpuImageMat();
+      ros2Image.setStep(cpuImage.step());
+
+      // Set data
+      Arrays.fill(ros2Image.getData(), (byte) 0);
+      cpuImage.data().get(ros2Image.getData(), 0, (int) OpenCVTools.memorySize(cpuImage));
+
+      // Publish the image
+      ros2Helper.publish(imageTopic, ros2Image);
+   }
+
+   private String getOpenCVTypeString(int openCVType)
+   {
+      int depth = openCVType & opencv_core.CV_MAT_DEPTH_MASK;
+      int channels = ((openCVType - depth) >> opencv_core.CV_CN_SHIFT) + 1;
+
+      StringBuilder typeString = new StringBuilder(5);
+      switch (depth)
+      {
+         case opencv_core.CV_8U -> typeString.append("8UC");
+         case opencv_core.CV_8S -> typeString.append("8SC");
+         case opencv_core.CV_16U -> typeString.append("16UC");
+         case opencv_core.CV_16S -> typeString.append("16SC");
+         case opencv_core.CV_32S -> typeString.append("32SC");
+         case opencv_core.CV_32F -> typeString.append("32FC");
+         case opencv_core.CV_64F -> typeString.append("64FC");
+      }
+
+      typeString.append(channels);
+
+      return typeString.toString();
    }
 
    @Override

--- a/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
@@ -1,0 +1,88 @@
+package us.ihmc.perception.demo;
+
+import sensor_msgs.msg.dds.Image;
+import us.ihmc.commons.thread.RepeatingTaskThread;
+import us.ihmc.communication.ros2.ROS2Helper;
+import us.ihmc.log.LogTools;
+import us.ihmc.perception.RawImage;
+import us.ihmc.perception.RawImagePublisher;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2NodeBuilder;
+import us.ihmc.ros2.ROS2QosProfile;
+import us.ihmc.ros2.ROS2Topic;
+import us.ihmc.sensors.zed.ZEDImageSensor;
+import us.ihmc.sensors.zed.ZEDModelData;
+import us.ihmc.sensors.zed.ZEDSVOPlaybackSensor;
+import us.ihmc.tools.IHMCCommonPaths;
+
+import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
+
+class ROS2ImagePublishingDemo
+{
+   private static final String SVO_FILE = IHMCCommonPaths.PERCEPTION_LOGS_DIRECTORY.resolve("20240715_103234_ZEDRecording_NewONRCourseWalk.svo2")
+                                                                                   .toAbsolutePath()
+                                                                                   .toString();
+
+   private final ROS2Node ros2Node;
+   private final ROS2Topic<Image> colorTopic;
+   private final ROS2Topic<Image> depthTopic;
+
+   private final RawImagePublisher rawImagePublisher;
+   private final RepeatingTaskThread publishThread;
+
+   private final ZEDSVOPlaybackSensor zed;
+
+   private ROS2ImagePublishingDemo()
+   {
+      ros2Node = new ROS2NodeBuilder().build("image_publishing_demo");
+
+      colorTopic = new ROS2Topic<>().withPrefix("zed").withModule("color").withQoS(ROS2QosProfile.RELIABLE()).withType(Image.class);
+      depthTopic = new ROS2Topic<>().withPrefix("zed").withModule("depth").withQoS(ROS2QosProfile.RELIABLE()).withType(Image.class);
+
+      rawImagePublisher = new RawImagePublisher(ros2Node);
+      publishThread = new RepeatingTaskThread("SVOPublishThread", this::publishSensorImages);
+
+      zed = new ZEDSVOPlaybackSensor(new ROS2Helper(ros2Node), 0, ZEDModelData.ZED_2, SL_DEPTH_MODE_PERFORMANCE, SVO_FILE);
+
+      Runtime.getRuntime().addShutdownHook(new Thread(this::destroy, getClass().getSimpleName() + "Shutdown"));
+
+      LogTools.info("Starting sensor...");
+      publishThread.startRepeating();
+      zed.run(true);
+   }
+
+   private void publishSensorImages()
+   {
+      try
+      {
+         zed.waitForGrab();
+
+         RawImage color = zed.getImage(ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);
+         RawImage depth = zed.getImage(ZEDImageSensor.DEPTH_IMAGE_KEY);
+
+         LogTools.info("Publishing images {}", color.getSequenceNumber());
+         rawImagePublisher.publishImage(colorTopic, color);
+         rawImagePublisher.publishImage(depthTopic, depth);
+
+         color.release();
+         depth.release();
+      }
+      catch (InterruptedException ignored) {}
+   }
+
+   private void destroy()
+   {
+      publishThread.kill();
+      publishThread.interrupt();
+
+      zed.close();
+
+      ros2Node.destroy();
+      rawImagePublisher.close();
+   }
+
+   public static void main(String[] args)
+   {
+      new ROS2ImagePublishingDemo();
+   }
+}

--- a/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
@@ -17,6 +17,31 @@ import us.ihmc.tools.IHMCCommonPaths;
 
 import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
 
+/**
+ * Demo for publishing standard ROS 2 {@link Image} messages.
+ * This demo does NOT publish IHMC's custom {@link perception_msgs.msg.dds.ImageMessage}.
+ * <p>
+ * The demo publishes color and depth images on the following topics:
+ * <ul>
+ *    <li>/zed/color</li>
+ *    <li>/zed/depth</li>
+ * </ul>
+ * <p>
+ * To visualize these images, you may use RViz2
+ * (<a href="https://docs.ros.org/en/humble/Installation.html">ROS 2 Humble Installation</a>).
+ * <p>
+ * With this demo running, launch RViz2. On Linux, open a new terminal and run:
+ * <pre>
+ * {@code
+ * source /opt/ros/humble/setup.bash
+ * export ROS_DOMAIN_ID=[your-domain-id] # insert your domain ID
+ * ros2 run rviz2 rviz2
+ * }
+ * </pre>
+ * In RViz2, add two Image display by clicking the Add button,
+ * and in the By topic options selecting the Image displays under
+ * the /zed/color topic, and again under the /zed/depth topic.
+ */
 class ROS2ImagePublishingDemo
 {
    private static final String SVO_FILE = IHMCCommonPaths.PERCEPTION_LOGS_DIRECTORY.resolve("20240715_103234_ZEDRecording_NewONRCourseWalk.svo2")
@@ -34,36 +59,51 @@ class ROS2ImagePublishingDemo
 
    private ROS2ImagePublishingDemo()
    {
+      // Create a ROS 2 Node
       ros2Node = new ROS2NodeBuilder().build("image_publishing_demo");
 
-      colorTopic = new ROS2Topic<>().withPrefix("zed").withModule("color").withQoS(ROS2QosProfile.RELIABLE()).withType(Image.class);
-      depthTopic = new ROS2Topic<>().withPrefix("zed").withModule("depth").withQoS(ROS2QosProfile.RELIABLE()).withType(Image.class);
+      // Create the /zed/color topic. QoS must be reliable for RViz2 to receive the images.
+      colorTopic = new ROS2Topic<>().withModule("zed").withSuffix("color").withQoS(ROS2QosProfile.RELIABLE()).withType(Image.class);
 
+      // Create the /zed/depth topic. Again, QoS must be reliable.
+      depthTopic = new ROS2Topic<>().withModule("zed").withSuffix("depth").withQoS(ROS2QosProfile.RELIABLE()).withType(Image.class);
+
+      // Create a publisher, and the publisher thread
       rawImagePublisher = new RawImagePublisher(ros2Node);
       publishThread = new RepeatingTaskThread("SVOPublishThread", this::publishSensorImages);
 
+      // Create a ZED sensor (in this case we use an SVO playback)
       zed = new ZEDSVOPlaybackSensor(new ROS2Helper(ros2Node), 0, ZEDModelData.ZED_2, SL_DEPTH_MODE_PERFORMANCE, SVO_FILE);
 
+      // Add shutdown hook to properly close/destroy everything
       Runtime.getRuntime().addShutdownHook(new Thread(this::destroy, getClass().getSimpleName() + "Shutdown"));
 
+      // Start the sensor and publish threads
       LogTools.info("Starting sensor...");
       publishThread.startRepeating();
       zed.run(true);
    }
 
+   /**
+    * This method runs in a loop to publish the images acquired from the ZED
+    */
    private void publishSensorImages()
    {
       try
       {
+         // Wait for the ZED to grab images
          zed.waitForGrab();
 
+         // Get the images
          RawImage color = zed.getImage(ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);
          RawImage depth = zed.getImage(ZEDImageSensor.DEPTH_IMAGE_KEY);
 
+         // Publish the images
          LogTools.info("Publishing images {}", color.getSequenceNumber());
          rawImagePublisher.publishImage(colorTopic, color);
          rawImagePublisher.publishImage(depthTopic, depth);
 
+         // Release the images
          color.release();
          depth.release();
       }
@@ -72,11 +112,14 @@ class ROS2ImagePublishingDemo
 
    private void destroy()
    {
+      // Stop the publisher thread
       publishThread.kill();
       publishThread.interrupt();
 
+      // Stop the ZED
       zed.close();
 
+      // Destroy the ROS2Node and publisher
       ros2Node.destroy();
       rawImagePublisher.close();
    }

--- a/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVTools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVTools.java
@@ -355,11 +355,31 @@ public class OpenCVTools
    }
 
    /**
+    * @return Bytes of memory used to store the data in the mat.
+    *       Not necessarily equal to {@link #dataSize(Mat)} as the
+    *       stored data may have padding at the end of each row.
+    */
+   public static long memorySize(Mat mat)
+   {
+      return mat.step() * mat.rows();
+   }
+
+   /**
     * @return Total size of data stored in the mat, in bytes.
     */
    public static long dataSize(GpuMat mat)
    {
       return mat.elemSize() * mat.rows() * mat.cols();
+   }
+
+   /**
+    * @return Bytes of memory used to store the data in the mat.
+    *       Not necessarily equal to {@link #dataSize(GpuMat)} as the
+    *       stored data may have padding at the end of each row.
+    */
+   public static long memorySize(GpuMat mat)
+   {
+      return mat.step() * mat.rows();
    }
 
    /**


### PR DESCRIPTION
Adds code to publish ROS 2 Image messages to the `RawImagePublisher`, as well as a Java example of the usage where the published images can be visualized in RViz2. 

Requires new release of ihmc-ros2-library with https://github.com/ihmcrobotics/ihmc-ros2-library/pull/65 merged. 