### PR TITLE
[Feature] Publish Camera Info Messages

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
@@ -163,9 +163,9 @@ public class RDXSceneGraphDemo
             zedSVOPlayer.run(true);
 
             zedPublishThread = new ImageSensorPublishThread(ros2Node, zedSVOPlayer,
-                                                            Map.of(ZEDImageSensor.LEFT_COLOR_IMAGE_KEY, PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.LEFT),
-                                                                   ZEDImageSensor.RIGHT_COLOR_IMAGE_KEY, PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.RIGHT),
-                                                                   ZEDImageSensor.DEPTH_IMAGE_KEY, PerceptionAPI.ZED2_DEPTH));
+                                                            Map.of(PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.LEFT), ZEDImageSensor.LEFT_COLOR_IMAGE_KEY,
+                                                                   PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.RIGHT), ZEDImageSensor.RIGHT_COLOR_IMAGE_KEY,
+                                                                   PerceptionAPI.ZED2_DEPTH, ZEDImageSensor.DEPTH_IMAGE_KEY));
             zedPublishThread.startRepeating();
 
             zedSVORecorderPanel = new RDXZEDSVORecorderPanel(ros2Helper);

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/StandAloneRealsenseProcess.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/StandAloneRealsenseProcess.java
@@ -30,10 +30,10 @@ import java.util.concurrent.TimeUnit;
 public class StandAloneRealsenseProcess
 {
    public static final String STAND_ALONE_REALSENSE_PROCESS = "StandAloneRealsenseProcess";
-   private static final Map<Integer, ROS2Topic<? extends Packet<?>>> D455_IMAGE_TOPIC_MAP = Map.of(RealSenseImageSensor.COLOR_IMAGE_KEY,
-                                                                                                   PerceptionAPI.SRT_REALSENSE_COLOR_STREAM_STATUS,
-                                                                                                   RealSenseImageSensor.DEPTH_IMAGE_KEY,
-                                                                                                   PerceptionAPI.D455_DEPTH_IMAGE);
+   private static final Map<ROS2Topic<? extends Packet<?>>, Integer> D455_IMAGE_TOPIC_MAP = Map.of(PerceptionAPI.SRT_REALSENSE_COLOR_STREAM_STATUS,
+                                                                                                   RealSenseImageSensor.COLOR_IMAGE_KEY,
+                                                                                                   PerceptionAPI.D455_DEPTH_IMAGE,
+                                                                                                   RealSenseImageSensor.DEPTH_IMAGE_KEY);
 
    private final ROS2DemandGraphNode realsenseDemandNode;
    private final ROS2DemandGraphNode realsensePublishDemandNode;
@@ -89,7 +89,6 @@ public class StandAloneRealsenseProcess
 
    private void initializeHeightMap(ControllerFootstepQueueMonitor controllerFootstepQueueMonitor)
    {
-      boolean runWithCUDA = true;
       heightMapUpdateThread = new RapidHeightMapUpdateThread(ros2Helper.getROS2Node(),
                                                              syncedRobot,
                                                              syncedRobot.getReferenceFrames().getSoleFrame(RobotSide.LEFT),

--- a/ihmc-perception/src/main/java/us/ihmc/perception/ImageSensorPublishThread.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/ImageSensorPublishThread.java
@@ -1,5 +1,6 @@
 package us.ihmc.perception;
 
+import sensor_msgs.msg.dds.CameraInfo;
 import us.ihmc.commons.thread.RepeatingTaskThread;
 import us.ihmc.communication.packets.Packet;
 import us.ihmc.ros2.ROS2Node;
@@ -12,19 +13,21 @@ import java.util.Map.Entry;
 
 public class ImageSensorPublishThread extends RepeatingTaskThread
 {
-   private final Map<Integer, ROS2Topic<? extends Packet<?>>> imageKeyToTopicMap;
-   private final Map<Integer, Long> lastPublishedSequenceNumbers = new HashMap<>();
+   private final Map<ROS2Topic<? extends Packet<?>>, Integer> topicToImageKeyMap;
+   private final Map<ROS2Topic<? extends Packet<?>>, Long> lastPublishedSequenceNumbers = new HashMap<>();
    private final RawImagePublisher publisher;
    private boolean publishingIsThrottled = false;
 
    private final ImageSensor imageSensor;
 
-   public ImageSensorPublishThread(ROS2Node ros2Node, ImageSensor sensorToPublish, Map<Integer, ROS2Topic<? extends Packet<?>>> imageKeyToTopicMap)
+   private int cameraInfoPublishModulus = 1;
+
+   public ImageSensorPublishThread(ROS2Node ros2Node, ImageSensor sensorToPublish, Map<ROS2Topic<? extends Packet<?>>, Integer> topicToImageKeyMap)
    {
       super(sensorToPublish.getSensorName() + "PublishThread");
 
       imageSensor = sensorToPublish;
-      this.imageKeyToTopicMap = imageKeyToTopicMap;
+      this.topicToImageKeyMap = topicToImageKeyMap;
       publisher = new RawImagePublisher(ros2Node);
    }
 
@@ -36,6 +39,19 @@ public class ImageSensorPublishThread extends RepeatingTaskThread
       return this;
    }
 
+   /**
+    * Set the number of grabs to skip between publishing {@link CameraInfo} messages.
+    * If set to zero, a message will be published every grab (default).
+    * If set to non-zero, {@code skip} number of grabs will be skipped after publishing a message.
+    * Do not set to a negative value.
+    *
+    * @param skip Number of grabs to skip between publishing {@link CameraInfo} messages.
+    */
+   public void setCameraInfoPublishGrabSkipCount(int skip)
+   {
+      cameraInfoPublishModulus = skip + 1;
+   }
+
    @Override
    protected void runTask()
    {
@@ -44,24 +60,28 @@ public class ImageSensorPublishThread extends RepeatingTaskThread
          if (!publishingIsThrottled)
             imageSensor.waitForGrab();
 
-         for (Entry<Integer, ROS2Topic<? extends Packet<?>>> imageEntry : imageKeyToTopicMap.entrySet())
+         for (Entry<ROS2Topic<? extends Packet<?>>, Integer> imageEntry : topicToImageKeyMap.entrySet())
          {
-            int imageKey = imageEntry.getKey();
-            ROS2Topic<? extends Packet<?>> imageTopic = imageEntry.getValue();
+            ROS2Topic<? extends Packet<?>> imageTopic = imageEntry.getKey();
+
+            // If the topic is a camera info topic, check whether we should skip this publish
+            if (imageTopic.getType().equals(CameraInfo.class) && getCompleted() % cameraInfoPublishModulus != 0)
+               continue;
 
             // Get the image to publish
+            int imageKey = imageEntry.getValue();
             RawImage imageToPublish = imageSensor.getImage(imageKey);
 
             // Skip if the image is null
             if (imageToPublish == null)
                continue;
 
-            // Skip if this image was already published
-            if (lastPublishedSequenceNumbers.containsKey(imageKey) && imageToPublish.getSequenceNumber() == lastPublishedSequenceNumbers.get(imageKey))
+            // Skip if this image was already published on the topic
+            if (lastPublishedSequenceNumbers.containsKey(imageTopic) && imageToPublish.getSequenceNumber() <= lastPublishedSequenceNumbers.get(imageTopic))
                continue;
 
             // Store the sequence number to avoid re-publishing this image
-            lastPublishedSequenceNumbers.put(imageKey, imageToPublish.getSequenceNumber());
+            lastPublishedSequenceNumbers.put(imageTopic, imageToPublish.getSequenceNumber());
 
             // Publish the image
             publisher.publishImage(imageTopic, imageToPublish);

--- a/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
@@ -26,7 +26,6 @@ import us.ihmc.ros2.ROS2Topic;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Instant;
-import java.util.Arrays;
 
 import static us.ihmc.perception.imageMessage.CompressionType.NVJPEG;
 import static us.ihmc.perception.imageMessage.CompressionType.ZSTD_NVJPEG_HYBRID;

--- a/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
@@ -9,6 +9,7 @@ import org.bytedeco.opencv.opencv_core.GpuMat;
 import org.bytedeco.opencv.opencv_core.Mat;
 import perception_msgs.msg.dds.ImageMessage;
 import perception_msgs.msg.dds.SRTStreamStatus;
+import sensor_msgs.msg.dds.CameraInfo;
 import sensor_msgs.msg.dds.Image;
 import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.ros2.ROS2Helper;
@@ -25,6 +26,7 @@ import us.ihmc.ros2.ROS2Topic;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.time.Instant;
+import java.util.Arrays;
 
 import static us.ihmc.perception.imageMessage.CompressionType.NVJPEG;
 import static us.ihmc.perception.imageMessage.CompressionType.ZSTD_NVJPEG_HYBRID;
@@ -65,6 +67,10 @@ public class RawImagePublisher implements AutoCloseable
       else if (imageTopic.getType().equals(Image.class))
       {  // Topic is a standard ROS2 Image topic -> publish as standard ROS2 Image message
          publishAsROS2Image((ROS2Topic<Image>) imageTopic, imageToPublish);
+      }
+      else if (imageTopic.getType().equals(CameraInfo.class))
+      {  // Topic is a camera info topic -> publish the image's camera info
+         publishCameraInfo((ROS2Topic<CameraInfo>) imageTopic, imageToPublish);
       }
       else if (imageTopic.getType().equals(SRTStreamStatus.class))
       {  // Topic is an SRT stream topic -> stream video over SRT
@@ -177,6 +183,91 @@ public class RawImagePublisher implements AutoCloseable
       typeString.append(channels);
 
       return typeString.toString();
+   }
+
+   // TODO: Support non-rectified images and stereo images
+   private void publishCameraInfo(ROS2Topic<CameraInfo> cameraInfoTopic, RawImage image)
+   {
+      CameraInfo cameraInfo = new CameraInfo();
+
+      // Set the header
+      Instant imageAcquisitionTime = image.getAcquisitionTime();
+      cameraInfo.getHeader().getStamp().setSec((int) imageAcquisitionTime.getEpochSecond());
+      cameraInfo.getHeader().getStamp().setNanosec(imageAcquisitionTime.getNano());
+      cameraInfo.getHeader().setFrameId("world"); // TODO: should be camera frame
+
+      // Set the calibration parameters
+      // Image dimensions
+      cameraInfo.setHeight(image.getHeight());
+      cameraInfo.setWidth(image.getWidth());
+
+      // Distortion model
+      cameraInfo.setDistortionModel("plumb_bob");
+      cameraInfo.getD().clear(5);
+      cameraInfo.getD().add(new double[]{0.0, 0.0, 0.0, 0.0, 0.0}); // We (mostly) work with rectified images, so assume no distortion
+
+      /*
+       * Set the intrinsics matrix
+       *      [fx  0 cx]
+       *  K = [ 0 fy cy]
+       *      [ 0  0  1]
+       */
+      cameraInfo.getK()[0] = image.getFocalLengthX();
+      cameraInfo.getK()[1] = 0.0;
+      cameraInfo.getK()[2] = image.getPrincipalPointX();
+      cameraInfo.getK()[3] = 0.0;
+      cameraInfo.getK()[4] = image.getFocalLengthY();
+      cameraInfo.getK()[5] = image.getPrincipalPointY();
+      cameraInfo.getK()[6] = 0.0;
+      cameraInfo.getK()[7] = 0.0;
+      cameraInfo.getK()[8] = 1.0;
+
+      // Set the rotation matrix (only used for stereo images, so we assume identity)
+      cameraInfo.getR()[0] = 1.0;
+      cameraInfo.getR()[1] = 0.0;
+      cameraInfo.getR()[2] = 0.0;
+      cameraInfo.getR()[3] = 0.0;
+      cameraInfo.getR()[4] = 1.0;
+      cameraInfo.getR()[5] = 0.0;
+      cameraInfo.getR()[6] = 0.0;
+      cameraInfo.getR()[7] = 0.0;
+      cameraInfo.getR()[8] = 1.0;
+
+      /*
+       * Set the projection matrix
+       *     [fx'  0  cx' Tx]
+       * P = [ 0  fy' cy' Ty]
+       *     [ 0   0   1   0]
+       * Since we're not using stereo images, Tx = Ty = 0
+       * We also assume fx` = fx, cx` = cx, etc.
+       */
+      cameraInfo.getP()[0] = image.getFocalLengthX();
+      cameraInfo.getP()[1] = 0.0;
+      cameraInfo.getP()[2] = image.getPrincipalPointX();
+      cameraInfo.getP()[3] = 0.0;
+      cameraInfo.getP()[4] = 0.0;
+      cameraInfo.getP()[5] = image.getFocalLengthY();
+      cameraInfo.getP()[6] = image.getPrincipalPointY();
+      cameraInfo.getP()[7] = 0.0;
+      cameraInfo.getP()[8] = 0.0;
+      cameraInfo.getP()[9] = 0.0;
+      cameraInfo.getP()[10] = 1.0;
+      cameraInfo.getP()[11] = 0.0;
+
+      // Set "Operational Parameters"
+      // Assume no binning
+      cameraInfo.setBinningX(0);
+      cameraInfo.setBinningY(0);
+
+      // Set the ROI to the full image
+      cameraInfo.getRoi().setXOffset(0);
+      cameraInfo.getRoi().setYOffset(0);
+      cameraInfo.getRoi().setHeight(0);
+      cameraInfo.getRoi().setWidth(0);
+      cameraInfo.getRoi().setDoRectify(false);
+
+      // Publish the message
+      ros2Helper.publish(cameraInfoTopic, cameraInfo);
    }
 
    @Override

--- a/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
@@ -1,5 +1,6 @@
 package us.ihmc.perception.demo;
 
+import sensor_msgs.msg.dds.CameraInfo;
 import sensor_msgs.msg.dds.Image;
 import us.ihmc.commons.thread.RepeatingTaskThread;
 import us.ihmc.communication.ros2.ROS2Helper;
@@ -18,16 +19,18 @@ import us.ihmc.tools.IHMCCommonPaths;
 import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
 
 /**
- * Demo for publishing standard ROS 2 {@link Image} messages.
+ * Demo for publishing standard ROS 2 {@link Image} messages along with {@link CameraInfo} messages.
  * This demo does NOT publish IHMC's custom {@link perception_msgs.msg.dds.ImageMessage}.
  * <p>
- * The demo publishes color and depth images on the following topics:
+ * The demo publishes messages on the following topics:
  * <ul>
- *    <li>/zed/color</li>
- *    <li>/zed/depth</li>
+ *    <li>/zed/color/image_raw</li>
+ *    <li>/zed/color/camera_info</li>
+ *    <li>/zed/depth/image_raw</li>
+ *    <li>/zed/depth/camera_info</li>
  * </ul>
  * <p>
- * To visualize these images, you may use RViz2
+ * To visualize these images, you may use RViz2 from ROS 2
  * (<a href="https://docs.ros.org/en/humble/Installation.html">ROS 2 Humble Installation</a>).
  * <p>
  * With this demo running, launch RViz2. On Linux, open a new terminal and run:
@@ -40,7 +43,19 @@ import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
  * </pre>
  * In RViz2, add two Image display by clicking the Add button,
  * and in the By topic options selecting the Image displays under
- * the /zed/color topic, and again under the /zed/depth topic.
+ * the /zed/color/image_raw topic, and again under the /zed/depth/image_raw topic.
+ * <p>
+ * To show a point cloud, set the Fixed Frame (under Global Options) to "world".
+ * Then, click Add, select DepthCloud, and click Ok.
+ * Under the DepthCloud options, set the options as such:
+ * <ul>
+ *    <li>Reliability Policy = Reliable</li>
+ *    <li>Depth Map Topic = /zed/depth/image_raw</li>
+ *    <li>Color Image Topic = /zed/color/image_raw</li>
+ * </ul>
+ * <p>
+ * You may notice the orientation of the point cloud is incorrect
+ * as this demo does not publish a tf tree.
  */
 class ROS2ImagePublishingDemo
 {
@@ -48,9 +63,15 @@ class ROS2ImagePublishingDemo
                                                                                    .toAbsolutePath()
                                                                                    .toString();
 
+   private static final int CAMERA_INFO_PUBLISH_SKIP = 5; // Publish camera_info messages every 5 frames
+
    private final ROS2Node ros2Node;
+
    private final ROS2Topic<Image> colorTopic;
+   private final ROS2Topic<CameraInfo> colorCameraInfoTopic;
+
    private final ROS2Topic<Image> depthTopic;
+   private final ROS2Topic<CameraInfo> depthCameraInfoTopic;
 
    private final RawImagePublisher rawImagePublisher;
    private final RepeatingTaskThread publishThread;
@@ -62,11 +83,16 @@ class ROS2ImagePublishingDemo
       // Create a ROS 2 Node
       ros2Node = new ROS2NodeBuilder().build("image_publishing_demo");
 
-      // Create the /zed/color topic. QoS must be reliable for RViz2 to receive the images.
-      colorTopic = new ROS2Topic<>().withModule("zed").withSuffix("color").withQoS(ROS2QosProfile.RELIABLE()).withType(Image.class);
+      // ZED topic used to create color and depth topics. QoS must be reliable for RViz2 to receive the images.
+      ROS2Topic<?> zedTopic = new ROS2Topic<>().withPrefix("zed").withQoS(ROS2QosProfile.RELIABLE());
 
-      // Create the /zed/depth topic. Again, QoS must be reliable.
-      depthTopic = new ROS2Topic<>().withModule("zed").withSuffix("depth").withQoS(ROS2QosProfile.RELIABLE()).withType(Image.class);
+      // Create the /zed/color/image_raw and /zed/color/camera_info topics
+      colorTopic = zedTopic.withModule("color").withSuffix("image_raw").withType(Image.class);
+      colorCameraInfoTopic = zedTopic.withModule("color").withSuffix("camera_info").withType(CameraInfo.class);
+
+      // Create the /zed/depth/image_raw and /zed/depth/camera_info topics
+      depthTopic = zedTopic.withModule("depth").withSuffix("image_raw").withType(Image.class);
+      depthCameraInfoTopic = zedTopic.withModule("depth").withSuffix("camera_info").withType(CameraInfo.class);
 
       // Create a publisher, and the publisher thread
       rawImagePublisher = new RawImagePublisher(ros2Node);
@@ -102,6 +128,14 @@ class ROS2ImagePublishingDemo
          LogTools.info("Publishing images {}", color.getSequenceNumber());
          rawImagePublisher.publishImage(colorTopic, color);
          rawImagePublisher.publishImage(depthTopic, depth);
+
+         // Publish the camera info
+         if (color.getSequenceNumber() % CAMERA_INFO_PUBLISH_SKIP == 0)
+         {
+            LogTools.info("Publishing camera info");
+            rawImagePublisher.publishImage(colorCameraInfoTopic, color);
+            rawImagePublisher.publishImage(depthCameraInfoTopic, depth);
+         }
 
          // Release the images
          color.release();

--- a/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
@@ -3,8 +3,10 @@ package us.ihmc.perception.demo;
 import sensor_msgs.msg.dds.CameraInfo;
 import sensor_msgs.msg.dds.Image;
 import us.ihmc.commons.thread.RepeatingTaskThread;
+import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.ros2.ROS2Helper;
 import us.ihmc.log.LogTools;
+import us.ihmc.perception.ImageSensorPublishThread;
 import us.ihmc.perception.RawImage;
 import us.ihmc.perception.RawImagePublisher;
 import us.ihmc.ros2.ROS2Node;
@@ -15,6 +17,8 @@ import us.ihmc.sensors.zed.ZEDImageSensor;
 import us.ihmc.sensors.zed.ZEDModelData;
 import us.ihmc.sensors.zed.ZEDSVOPlaybackSensor;
 import us.ihmc.tools.IHMCCommonPaths;
+
+import java.util.Map;
 
 import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
 
@@ -67,16 +71,20 @@ class ROS2ImagePublishingDemo
 
    private final ROS2Node ros2Node;
 
-   private final ROS2Topic<Image> colorTopic;
+   private final ROS2Topic<Image> colorImageTopic;
    private final ROS2Topic<CameraInfo> colorCameraInfoTopic;
 
-   private final ROS2Topic<Image> depthTopic;
+   private final ROS2Topic<Image> depthImageTopic;
    private final ROS2Topic<CameraInfo> depthCameraInfoTopic;
 
-   private final RawImagePublisher rawImagePublisher;
-   private final RepeatingTaskThread publishThread;
-
    private final ZEDSVOPlaybackSensor zed;
+
+   // Field for predefined publish thread
+   private ImageSensorPublishThread imageSensorPublishThread;
+
+   // Fields for a custom publish thread
+   private RawImagePublisher rawImagePublisher;
+   private RepeatingTaskThread customPublishThread;
 
    private ROS2ImagePublishingDemo()
    {
@@ -87,16 +95,12 @@ class ROS2ImagePublishingDemo
       ROS2Topic<?> zedTopic = new ROS2Topic<>().withPrefix("zed").withQoS(ROS2QosProfile.RELIABLE());
 
       // Create the /zed/color/image_raw and /zed/color/camera_info topics
-      colorTopic = zedTopic.withModule("color").withSuffix("image_raw").withType(Image.class);
+      colorImageTopic = zedTopic.withModule("color").withSuffix("image_raw").withType(Image.class);
       colorCameraInfoTopic = zedTopic.withModule("color").withSuffix("camera_info").withType(CameraInfo.class);
 
       // Create the /zed/depth/image_raw and /zed/depth/camera_info topics
-      depthTopic = zedTopic.withModule("depth").withSuffix("image_raw").withType(Image.class);
+      depthImageTopic = zedTopic.withModule("depth").withSuffix("image_raw").withType(Image.class);
       depthCameraInfoTopic = zedTopic.withModule("depth").withSuffix("camera_info").withType(CameraInfo.class);
-
-      // Create a publisher, and the publisher thread
-      rawImagePublisher = new RawImagePublisher(ros2Node);
-      publishThread = new RepeatingTaskThread("SVOPublishThread", this::publishSensorImages);
 
       // Create a ZED sensor (in this case we use an SVO playback)
       zed = new ZEDSVOPlaybackSensor(new ROS2Helper(ros2Node), 0, ZEDModelData.ZED_2, SL_DEPTH_MODE_PERFORMANCE, SVO_FILE);
@@ -104,13 +108,48 @@ class ROS2ImagePublishingDemo
       // Add shutdown hook to properly close/destroy everything
       Runtime.getRuntime().addShutdownHook(new Thread(this::destroy, getClass().getSimpleName() + "Shutdown"));
 
+      // Create a publisher, and the publisher thread
+      rawImagePublisher = new RawImagePublisher(ros2Node);
+      customPublishThread = new RepeatingTaskThread("SVOPublishThread", this::publishSensorImages);
+
       // Start the sensor and publish threads
       LogTools.info("Starting sensor...");
-      publishThread.startRepeating();
       zed.run(true);
+
+      // Uncomment the method for the thread you want to run
+      startPredefinedPublishThread();
+//      startCustomPublishThread();
+   }
+
+   private void startPredefinedPublishThread()
+   {
+      // Define a topic to image key map
+      Map<ROS2Topic<? extends Packet<?>>, Integer> zedTopicMap =
+            Map.of(colorImageTopic, ZEDImageSensor.LEFT_COLOR_IMAGE_KEY,       // Color image topic requires ZED's left color image
+                   colorCameraInfoTopic, ZEDImageSensor.LEFT_COLOR_IMAGE_KEY,  // Color camera info topic requires ZED's left color image
+                   depthImageTopic, ZEDImageSensor.DEPTH_IMAGE_KEY,            // Depth image topic requires ZED's depth image
+                   depthCameraInfoTopic, ZEDImageSensor.DEPTH_IMAGE_KEY);      // Depth camera info topic requires ZED's depth image
+
+      // Create the predefined publish thread and set its parameters
+      imageSensorPublishThread = new ImageSensorPublishThread(ros2Node, zed, zedTopicMap);
+      imageSensorPublishThread.setCameraInfoPublishGrabSkipCount(CAMERA_INFO_PUBLISH_SKIP);
+
+      // Start the thread
+      imageSensorPublishThread.startRepeating();
+   }
+
+   private void startCustomPublishThread()
+   {
+      // Create a publisher, and the publisher thread
+      rawImagePublisher = new RawImagePublisher(ros2Node);
+      customPublishThread = new RepeatingTaskThread("SVOPublishThread", this::publishSensorImages);
+
+      // start repeating
+      customPublishThread.startRepeating();
    }
 
    /**
+    * The custom publish method (a simplified version of what the predefined one does).
     * This method runs in a loop to publish the images acquired from the ZED
     */
    private void publishSensorImages()
@@ -126,11 +165,11 @@ class ROS2ImagePublishingDemo
 
          // Publish the images
          LogTools.info("Publishing images {}", color.getSequenceNumber());
-         rawImagePublisher.publishImage(colorTopic, color);
-         rawImagePublisher.publishImage(depthTopic, depth);
+         rawImagePublisher.publishImage(colorImageTopic, color);
+         rawImagePublisher.publishImage(depthImageTopic, depth);
 
          // Publish the camera info
-         if (color.getSequenceNumber() % CAMERA_INFO_PUBLISH_SKIP == 0)
+         if (color.getSequenceNumber() % (CAMERA_INFO_PUBLISH_SKIP + 1) == 0)
          {
             LogTools.info("Publishing camera info");
             rawImagePublisher.publishImage(colorCameraInfoTopic, color);
@@ -146,16 +185,23 @@ class ROS2ImagePublishingDemo
 
    private void destroy()
    {
-      // Stop the publisher thread
-      publishThread.kill();
-      publishThread.interrupt();
+      // If we used the custom publish thread, kill it
+      if (customPublishThread != null)
+      {
+         customPublishThread.kill();
+         customPublishThread.interrupt();
+         rawImagePublisher.close();
+      }
+
+      // If we used the predefined publish thread, kill it
+      if (imageSensorPublishThread != null)
+         imageSensorPublishThread.kill();
 
       // Stop the ZED
       zed.close();
 
-      // Destroy the ROS2Node and publisher
+      // Destroy the ROS2Node
       ros2Node.destroy();
-      rawImagePublisher.close();
    }
 
    public static void main(String[] args)


### PR DESCRIPTION
Added ability to publish `CameraInfo` messages to `RawImagePublisher` and `ImageSensorPublishThread`. The latter requires some shuffling of Map entries. 

Also improved the `ROS2ImagePublishingDemo`. 