### PR TITLE
[Feature] Use ReferenceFrames in ImageSensors

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/colorVision/BlackflyImagePublisher.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/colorVision/BlackflyImagePublisher.java
@@ -7,7 +7,6 @@ import org.bytedeco.opencv.opencv_core.Size;
 import perception_msgs.msg.dds.ImageMessage;
 import us.ihmc.communication.packets.MessageTools;
 import us.ihmc.communication.property.ROS2StoredPropertySet;
-import us.ihmc.communication.ros2.ROS2Helper;
 import us.ihmc.perception.CameraModel;
 import us.ihmc.perception.RawImage;
 import us.ihmc.perception.cuda.CUDAJPEGProcessor;
@@ -116,8 +115,8 @@ public class BlackflyImagePublisher
          distortedImageMessage.setPrincipalPointYPixels(imageToPublish.getPrincipalPointY() * publishedImageScaleFactor);
          distortedImageMessage.setImageWidth(scaledWidth);
          distortedImageMessage.setImageHeight(scaledHeight);
-         distortedImageMessage.getPosition().set(imageToPublish.getPosition());
-         distortedImageMessage.getOrientation().set(imageToPublish.getOrientation());
+         distortedImageMessage.getPosition().set(imageToPublish.getTranslation());
+         distortedImageMessage.getOrientation().set(imageToPublish.getRotation());
          distortedImageMessage.setSequenceNumber(imageToPublish.getSequenceNumber());
          distortedImageMessage.setCameraModel(CameraModel.EQUIDISTANT_FISHEYE.toByte());
          distortedImageMessage.setPixelFormat(PixelFormat.BGR8.toByte());

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/graphics/RDXRawImagePointCloudRenderer.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/graphics/RDXRawImagePointCloudRenderer.java
@@ -13,8 +13,6 @@ import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.jetbrains.annotations.Nullable;
-import us.ihmc.euclid.referenceFrame.FramePose3D;
-import us.ihmc.euclid.referenceFrame.interfaces.FixedFramePose3DBasics;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.perception.RawImage;
 import us.ihmc.perception.camera.CameraIntrinsics;
@@ -35,7 +33,7 @@ public class RDXRawImagePointCloudRenderer extends AbstractRDXPointCloudRenderer
    // DEPTH IMAGE UNIFORM DATA
    private CameraIntrinsics depthIntrinsics = new CameraIntrinsics();
    private float depthDiscretization = 0.0f;
-   private final FixedFramePose3DBasics depthPose = new FramePose3D();
+   private final RigidBodyTransform depthTransform = new RigidBodyTransform();
    private final Matrix4 libGDXDepthTransform = new Matrix4();
    private final RigidBodyTransform tempDepthTransform = new RigidBodyTransform();
 
@@ -82,8 +80,8 @@ public class RDXRawImagePointCloudRenderer extends AbstractRDXPointCloudRenderer
       // Update depth image uniforms
       depthIntrinsics = depthImage.getIntrinsicsCopy();
       depthDiscretization = depthImage.getDepthDiscretization();
-      depthPose.set(depthImage.getPose());
-      LibGDXTools.toLibGDX(depthPose, tempDepthTransform, libGDXDepthTransform);
+      depthTransform.set(depthImage.getTransformToWorld());
+      LibGDXTools.toLibGDX(depthTransform, tempDepthTransform, libGDXDepthTransform);
 
       int width = depthImage.getWidth();
       int height = depthImage.getHeight();
@@ -133,8 +131,8 @@ public class RDXRawImagePointCloudRenderer extends AbstractRDXPointCloudRenderer
 
       // Update color image uniforms
       colorIntrinsics = colorImage.getIntrinsicsCopy();
-      depthToColorTransform.setAndInvert(colorImage.getPose());
-      depthToColorTransform.multiply(depthPose);
+      depthToColorTransform.setAndInvert(colorImage.getTransformToWorld());
+      depthToColorTransform.multiply(depthTransform);
       LibGDXTools.toLibGDX(depthToColorTransform, tempColorTransform, libGDXColorTransform);
 
       // Reallocate pixmap and data pointer if image size changed

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/DepthImageOverlapRemover.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/DepthImageOverlapRemover.java
@@ -70,8 +70,8 @@ public class DepthImageOverlapRemover
          if (highQualityImage == null || highQualityImage.isEmpty())
             return lowQualityImage;
 
-         zedFrame.update(transformToWorld -> transformToWorld.set(lowQualityImage.getOrientation(), lowQualityImage.getPosition()));
-         realsenseFrame.update(transformToWorld -> transformToWorld.set(highQualityImage.getOrientation(), highQualityImage.getPosition()));
+         zedFrame.update(transformToWorld -> transformToWorld.set(lowQualityImage.getRotation(), lowQualityImage.getTranslation()));
+         realsenseFrame.update(transformToWorld -> transformToWorld.set(highQualityImage.getRotation(), highQualityImage.getTranslation()));
          zedFrame.getReferenceFrame().getTransformToDesiredFrame(zedToRealsenseTransform, realsenseFrame.getReferenceFrame());
          zedToRealsenseTransformParameter.setParameter(zedToRealsenseTransform);
          zedToRealsenseTransformParameter.writeOpenCLBufferObject(openCLManager);

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/StandAloneRealsenseProcess.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/StandAloneRealsenseProcess.java
@@ -78,7 +78,7 @@ public class StandAloneRealsenseProcess
       ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1, threadFactory);
       scheduler.scheduleAtFixedRate(realsenseTunableTransform::update, 0, 33, TimeUnit.MILLISECONDS);
 
-      d455Sensor.setSensorFrameSupplier(syncedRobot.getReferenceFrames()::getSteppingCameraFrame);
+      d455Sensor.setSensorFrame(syncedRobot.getReferenceFrames().getSteppingCameraFrame());
       loopOnDemand(d455Sensor.getGrabThread(), realsenseDemandNode);
 
       d455PublishThread = new ImageSensorPublishThread(ros2Node, d455Sensor, D455_IMAGE_TOPIC_MAP);

--- a/ihmc-perception/src/main/java/us/ihmc/perception/BallDetectionManager.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/BallDetectionManager.java
@@ -92,7 +92,7 @@ public class BallDetectionManager
             double z = -(ballCenter.y() - colorImage.getPrincipalPointY()) / colorImage.getFocalLengthY() * depth;
 
             // get ball's position with respect to world
-            RigidBodyTransform newBallPosition = new RigidBodyTransform(colorImage.getOrientation(), colorImage.getPosition());
+            RigidBodyTransform newBallPosition = new RigidBodyTransform(colorImage.getTransformToWorld());
             newBallPosition.appendTranslation(depth, y, z);
             ballPosition.update(newBallPosition);
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/RawImage.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/RawImage.java
@@ -5,11 +5,10 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.opencv.opencv_core.GpuMat;
 import org.bytedeco.opencv.opencv_core.Mat;
 import perception_msgs.msg.dds.ImageMessage;
-import us.ihmc.euclid.referenceFrame.FramePose3D;
-import us.ihmc.euclid.referenceFrame.interfaces.FixedFramePoint3DBasics;
-import us.ihmc.euclid.referenceFrame.interfaces.FixedFramePose3DBasics;
-import us.ihmc.euclid.referenceFrame.interfaces.FixedFrameQuaternionBasics;
-import us.ihmc.euclid.referenceFrame.interfaces.FramePose3DReadOnly;
+import us.ihmc.euclid.orientation.interfaces.Orientation3DReadOnly;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.euclid.tuple3D.interfaces.Tuple3DReadOnly;
 import us.ihmc.perception.camera.CameraIntrinsics;
 import us.ihmc.perception.imageMessage.PixelFormat;
 
@@ -59,7 +58,7 @@ public class RawImage
    private final float depthDiscretization;
    private final long sequenceNumber;
    private final Instant acquisitionTime;
-   private final FramePose3D sensorPose; // Should always be in world frame
+   private final RigidBodyTransformReadOnly sensorToWorldTransform;
 
    private final AtomicInteger numberOfReferences = new AtomicInteger(1);
 
@@ -68,7 +67,7 @@ public class RawImage
                    PixelFormat pixelFormat,
                    CameraIntrinsics cameraIntrinsics,
                    CameraModel cameraModel,
-                   FramePose3DReadOnly sensorPose,
+                   RigidBodyTransformReadOnly sensorToWorldTransform,
                    Instant acquisitionTime,
                    long sequenceNumber,
                    float depthDiscretization)
@@ -81,8 +80,7 @@ public class RawImage
       this.pixelFormat = pixelFormat;
       this.cameraIntrinsics = new CameraIntrinsics(cameraIntrinsics);
       this.cameraModel = cameraModel;
-      this.sensorPose = new FramePose3D(sensorPose);
-      this.sensorPose.changeFrame(sensorPose.getReferenceFrame().getRootFrame());
+      this.sensorToWorldTransform = new RigidBodyTransform(sensorToWorldTransform);
       this.acquisitionTime = acquisitionTime;
       this.sequenceNumber = sequenceNumber;
       this.depthDiscretization = depthDiscretization;
@@ -97,7 +95,7 @@ public class RawImage
       this.pixelFormat = other.pixelFormat;
       this.cameraIntrinsics = other.cameraIntrinsics;
       this.cameraModel = other.cameraModel;
-      this.sensorPose = other.sensorPose;
+      this.sensorToWorldTransform = other.sensorToWorldTransform;
       this.acquisitionTime = other.acquisitionTime;
       this.sequenceNumber = other.sequenceNumber;
       this.depthDiscretization = other.depthDiscretization;
@@ -105,42 +103,48 @@ public class RawImage
 
    public static RawImage createWithBGRImage(Pointer matPointer,
                                              CameraIntrinsics cameraIntrinsics,
-                                             FixedFramePose3DBasics sensorPose,
+                                             RigidBodyTransformReadOnly sensorTransformToWorld,
                                              Instant acquisitionTime,
                                              long sequenceNumber)
    {
-      return createWithBGRImage(matPointer, cameraIntrinsics, CameraModel.PINHOLE, sensorPose, acquisitionTime, sequenceNumber);
+      return createWithBGRImage(matPointer, cameraIntrinsics, CameraModel.PINHOLE, sensorTransformToWorld, acquisitionTime, sequenceNumber);
    }
 
    public static RawImage createWithBGRImage(Pointer matPointer,
                                              CameraIntrinsics cameraIntrinsics,
                                              CameraModel cameraModel,
-                                             FixedFramePose3DBasics sensorPose,
+                                             RigidBodyTransformReadOnly sensorTransformToWorld,
                                              Instant acquisitionTime,
                                              long sequenceNumber)
    {
       if (matPointer instanceof Mat cpuImage)
-         return new RawImage(cpuImage, null, PixelFormat.BGR8, cameraIntrinsics, cameraModel, sensorPose, acquisitionTime, sequenceNumber, -1.0f);
+         return new RawImage(cpuImage, null, PixelFormat.BGR8, cameraIntrinsics, cameraModel, sensorTransformToWorld, acquisitionTime, sequenceNumber, -1.0f);
       else if (matPointer instanceof GpuMat gpuImage)
-         return new RawImage(null, gpuImage, PixelFormat.BGR8, cameraIntrinsics, cameraModel, sensorPose, acquisitionTime, sequenceNumber, -1.0f);
+         return new RawImage(null, gpuImage, PixelFormat.BGR8, cameraIntrinsics, cameraModel, sensorTransformToWorld, acquisitionTime, sequenceNumber, -1.0f);
 
       throw new IllegalArgumentException("The pointer passed in was neither a Mat nor GpuMat");
    }
 
    public static RawImage createWith16BitDepth(Pointer matPointer,
                                                CameraIntrinsics cameraIntrinsics,
-                                               FixedFramePose3DBasics sensorPose,
+                                               RigidBodyTransformReadOnly sensorTransformToWorld,
                                                Instant acquisitionTime,
                                                long sequenceNumber,
                                                float depthDiscretization)
    {
-      return createWith16BitDepth(matPointer, cameraIntrinsics, CameraModel.PINHOLE, sensorPose, acquisitionTime, sequenceNumber, depthDiscretization);
+      return createWith16BitDepth(matPointer,
+                                  cameraIntrinsics,
+                                  CameraModel.PINHOLE,
+                                  sensorTransformToWorld,
+                                  acquisitionTime,
+                                  sequenceNumber,
+                                  depthDiscretization);
    }
 
    public static RawImage createWith16BitDepth(Pointer matPointer,
                                                CameraIntrinsics cameraIntrinsics,
                                                CameraModel cameraModel,
-                                               FixedFramePose3DBasics sensorPose,
+                                               RigidBodyTransformReadOnly sensorTransformToWorld,
                                                Instant acquisitionTime,
                                                long sequenceNumber,
                                                float depthDiscretization)
@@ -151,7 +155,7 @@ public class RawImage
                              PixelFormat.GRAY16,
                              cameraIntrinsics,
                              cameraModel,
-                             sensorPose,
+                             sensorTransformToWorld,
                              acquisitionTime,
                              sequenceNumber,
                              depthDiscretization);
@@ -161,7 +165,7 @@ public class RawImage
                              PixelFormat.GRAY16,
                              cameraIntrinsics,
                              cameraModel,
-                             sensorPose,
+                             sensorTransformToWorld,
                              acquisitionTime,
                              sequenceNumber,
                              depthDiscretization);
@@ -172,6 +176,7 @@ public class RawImage
    /**
     * Provides a new {@link RawImage} with the same pixel format, intrinsics, and metadata as this one, but with a different image.
     * Useful when applying changes to Mats and wishing to keep the same intrinsics & metadata in the {@link RawImage}.
+    *
     * @param newCpuImageMat new CPU image mat to replace the current image. Must have the same dimensions.
     * @return A new {@link RawImage} with the same intrinsics & metadata, but with a different image.
     */
@@ -183,6 +188,7 @@ public class RawImage
    /**
     * Provides a new {@link RawImage} with the same intrinsics and metadata as this one, but with a different image.
     * Useful when applying changes to Mats and wishing to keep the same intrinsics & metadata in the {@link RawImage}.
+    *
     * @param newCpuImageMat new CPU image mat to replace the current image. Must have the same dimensions.
     * @param newPixelFormat the PixelFormat of the new image.
     * @return A new {@link RawImage} with the same intrinsics & metadata, but with a different image.
@@ -197,7 +203,7 @@ public class RawImage
                           newPixelFormat,
                           this.cameraIntrinsics,
                           this.cameraModel,
-                          this.sensorPose,
+                          this.sensorToWorldTransform,
                           this.acquisitionTime,
                           this.sequenceNumber,
                           this.depthDiscretization);
@@ -206,6 +212,7 @@ public class RawImage
    /**
     * Provides a new {@link RawImage} with the same pixel format, intrinsics, and metadata as this one, but with a different image.
     * Useful when applying changes to Mats and wishing to keep the same intrinsics & metadata in the {@link RawImage}.
+    *
     * @param newGpuImageMat new GPU image mat to replace the current image. Must have the same dimensions.
     * @return A new {@link RawImage} with the same intrinsics & metadata, but with a different image.
     */
@@ -217,6 +224,7 @@ public class RawImage
    /**
     * Provides a new {@link RawImage} with the same intrinsics and metadata as this one, but with a different image.
     * Useful when applying changes to Mats and wishing to keep the same intrinsics & metadata in the {@link RawImage}.
+    *
     * @param newGpuImageMat new GPU image mat to replace the current image. Must have the same dimensions.
     * @param newPixelFormat the PixelFormat of the new image.
     * @return A new {@link RawImage} with the same intrinsics & metadata, but with a different image.
@@ -231,7 +239,7 @@ public class RawImage
                           newPixelFormat,
                           this.cameraIntrinsics,
                           this.cameraModel,
-                          this.sensorPose,
+                          this.sensorToWorldTransform,
                           this.acquisitionTime,
                           this.sequenceNumber,
                           this.depthDiscretization);
@@ -270,6 +278,7 @@ public class RawImage
     * If this image only has a {@link GpuMat}, a new {@link Mat} will be created
     * and the image data will be downloaded from the device (GPU).
     * </p>
+    *
     * @return The {@link Mat} containing the image data.
     */
    public Mat getCpuImageMat()
@@ -294,6 +303,7 @@ public class RawImage
     * If this image only has a {@link Mat}, a new {@link GpuMat} will be created
     * and the image data will be uploaded to the device (GPU).
     * </p>
+    *
     * @return The {@link GpuMat} containing the image data.
     */
    public GpuMat getGpuImageMat()
@@ -318,6 +328,7 @@ public class RawImage
     * Same as calling {@code getCpuImageMat().data()}. As such, if this image does not have a {@link Mat},
     * a new {@link Mat} will be created and the image data will be downloaded from the device (GPU).
     * </p>
+    *
     * @return The pointer to the image data.
     */
    public BytePointer getDataPointer()
@@ -333,6 +344,7 @@ public class RawImage
     * Same as calling {@code getGpuImageMat().data()}. As such, if this image does not have a {@link GpuMat},
     * a new {@link GpuMat} will be created and the image data will be uploaded to the device (GPU).
     * </p>
+    *
     * @return The CUDA pointer to the image data.
     */
    public BytePointer getCUDADataPointer()
@@ -385,19 +397,19 @@ public class RawImage
       return (float) cameraIntrinsics.getCy();
    }
 
-   public FramePose3DReadOnly getPose()
+   public RigidBodyTransformReadOnly getTransformToWorld()
    {
-      return sensorPose;
+      return sensorToWorldTransform;
    }
 
-   public FixedFramePoint3DBasics getPosition()
+   public Tuple3DReadOnly getTranslation()
    {
-      return sensorPose.getPosition();
+      return sensorToWorldTransform.getTranslation();
    }
 
-   public FixedFrameQuaternionBasics getOrientation()
+   public Orientation3DReadOnly getRotation()
    {
-      return sensorPose.getOrientation();
+      return sensorToWorldTransform.getRotation();
    }
 
    public boolean hasCpuImage()

--- a/ihmc-perception/src/main/java/us/ihmc/perception/RawImage.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/RawImage.java
@@ -5,9 +5,11 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.opencv.opencv_core.GpuMat;
 import org.bytedeco.opencv.opencv_core.Mat;
 import perception_msgs.msg.dds.ImageMessage;
+import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.interfaces.FixedFramePoint3DBasics;
 import us.ihmc.euclid.referenceFrame.interfaces.FixedFramePose3DBasics;
 import us.ihmc.euclid.referenceFrame.interfaces.FixedFrameQuaternionBasics;
+import us.ihmc.euclid.referenceFrame.interfaces.FramePose3DReadOnly;
 import us.ihmc.perception.camera.CameraIntrinsics;
 import us.ihmc.perception.imageMessage.PixelFormat;
 
@@ -57,7 +59,7 @@ public class RawImage
    private final float depthDiscretization;
    private final long sequenceNumber;
    private final Instant acquisitionTime;
-   private final FixedFramePose3DBasics sensorPose;
+   private final FramePose3D sensorPose; // Should always be in world frame
 
    private final AtomicInteger numberOfReferences = new AtomicInteger(1);
 
@@ -66,7 +68,7 @@ public class RawImage
                    PixelFormat pixelFormat,
                    CameraIntrinsics cameraIntrinsics,
                    CameraModel cameraModel,
-                   FixedFramePose3DBasics sensorPose,
+                   FramePose3DReadOnly sensorPose,
                    Instant acquisitionTime,
                    long sequenceNumber,
                    float depthDiscretization)
@@ -77,9 +79,10 @@ public class RawImage
       this.cpuImageMat = cpuImageMat;
       this.gpuImageMat = gpuImageMat;
       this.pixelFormat = pixelFormat;
-      this.cameraIntrinsics = cameraIntrinsics;
+      this.cameraIntrinsics = new CameraIntrinsics(cameraIntrinsics);
       this.cameraModel = cameraModel;
-      this.sensorPose = sensorPose;
+      this.sensorPose = new FramePose3D(sensorPose);
+      this.sensorPose.changeFrame(sensorPose.getReferenceFrame().getRootFrame());
       this.acquisitionTime = acquisitionTime;
       this.sequenceNumber = sequenceNumber;
       this.depthDiscretization = depthDiscretization;
@@ -382,7 +385,7 @@ public class RawImage
       return (float) cameraIntrinsics.getCy();
    }
 
-   public FixedFramePose3DBasics getPose()
+   public FramePose3DReadOnly getPose()
    {
       return sensorPose;
    }

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAPointCloudExtractor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDAPointCloudExtractor.java
@@ -92,7 +92,7 @@ public class CUDAPointCloudExtractor implements AutoCloseable
       }
 
       // Get a float[] of the transformation matrix, and copy it into CUDA page-locked memory
-      depthToWorldTransform.set(depthImage.getPose());
+      depthToWorldTransform.set(depthImage.getTransformToWorld());
       depthToWorldTransform.get(transformArray);
       transformPointer.put(transformArray);
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8Model.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8Model.java
@@ -544,7 +544,7 @@ public class YOLOv8Model
                           PixelFormat.GRAY8,
                           new CameraIntrinsics(maskIntrinsics),
                           CameraModel.PINHOLE,
-                          bgrInputImage.getPose(),
+                          bgrInputImage.getTransformToWorld(),
                           bgrInputImage.getAcquisitionTime(),
                           bgrInputImage.getSequenceNumber(),
                           bgrInputImage.getDepthDiscretization());

--- a/ihmc-perception/src/main/java/us/ihmc/perception/opencl/OpenCLDepthImageSegmenter.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/opencl/OpenCLDepthImageSegmenter.java
@@ -26,8 +26,8 @@ public class OpenCLDepthImageSegmenter
       depthImage.get();
       imageMask.get();
 
-      depthFrame.update(transformToWorld -> transformToWorld.set(depthImage.getOrientation(), depthImage.getPosition()));
-      maskFrame.update(transformToWorld -> transformToWorld.set(imageMask.getOrientation(), imageMask.getPosition()));
+      depthFrame.update(transformToWorld -> transformToWorld.set(depthImage.getRotation(), depthImage.getTranslation()));
+      maskFrame.update(transformToWorld -> transformToWorld.set(imageMask.getRotation(), imageMask.getTranslation()));
       depthFrame.getReferenceFrame().getTransformToDesiredFrame(depthToMaskTransform, maskFrame.getReferenceFrame());
       depthToMaskTransformParameter.setParameter(depthToMaskTransform);
       depthToMaskTransformParameter.writeOpenCLBufferObject(openCLManager);

--- a/ihmc-perception/src/main/java/us/ihmc/perception/opencl/OpenCLPointCloudExtractor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/opencl/OpenCLPointCloudExtractor.java
@@ -39,7 +39,7 @@ public class OpenCLPointCloudExtractor
          pointCloudVertexOutput.createOpenCLBufferObject(openCLManager);
       }
 
-      RigidBodyTransform depthToWorldTransform = new RigidBodyTransform(depthImage.getOrientation(), depthImage.getPosition());
+      RigidBodyTransform depthToWorldTransform = new RigidBodyTransform(depthImage.getRotation(), depthImage.getTranslation());
       depthToWorldTransformParameter.setParameter(depthToWorldTransform);
       depthToWorldTransformParameter.writeOpenCLBufferObject(openCLManager);
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVArUcoMarkerDetectionThread.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/opencv/OpenCVArUcoMarkerDetectionThread.java
@@ -53,7 +53,7 @@ public class OpenCVArUcoMarkerDetectionThread extends RepeatingTaskThread
          }
 
          // Update the sensor frame
-         sensorFrame.update(transformToWorld -> transformToWorld.set(colorImage.getPose()));
+         sensorFrame.update(transformToWorld -> transformToWorld.set(colorImage.getTransformToWorld()));
 
          // Detect markers
          detector.update(colorImage.getCpuImageMat());

--- a/ihmc-perception/src/main/java/us/ihmc/perception/rapidRegions/RapidPlanarRegionsExtractionThread.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/rapidRegions/RapidPlanarRegionsExtractionThread.java
@@ -75,7 +75,7 @@ public class RapidPlanarRegionsExtractionThread extends RepeatingTaskThread
       extractorParametersSync.updateAndPublishThrottledStatus();
 
       // Update the sensor frame using the depth image pose
-      sensorFrame.update(transformToWorld -> transformToWorld.set(depthImage.getOrientation(), depthImage.getPosition()));
+      sensorFrame.update(transformToWorld -> transformToWorld.set(depthImage.getTransformToWorld()));
 
       // Extract the planar regions
       BytedecoImage bytedecoImage = new BytedecoImage(depthImage.getCpuImageMat().clone());

--- a/ihmc-perception/src/main/java/us/ihmc/perception/streaming/ROS2SRTVideoStreamer.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/streaming/ROS2SRTVideoStreamer.java
@@ -5,7 +5,6 @@ import perception_msgs.msg.dds.SRTStreamStatus;
 import perception_msgs.msg.dds.VideoFrameExtraData;
 import us.ihmc.commons.time.FrequencyCalculator;
 import us.ihmc.communication.packets.MessageTools;
-import us.ihmc.euclid.geometry.Pose3D;
 import us.ihmc.log.LogTools;
 import us.ihmc.perception.RawImage;
 import us.ihmc.ros2.ROS2Node;
@@ -141,7 +140,7 @@ public class ROS2SRTVideoStreamer
 
       frameExtraData.setSequenceNumber(frame.getSequenceNumber());
       MessageTools.toMessage(frame.getAcquisitionTime(), frameExtraData.getAcquisitionTime());
-      frameExtraData.getSensorPose().set(new Pose3D(frame.getPosition(), frame.getOrientation()));
+      frameExtraData.getSensorPose().set(frame.getTransformToWorld());
 
       if (isStreamingDepth)
       {

--- a/ihmc-perception/src/main/java/us/ihmc/perception/tools/PerceptionMessageTools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/tools/PerceptionMessageTools.java
@@ -112,8 +112,8 @@ public class PerceptionMessageTools
       messageToPack.setDepthDiscretization(image.getDepthDiscretization());
       messageToPack.setSequenceNumber(image.getSequenceNumber());
       MessageTools.toMessage(image.getAcquisitionTime(), messageToPack.getAcquisitionTime());
-      messageToPack.getPosition().set(image.getPosition());
-      messageToPack.getOrientation().set(image.getOrientation());
+      messageToPack.getPosition().set(image.getTranslation());
+      messageToPack.getOrientation().set(image.getRotation());
    }
 
    public static void packCompressedDepthImage(BytePointer compressedDepthPointer,

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/ImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/ImageSensor.java
@@ -24,13 +24,7 @@ public abstract class ImageSensor implements AutoCloseable
    }
 
    /**
-    * Initializes and starts the sensor.
-    * @return Whether the sensor was successfully initialized and started.
-    */
-   protected abstract boolean startSensor();
-
-   /**
-    * Set the sensor frame supplier.
+    * Set the sensor frame.
     * @param sensorFrame The sensor's reference frame.
     */
    public void setSensorFrame(ReferenceFrame sensorFrame)
@@ -46,6 +40,17 @@ public abstract class ImageSensor implements AutoCloseable
    {
       // To be optionally implemented by subclasses
    }
+
+   public ReferenceFrame getSensorFrame()
+   {
+      return sensorFrame;
+   }
+
+   /**
+    * Initializes and starts the sensor.
+    * @return Whether the sensor was successfully initialized and started.
+    */
+   protected abstract boolean startSensor();
 
    /**
     * @return Whether the sensor is running. Not necessarily the same as whether the grab thread is running.
@@ -72,6 +77,23 @@ public abstract class ImageSensor implements AutoCloseable
     * The caller must call {@link RawImage#release()}.
     */
    public abstract RawImage getImage(int imageKey);
+
+   /**
+    * Get the {@link ReferenceFrame} associated with an image, specified by the image key.
+    *
+    * @param imageKey Key of the image associated with the reference frame.
+    * @return The {@link ReferenceFrame} of the image. {@code null} if an invalid key is provided.
+    */
+   public abstract ReferenceFrame getImageFrame(int imageKey);
+
+   /**
+    * Get all image reference frames provided by the sensor.
+    *
+    * @return An array of all image reference frames provided by the sensor.
+    * @apiNote The number of reference might not equal the number of images as some images may share a frame.
+    *       Image keys do not work on the returned array.
+    */
+   public abstract ReferenceFrame[] getImageFrames();
 
    public String getSensorName()
    {

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/ImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/ImageSensor.java
@@ -6,15 +6,13 @@ import us.ihmc.commons.thread.ThreadTools;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.perception.RawImage;
 
-import java.util.function.Supplier;
-
 public abstract class ImageSensor implements AutoCloseable
 {
    private static final double SECONDS_BETWEEN_RETRIES = 1.0;  // Wait 1 second between retries for starting sensors
 
    private final String sensorName;
-   /** Sensor will be in world frame by default, unless a sensor frame supplier is specified through {@link #setSensorFrameSupplier(Supplier)}. */
-   protected volatile Supplier<ReferenceFrame> sensorFrameSupplier = ReferenceFrame::getWorldFrame;
+   /** Sensor will be in world frame by default, unless a sensor frame is specified through {@link #setSensorFrame(ReferenceFrame)}. */
+   protected ReferenceFrame sensorFrame = ReferenceFrame.getWorldFrame();
 
    private final RepeatingTaskThread grabThread;
    private final Object grabNotification = new Object();
@@ -33,11 +31,20 @@ public abstract class ImageSensor implements AutoCloseable
 
    /**
     * Set the sensor frame supplier.
-    * @param sensorFrameSupplier Supplier of the sensor's reference frame.
+    * @param sensorFrame The sensor's reference frame.
     */
-   public void setSensorFrameSupplier(Supplier<ReferenceFrame> sensorFrameSupplier)
+   public void setSensorFrame(ReferenceFrame sensorFrame)
    {
-      this.sensorFrameSupplier = sensorFrameSupplier;
+      if (this.sensorFrame != sensorFrame)
+      {
+         this.sensorFrame = sensorFrame;
+         onSensorFrameChanged();
+      }
+   }
+
+   protected void onSensorFrameChanged()
+   {
+      // To be optionally implemented by subclasses
    }
 
    /**

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/realsense/RealSenseImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/realsense/RealSenseImageSensor.java
@@ -4,7 +4,6 @@ import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.opencv_core.Mat;
 import us.ihmc.commons.thread.Notification;
 import us.ihmc.commons.thread.Throttler;
-import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.tools.ReferenceFrameTools;
 import us.ihmc.euclid.transform.RigidBodyTransform;
@@ -152,6 +151,23 @@ public class RealSenseImageSensor extends ImageSensor
 
          return grabbedImages[imageKey].get();
       }
+   }
+
+   @Override
+   public ReferenceFrame getImageFrame(int imageKey)
+   {
+      return switch (imageKey)
+      {
+         case COLOR_IMAGE_KEY -> colorFrame;
+         case DEPTH_IMAGE_KEY -> depthFrame;
+         default -> null;
+      };
+   }
+
+   @Override
+   public ReferenceFrame[] getImageFrames()
+   {
+      return new ReferenceFrame[] {colorFrame, depthFrame};
    }
 
    @Override

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/realsense/RealSenseImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/realsense/RealSenseImageSensor.java
@@ -112,7 +112,7 @@ public class RealSenseImageSensor extends ImageSensor
 
          if (colorFrame != null)
             colorFrame.remove();
-         RigidBodyTransform colorToDepthTransform = new RigidBodyTransform(realsense.getDepthToColorRotation(), realsense.depthToColorTranslation);
+         RigidBodyTransform colorToDepthTransform = new RigidBodyTransform(realsense.getDepthToColorRotation(), realsense.getDepthToColorTranslation());
          colorToDepthTransform.invert();
          colorFrame = ReferenceFrameTools.constructFrameWithUnchangingTransformToParent(getSensorName() + "_color", sensorFrame, colorToDepthTransform);
       }
@@ -124,7 +124,7 @@ public class RealSenseImageSensor extends ImageSensor
             grabbedImages[COLOR_IMAGE_KEY].release();
          grabbedImages[COLOR_IMAGE_KEY] = RawImage.createWithBGRImage(bgrImage,
                                                                       realsense.getColorCameraIntrinsics(),
-                                                                      new FramePose3D(colorFrame),
+                                                                      colorFrame.getTransformToRoot(),
                                                                       grabTime,
                                                                       grabSequenceNumber);
 
@@ -132,7 +132,7 @@ public class RealSenseImageSensor extends ImageSensor
             grabbedImages[DEPTH_IMAGE_KEY].release();
          grabbedImages[DEPTH_IMAGE_KEY] = RawImage.createWith16BitDepth(depthImage,
                                                                         realsense.getDepthCameraIntrinsics(),
-                                                                        new FramePose3D(depthFrame),
+                                                                        depthFrame.getTransformToRoot(),
                                                                         grabTime,
                                                                         grabSequenceNumber,
                                                                         (float) realsense.getDepthDiscretization());

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/realsense/RealSenseImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/realsense/RealSenseImageSensor.java
@@ -2,9 +2,12 @@ package us.ihmc.sensors.realsense;
 
 import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.opencv_core.Mat;
+import us.ihmc.commons.thread.Notification;
 import us.ihmc.commons.thread.Throttler;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.referenceFrame.tools.ReferenceFrameTools;
+import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.log.LogTools;
 import us.ihmc.perception.RawImage;
 import us.ihmc.sensors.ImageSensor;
@@ -27,8 +30,10 @@ public class RealSenseImageSensor extends ImageSensor
    private long grabSequenceNumber = 0L;
    private int grabFailureCount = 0;
 
-   private final FramePose3D depthPose = new FramePose3D();
-   private final FramePose3D colorPose = new FramePose3D();
+   private ReferenceFrame depthFrame;
+   private ReferenceFrame colorFrame;
+   private final Notification resetFrames = new Notification();
+
    private final Throttler grabThrottler = new Throttler().setFrequency(OUTPUT_FREQUENCY);
 
    public RealSenseImageSensor(RealSenseConfiguration realsenseConfiguration)
@@ -36,6 +41,13 @@ public class RealSenseImageSensor extends ImageSensor
       super(realsenseConfiguration.name().split("_")[0]);
 
       this.realsenseConfiguration = realsenseConfiguration;
+      resetFrames.set();
+   }
+
+   @Override
+   protected void onSensorFrameChanged()
+   {
+      resetFrames.set();
    }
 
    @Override
@@ -77,15 +89,6 @@ public class RealSenseImageSensor extends ImageSensor
    {
       grabThrottler.waitAndRun();
 
-      // Update the sensor poses
-      ReferenceFrame sensorFrame = sensorFrameSupplier.get();
-      depthPose.setToZero(sensorFrame);
-      depthPose.changeFrame(ReferenceFrame.getWorldFrame());
-
-      colorPose.setIncludingFrame(sensorFrame, realsense.getDepthToColorTranslation(), realsense.getDepthToColorRotation());
-      colorPose.invert();
-      colorPose.changeFrame(ReferenceFrame.getWorldFrame());
-
       // Read grabbed images
       if (!realsense.readFrameData())
       {
@@ -100,6 +103,20 @@ public class RealSenseImageSensor extends ImageSensor
       Mat bgrImage = new Mat(realsense.getColorHeight(), realsense.getColorWidth(), opencv_core.CV_8UC3, realsense.getColorFrameData());
       Mat depthImage = new Mat(realsense.getDepthHeight(), realsense.getDepthWidth(), opencv_core.CV_16UC1, realsense.getDepthFrameData());
 
+      // Update sensor frames
+      if (resetFrames.poll())
+      {
+         if (depthFrame != null)
+            depthFrame.remove();
+         depthFrame = ReferenceFrameTools.constructFrameWithUnchangingTransformToParent(getSensorName() + "_depth", sensorFrame, new RigidBodyTransform());
+
+         if (colorFrame != null)
+            colorFrame.remove();
+         RigidBodyTransform colorToDepthTransform = new RigidBodyTransform(realsense.getDepthToColorRotation(), realsense.depthToColorTranslation);
+         colorToDepthTransform.invert();
+         colorFrame = ReferenceFrameTools.constructFrameWithUnchangingTransformToParent(getSensorName() + "_color", sensorFrame, colorToDepthTransform);
+      }
+
       // Update grabbed images
       synchronized (grabbedImages)
       {
@@ -107,7 +124,7 @@ public class RealSenseImageSensor extends ImageSensor
             grabbedImages[COLOR_IMAGE_KEY].release();
          grabbedImages[COLOR_IMAGE_KEY] = RawImage.createWithBGRImage(bgrImage,
                                                                       realsense.getColorCameraIntrinsics(),
-                                                                      new FramePose3D(colorPose),
+                                                                      new FramePose3D(colorFrame),
                                                                       grabTime,
                                                                       grabSequenceNumber);
 
@@ -115,7 +132,7 @@ public class RealSenseImageSensor extends ImageSensor
             grabbedImages[DEPTH_IMAGE_KEY].release();
          grabbedImages[DEPTH_IMAGE_KEY] = RawImage.createWith16BitDepth(depthImage,
                                                                         realsense.getDepthCameraIntrinsics(),
-                                                                        new FramePose3D(depthPose),
+                                                                        new FramePose3D(depthFrame),
                                                                         grabTime,
                                                                         grabSequenceNumber,
                                                                         (float) realsense.getDepthDiscretization());

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
@@ -2,11 +2,11 @@ package us.ihmc.sensors.zed;
 
 import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.opencv.opencv_core.GpuMat;
-import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.referenceFrame.tools.ReferenceFrameTools;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformBasics;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.euclid.tuple3D.Vector3D;
 import us.ihmc.euclid.tuple4D.Quaternion;
 import us.ihmc.log.LogTools;
@@ -276,22 +276,25 @@ public class ZEDImageSensor extends ImageSensor
          returnCode = sl_retrieve_image(cameraID, rightColorImagePointer, SL_VIEW_RIGHT, SL_MEM_GPU, imageWidth, imageHeight);
          throwOnError(returnCode);
 
-         FramePose3D leftSensorPose = new FramePose3D(leftSensorFrame);
-         FramePose3D rightSensorPose = new FramePose3D(rightSensorFrame);
-
          synchronized (grabbedImages)
          {  // Create RawImages from the grabbed retrieved slMats
             if (grabbedImages[LEFT_COLOR_IMAGE_KEY] != null)
                grabbedImages[LEFT_COLOR_IMAGE_KEY].release();
-            grabbedImages[LEFT_COLOR_IMAGE_KEY] = slMatToRawImage(leftColorImagePointer, PixelFormat.BGRA8, leftSensorIntrinsics, leftSensorPose);
+            grabbedImages[LEFT_COLOR_IMAGE_KEY] = slMatToRawImage(leftColorImagePointer,
+                                                                  PixelFormat.BGRA8,
+                                                                  leftSensorIntrinsics,
+                                                                  leftSensorFrame.getTransformToRoot());
 
             if (grabbedImages[RIGHT_COLOR_IMAGE_KEY] != null)
                grabbedImages[RIGHT_COLOR_IMAGE_KEY].release();
-            grabbedImages[RIGHT_COLOR_IMAGE_KEY] = slMatToRawImage(rightColorImagePointer, PixelFormat.BGRA8, rightSensorIntrinsics, rightSensorPose);
+            grabbedImages[RIGHT_COLOR_IMAGE_KEY] = slMatToRawImage(rightColorImagePointer,
+                                                                   PixelFormat.BGRA8,
+                                                                   rightSensorIntrinsics,
+                                                                   rightSensorFrame.getTransformToRoot());
 
             if (grabbedImages[DEPTH_IMAGE_KEY] != null)
                grabbedImages[DEPTH_IMAGE_KEY].release();
-            grabbedImages[DEPTH_IMAGE_KEY] = slMatToRawImage(depthImagePointer, PixelFormat.GRAY16, leftSensorIntrinsics, leftSensorPose);
+            grabbedImages[DEPTH_IMAGE_KEY] = slMatToRawImage(depthImagePointer, PixelFormat.GRAY16, leftSensorIntrinsics, leftSensorFrame.getTransformToRoot());
          }
       }
       catch (ZEDException exception)
@@ -305,7 +308,10 @@ public class ZEDImageSensor extends ImageSensor
       return true;
    }
 
-   private RawImage slMatToRawImage(Pointer slMatPointer, PixelFormat imagePixelFormat, CameraIntrinsics cameraIntrinsics, FramePose3D sensorPose)
+   private RawImage slMatToRawImage(Pointer slMatPointer,
+                                    PixelFormat imagePixelFormat,
+                                    CameraIntrinsics cameraIntrinsics,
+                                    RigidBodyTransformReadOnly sensorTransform)
    {
       GpuMat imageGpuMat = new GpuMat(imageHeight,
                                       imageWidth,
@@ -317,7 +323,7 @@ public class ZEDImageSensor extends ImageSensor
                           imagePixelFormat,
                           cameraIntrinsics,
                           CameraModel.PINHOLE,
-                          new FramePose3D(sensorPose),
+                          sensorTransform,
                           lastGrabTime,
                           grabSequenceNumber,
                           MILLIMETER_TO_METERS);

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
@@ -341,6 +341,23 @@ public class ZEDImageSensor extends ImageSensor
       }
    }
 
+   @Override
+   public ReferenceFrame getImageFrame(int imageKey)
+   {
+      return switch (imageKey)
+      {
+         case LEFT_COLOR_IMAGE_KEY, DEPTH_IMAGE_KEY -> leftSensorFrame;
+         case RIGHT_COLOR_IMAGE_KEY -> rightSensorFrame;
+         default -> null;
+      };
+   }
+
+   @Override
+   public ReferenceFrame[] getImageFrames()
+   {
+      return new ReferenceFrame[] {leftSensorFrame, rightSensorFrame};
+   }
+
    public ReferenceFrame getTrackedSensorFrame()
    {
       return trackedSensorFrame.getReferenceFrame();

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
@@ -4,6 +4,8 @@ import org.bytedeco.javacpp.Pointer;
 import org.bytedeco.opencv.opencv_core.GpuMat;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.referenceFrame.tools.ReferenceFrameTools;
+import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformBasics;
 import us.ihmc.euclid.tuple3D.Vector3D;
 import us.ihmc.euclid.tuple4D.Quaternion;
@@ -15,7 +17,6 @@ import us.ihmc.perception.imageMessage.PixelFormat;
 import us.ihmc.robotics.referenceFrames.MutableReferenceFrame;
 import us.ihmc.sensors.ImageSensor;
 import us.ihmc.zed.SL_CalibrationParameters;
-import us.ihmc.zed.SL_CameraInformation;
 import us.ihmc.zed.SL_InitParameters;
 import us.ihmc.zed.SL_PositionalTrackingParameters;
 import us.ihmc.zed.SL_Quaternion;
@@ -58,9 +59,9 @@ public class ZEDImageSensor extends ImageSensor
    private int imageWidth;
    private int imageHeight;
 
-   private float sensorCenterToCameraDistanceY = 0.0f;
-   private final FramePose3D leftSensorPose = new FramePose3D();
-   private final FramePose3D rightSensorPose = new FramePose3D();
+   private float sensorCenterToCameraDistanceY;
+   private ReferenceFrame leftSensorFrame = null;
+   private ReferenceFrame rightSensorFrame = null;
 
    private long grabSequenceNumber = 0L;
    private Instant lastGrabTime;
@@ -83,6 +84,9 @@ public class ZEDImageSensor extends ImageSensor
       this.slInputType = slInputType;
       this.slDepthMode = slDepthMode;
 
+      sensorCenterToCameraDistanceY = (float) zedModel.getCenterToCameraDistance();
+      updateReferenceFrames();
+
       // Set runtime parameters to default values
       zedRuntimeParameters.reference_frame(SL_REFERENCE_FRAME_CAMERA);
       zedRuntimeParameters.enable_depth(true);
@@ -90,6 +94,25 @@ public class ZEDImageSensor extends ImageSensor
       zedRuntimeParameters.texture_confidence_threshold(100);
       zedRuntimeParameters.remove_saturated_areas(true);
       zedRuntimeParameters.enable_fill_mode(false);
+   }
+
+   private void updateReferenceFrames()
+   {
+      if (leftSensorFrame != null)
+         leftSensorFrame.remove();
+      RigidBodyTransform leftSensorTransform = new RigidBodyTransform(new Quaternion(), new Vector3D(0.0, sensorCenterToCameraDistanceY, 0.0));
+      leftSensorFrame = ReferenceFrameTools.constructFrameWithUnchangingTransformToParent(getSensorName() + "_left", sensorFrame, leftSensorTransform);
+
+      if (rightSensorFrame != null)
+         rightSensorFrame.remove();
+      RigidBodyTransform rightSensorTransform = new RigidBodyTransform(new Quaternion(), new Vector3D(0.0, -sensorCenterToCameraDistanceY, 0.0));
+      rightSensorFrame = ReferenceFrameTools.constructFrameWithUnchangingTransformToParent(getSensorName() + "_right", sensorFrame, rightSensorTransform);
+   }
+
+   @Override
+   protected void onSensorFrameChanged()
+   {
+      updateReferenceFrames();
    }
 
    @Override
@@ -135,12 +158,11 @@ public class ZEDImageSensor extends ImageSensor
          rightSensorIntrinsics.setFy(sensorIntrinsics.right_cam().fy());
          rightSensorIntrinsics.setCx(sensorIntrinsics.right_cam().cx());
          rightSensorIntrinsics.setCy(sensorIntrinsics.right_cam().cy());
+
+         sensorCenterToCameraDistanceY = -0.5f * sensorIntrinsics.translation().y();
          sensorIntrinsics.close();
 
-         // Get center to camera distance
-         SL_CameraInformation cameraInformation = sl_get_camera_information(cameraID, 0, 0);
-         sensorCenterToCameraDistanceY = 0.5f * cameraInformation.camera_configuration().calibration_parameters().translation().y();
-         cameraInformation.close();
+         updateReferenceFrames();
 
          // Create image retrieval pointers
          slMatPointers[LEFT_COLOR_IMAGE_KEY] = sl_mat_create_new(imageWidth, imageHeight, SL_MAT_TYPE_U8_C4, SL_MEM_GPU);
@@ -197,17 +219,6 @@ public class ZEDImageSensor extends ImageSensor
    @Override
    protected boolean grab()
    {
-      // Update the sensor pose
-      ReferenceFrame sensorFrame = sensorFrameSupplier.get();
-
-      leftSensorPose.setToZero(sensorFrame);
-      leftSensorPose.getPosition().subY(sensorCenterToCameraDistanceY);
-      leftSensorPose.changeFrame(ReferenceFrame.getWorldFrame());
-
-      rightSensorPose.setToZero(sensorFrame);
-      rightSensorPose.getPosition().addY(sensorCenterToCameraDistanceY);
-      rightSensorPose.changeFrame(ReferenceFrame.getWorldFrame());
-
       int returnCode;
       try
       {
@@ -264,6 +275,9 @@ public class ZEDImageSensor extends ImageSensor
          Pointer rightColorImagePointer = slMatPointers[RIGHT_COLOR_IMAGE_KEY];
          returnCode = sl_retrieve_image(cameraID, rightColorImagePointer, SL_VIEW_RIGHT, SL_MEM_GPU, imageWidth, imageHeight);
          throwOnError(returnCode);
+
+         FramePose3D leftSensorPose = new FramePose3D(leftSensorFrame);
+         FramePose3D rightSensorPose = new FramePose3D(rightSensorFrame);
 
          synchronized (grabbedImages)
          {  // Create RawImages from the grabbed retrieved slMats

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDSVOPlaybackSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDSVOPlaybackSensor.java
@@ -57,7 +57,7 @@ public class ZEDSVOPlaybackSensor extends ZEDImageSensor
    {
       enablePositionalTracking(useTrackedPose);
       if (useTrackedPose)
-         setSensorFrameSupplier(this::getTrackedSensorFrame);
+         setSensorFrame(getTrackedSensorFrame());
    }
 
    @Override

--- a/ihmc-perception/src/test/java/us/ihmc/perception/RawImageTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/RawImageTest.java
@@ -8,11 +8,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import us.ihmc.commons.thread.ThreadTools;
-import us.ihmc.euclid.geometry.Pose3D;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
-import us.ihmc.euclid.referenceFrame.interfaces.FixedFramePose3DBasics;
 import us.ihmc.euclid.tools.EuclidCoreTestTools;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.yawPitchRoll.YawPitchRoll;
 import us.ihmc.perception.camera.CameraIntrinsics;
 import us.ihmc.perception.imageMessage.PixelFormat;
 
@@ -163,11 +163,10 @@ public class RawImageTest
       CameraIntrinsics cameraIntrinsics = new CameraIntrinsics(mat8UC1.rows(), mat8UC1.cols(), 10.0f, 10.0f, mat8UC1.cols() / 2.0f, mat8UC1.rows() / 2.0f);
       CameraIntrinsics cameraIntrinsicsOriginal = new CameraIntrinsics(cameraIntrinsics);
 
-      Pose3D pose = new Pose3D(0.1, 0.2, 0.3, 0.4, 0.5, 0.6);
-      FramePose3D sensorPose = new FramePose3D(ReferenceFrame.getWorldFrame(), pose);
-      FixedFramePose3DBasics sensorPoseOriginal = new FramePose3D(sensorPose);
+      RigidBodyTransform sensorTransform = new RigidBodyTransform(new YawPitchRoll(0.1, 0.2, 0.3), new Vector3D(0.4, 0.5, 0.6));
+      RigidBodyTransform sensorTransformOriginal = new RigidBodyTransform(sensorTransform);
 
-      RawImage image = new RawImage(mat8UC1, null, GRAY8, cameraIntrinsics, CameraModel.PINHOLE, sensorPose, Instant.now(), 0L, 0.001f);
+      RawImage image = new RawImage(mat8UC1, null, GRAY8, cameraIntrinsics, CameraModel.PINHOLE, sensorTransform, Instant.now(), 0L, 0.001f);
 
       // Try modifying the passed in camera intrinsics object
       cameraIntrinsics.setWidth(0);
@@ -182,10 +181,10 @@ public class RawImageTest
       assertNotEquals(cameraIntrinsics.toString(), image.getIntrinsicsCopy().toString());
 
       // Try modifying the passed in pose
-      pose.appendTranslation(0.5, 0.5, 0.5);
-      sensorPose.appendYawRotation(0.3);
-      EuclidCoreTestTools.assertEquals(sensorPoseOriginal, image.getPose(), 1E-7);
-      assertFalse(sensorPose.geometricallyEquals(image.getPose(), 1E-7));
+      sensorTransform.getTranslation().add(0.5, 0.5, 0.5);
+      sensorTransform.getRotation().appendYawRotation(0.3);
+      EuclidCoreTestTools.assertGeometricallyEquals(sensorTransformOriginal, image.getTransformToWorld(), 1E-7);
+      assertFalse(sensorTransform.geometricallyEquals(image.getTransformToWorld(), 1E-7));
 
       image.release();
    }

--- a/ihmc-perception/src/test/java/us/ihmc/perception/RawImageTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/RawImageTest.java
@@ -8,7 +8,11 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import us.ihmc.commons.thread.ThreadTools;
+import us.ihmc.euclid.geometry.Pose3D;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.referenceFrame.interfaces.FixedFramePose3DBasics;
+import us.ihmc.euclid.tools.EuclidCoreTestTools;
 import us.ihmc.perception.camera.CameraIntrinsics;
 import us.ihmc.perception.imageMessage.PixelFormat;
 
@@ -128,7 +132,6 @@ public class RawImageTest
    @Test
    public void testReplaceImageDifferentType()
    {
-
       // CPU to CPU, different type
       assertDoesNotThrow(() ->
       {
@@ -152,6 +155,39 @@ public class RawImageTest
          originalImage.release();
          replacedImage.release();
       });
+   }
+
+   @Test
+   public void testImmutability()
+   {
+      CameraIntrinsics cameraIntrinsics = new CameraIntrinsics(mat8UC1.rows(), mat8UC1.cols(), 10.0f, 10.0f, mat8UC1.cols() / 2.0f, mat8UC1.rows() / 2.0f);
+      CameraIntrinsics cameraIntrinsicsOriginal = new CameraIntrinsics(cameraIntrinsics);
+
+      Pose3D pose = new Pose3D(0.1, 0.2, 0.3, 0.4, 0.5, 0.6);
+      FramePose3D sensorPose = new FramePose3D(ReferenceFrame.getWorldFrame(), pose);
+      FixedFramePose3DBasics sensorPoseOriginal = new FramePose3D(sensorPose);
+
+      RawImage image = new RawImage(mat8UC1, null, GRAY8, cameraIntrinsics, CameraModel.PINHOLE, sensorPose, Instant.now(), 0L, 0.001f);
+
+      // Try modifying the passed in camera intrinsics object
+      cameraIntrinsics.setWidth(0);
+      cameraIntrinsics.setHeight(999);
+      assertEquals(cameraIntrinsicsOriginal.toString(), image.getIntrinsicsCopy().toString()); // comparing toString since we get two separate objects
+      assertNotEquals(cameraIntrinsics.toString(), image.getIntrinsicsCopy().toString());
+
+      // Try modifying the camera intrinsics received from the RawImage
+      image.getIntrinsicsCopy().setWidth(999);
+      image.getIntrinsicsCopy().setHeight(0);
+      assertEquals(cameraIntrinsicsOriginal.toString(), image.getIntrinsicsCopy().toString()); // comparing toString since we get two separate objects
+      assertNotEquals(cameraIntrinsics.toString(), image.getIntrinsicsCopy().toString());
+
+      // Try modifying the passed in pose
+      pose.appendTranslation(0.5, 0.5, 0.5);
+      sensorPose.appendYawRotation(0.3);
+      EuclidCoreTestTools.assertEquals(sensorPoseOriginal, image.getPose(), 1E-7);
+      assertFalse(sensorPose.geometricallyEquals(image.getPose(), 1E-7));
+
+      image.release();
    }
 
    private boolean dataEquals(BytePointer dataA, BytePointer dataB)

--- a/ihmc-perception/src/test/java/us/ihmc/perception/streaming/SRTStreamerSubscriberTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/streaming/SRTStreamerSubscriberTest.java
@@ -12,10 +12,10 @@ import us.ihmc.commons.thread.ThreadTools;
 import us.ihmc.commons.thread.Throttler;
 import us.ihmc.communication.PerceptionAPI;
 import us.ihmc.communication.ros2.ROS2Helper;
-import us.ihmc.euclid.geometry.Pose3D;
-import us.ihmc.euclid.referenceFrame.FramePose3D;
-import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tools.EuclidCoreTestTools;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.yawPitchRoll.YawPitchRoll;
 import us.ihmc.perception.RawImage;
 import us.ihmc.perception.RawImageTest;
 import us.ihmc.perception.camera.CameraIntrinsics;
@@ -277,10 +277,10 @@ public class SRTStreamerSubscriberTest
                                                                400.0,
                                                                sampleImage.cols() / 2.0,
                                                                sampleImage.rows() / 2.0);
-      FramePose3D testPose = new FramePose3D(ReferenceFrame.getWorldFrame(), new Pose3D(0.3, 0.4, 0.5, 0.5, 0.4, 0.3));
+      RigidBodyTransform testTransform = new RigidBodyTransform(new YawPitchRoll(0.3, 0.4, 0.5), new Vector3D(0.5, 0.4, 0.3));
 
       // Create an example raw image
-      RawImage rawImage = RawImage.createWithBGRImage(sampleImage, cameraIntrinsics, testPose, Instant.now(), 0L);
+      RawImage rawImage = RawImage.createWithBGRImage(sampleImage, cameraIntrinsics, testTransform, Instant.now(), 0L);
 
       // Create and initialize the streamer
       ROS2SRTVideoStreamer streamer = new ROS2SRTVideoStreamer(ROS2_NODE, requestTopic, localAddress);
@@ -304,7 +304,7 @@ public class SRTStreamerSubscriberTest
          assertEquals(cameraIntrinsics.getFy(), receivedImage.getFocalLengthY());
          assertEquals(cameraIntrinsics.getCx(), receivedImage.getPrincipalPointX());
          assertEquals(cameraIntrinsics.getCy(), receivedImage.getPrincipalPointY());
-         EuclidCoreTestTools.assertEquals(testPose, receivedImage.getPose(), 1E-5);
+         EuclidCoreTestTools.assertGeometricallyEquals(testTransform, receivedImage.getTransformToWorld(), 1E-5);
       });
 
       // No communication at this time


### PR DESCRIPTION
ImageSensors have been using FramePose3Ds for keeping the sensor pose. This PR changes it to ReferenceFrames. This will be handy for the ROS 2 tf stuff. 

Additionally, RawImages now store a RigidBodyTransform (sensor's transform to world) instead of the FixedFramePose3DBasics (sensor's pose in world frame). Plus, the immutability of the RawImage was improved. 