### PR TITLE
[Feature] tf2 Compatibility

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/ROS2HumanoidFrames.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/ROS2HumanoidFrames.java
@@ -111,19 +111,19 @@ public class ROS2HumanoidFrames
        */
       if (frameToCopy.equals(fullRobotModel.getRootJoint().getFrameAfterJoint()))
       {  // base link == frame before root joint
-         baseLinkFrame = new ROS2FollowingFrame(ros2Node, "base_link", odomFrame, frameToCopy);
+         baseLinkFrame = createFrameCopy(frameToCopy, "base_link", odomFrame);
          ros2FrameCopy = baseLinkFrame;
       }
       else if (frameToCopy.equals(humanoidFrames.getChestFrame()))
       {  // torso == chest
          ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), baseLinkFrame);
-         torsoFrame = new ROS2FollowingFrame(ros2Node, "torso", parentFrame, frameToCopy);
+         torsoFrame = createFrameCopy(frameToCopy, "torso", parentFrame);
          ros2FrameCopy = torsoFrame;
       }
       else if (frameToCopy.equals(humanoidFrames.getHeadFrame()))
       {  // gaze == head
          ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), torsoFrame);
-         gazeFrame = new ROS2FollowingFrame(ros2Node, "gaze", parentFrame, frameToCopy);
+         gazeFrame = createFrameCopy(frameToCopy, "gaze", parentFrame);
          ros2FrameCopy = gazeFrame;
       }
       else
@@ -138,28 +138,28 @@ public class ROS2HumanoidFrames
             if (frameToCopy.equals(fullRobotModel.getHand(side).getParentJoint().getFrameAfterJoint()))
             {  // wrist == parent joint frame of hand
                ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), torsoFrame);
-               ROS2Frame wristFrame = new ROS2FollowingFrame(ros2Node, sidePrefix + "wrist", parentFrame, frameToCopy);
+               ROS2Frame wristFrame = createFrameCopy(frameToCopy, sidePrefix + "wrist", parentFrame);
                wristFrames.put(side, wristFrame);
                ros2FrameCopy = wristFrame;
             }
             else if (frameToCopy.equals(fullRobotModel.getHandControlFrame(side)))
             {  // gripper == hand control frame
                ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), wristFrames.get(side));
-               ROS2Frame gripperFrame = new ROS2FollowingFrame(ros2Node, sidePrefix + "gripper", parentFrame, frameToCopy);
+               ROS2Frame gripperFrame = createFrameCopy(frameToCopy, sidePrefix + "gripper", parentFrame);
                gripperFrames.put(side, gripperFrame);
                ros2FrameCopy = gripperFrame;
             }
             else if (frameToCopy.equals(humanoidFrames.getFootFrame(side)))
             {  // ankle == foot frame
                ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), baseLinkFrame);
-               ROS2Frame ankleFrame = new ROS2FollowingFrame(ros2Node, sidePrefix + "ankle", parentFrame, frameToCopy);
+               ROS2Frame ankleFrame = createFrameCopy(frameToCopy, sidePrefix + "ankle", parentFrame);
                ankleFrames.put(side, ankleFrame);
                ros2FrameCopy = ankleFrame;
             }
             else if (frameToCopy.equals(humanoidFrames.getSoleFrame(side)))
             {  // sole == sole 👍
                ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), ankleFrames.get(side));
-               ROS2Frame soleFrame = new ROS2FollowingFrame(ros2Node, sidePrefix + "sole", parentFrame, frameToCopy);
+               ROS2Frame soleFrame = createFrameCopy(frameToCopy, sidePrefix + "sole", parentFrame);
                soleFrames.put(side, soleFrame);
                ros2FrameCopy = soleFrame;
             }
@@ -170,11 +170,19 @@ public class ROS2HumanoidFrames
       if (ros2FrameCopy == null)
       {
          ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), baseLinkFrame);
-         ros2FrameCopy = new ROS2FollowingFrame(ros2Node, "ros2_" + frameToCopy.getName(), parentFrame, frameToCopy);
+         ros2FrameCopy = createFrameCopy(frameToCopy, "ros2_" + frameToCopy.getName(), parentFrame);
       }
 
       ros2FrameCopyMap.put(frameToCopy, ros2FrameCopy);
       allROS2Frames.add(ros2FrameCopy);
+   }
+
+   private ROS2Frame createFrameCopy(ReferenceFrame frameToCopy, String id, ROS2Frame parentFrame)
+   {
+      if (frameToCopy.isFixedInParent() && parentFrame.equals(ros2FrameCopyMap.get(frameToCopy.getParent())))
+         return new ROS2StaticFrame(ros2Node, id, parentFrame, frameToCopy.getTransformToParent());
+      else
+         return new ROS2FollowingFrame(ros2Node, id, parentFrame, frameToCopy);
    }
 
    private RigidBodyTransform computeBaseFootprintToBaseLinkTransform(RigidBodyTransform transformToPack)

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/ROS2HumanoidFrames.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/ROS2HumanoidFrames.java
@@ -1,0 +1,286 @@
+package us.ihmc.avatar.drcRobot;
+
+import us.ihmc.communication.ros2.tf2.ROS2FollowingFrame;
+import us.ihmc.communication.ros2.tf2.ROS2Frame;
+import us.ihmc.communication.ros2.tf2.ROS2MutableFrame;
+import us.ihmc.communication.ros2.tf2.ROS2StaticFrame;
+import us.ihmc.euclid.orientation.interfaces.Orientation3DBasics;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.referenceFrame.tools.ReferenceFrameTools;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.humanoidRobotics.frames.HumanoidReferenceFrames;
+import us.ihmc.robotModels.FullHumanoidRobotModel;
+import us.ihmc.robotics.robotSide.RobotSide;
+import us.ihmc.robotics.robotSide.SideDependentList;
+import us.ihmc.ros2.ROS2Node;
+
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Stores {@link ROS2Frame} copies of all reference frames stemming from the robot's root frame.
+ * <p>
+ * The {@code ROS2Frame}s publish their respective {@link tf2_msgs.msg.dds.TFMessage}s,
+ * resulting in the robot's entire tf tree being published.
+ * <p>
+ * To read the ROS standards for reference frames, see:
+ * <ul>
+ *    <li><a href="https://ros.org/reps/rep-0120.html">Coordinate Frames for Humanoid Robots</a></li>
+ *    <li><a href="https://ros.org/reps/rep-0105.html">Coordinate Frames for Mobile Platforms</a></li>
+ * </ul>
+ */
+public class ROS2HumanoidFrames
+{
+   @SuppressWarnings("MismatchedQueryAndUpdateOfCollection")
+   private static final SideDependentList<String> SIDE_PREFIXES = new SideDependentList<>("l_", "r_");
+
+   private final ROS2Node ros2Node;
+
+   private final HumanoidReferenceFrames humanoidFrames;
+   private final FullHumanoidRobotModel fullRobotModel;
+
+   // Standard ROS 2 humanoid robot frames
+   private final ROS2Frame mapFrame;
+   private final ROS2Frame odomFrame;
+   private ROS2Frame baseLinkFrame; // Pelvis frame
+   private final ROS2MutableFrame baseFootprintFrame; // mid-foot-z-up frame, but z = min(leftFootZ, rightFootZ)
+   private ROS2Frame torsoFrame;
+   private ROS2Frame gazeFrame;
+   private final SideDependentList<ROS2Frame> wristFrames = new SideDependentList<>();
+   private final SideDependentList<ROS2Frame> gripperFrames = new SideDependentList<>();
+   private final SideDependentList<ROS2Frame> ankleFrames = new SideDependentList<>();
+   private final SideDependentList<ROS2Frame> soleFrames = new SideDependentList<>();
+   private final SideDependentList<ROS2Frame> toeFrames = new SideDependentList<>();
+
+   // Map of all reference frame for which ROS2Frame copies were made
+   private final Map<ReferenceFrame, ROS2Frame> ros2FrameCopyMap = new HashMap<>();
+
+   // Set of all ROS2Frames made in this class
+   private final Set<ROS2Frame> allROS2Frames = new LinkedHashSet<>();
+
+   public ROS2HumanoidFrames(ROS2Node ros2Node, ROS2SyncedRobotModel syncedRobotModel)
+   {
+      this.ros2Node = ros2Node;
+      humanoidFrames = syncedRobotModel.getReferenceFrames();
+      fullRobotModel = syncedRobotModel.getFullRobotModel();
+
+      // Map is the local base frame in which the robot should not drift, but the robot's pose need not be continuous
+      mapFrame = new ROS2StaticFrame(ros2Node, "map", ReferenceFrameTools.getWorldFrame(), new RigidBodyTransform(), true, true);
+      allROS2Frames.add(mapFrame);
+
+      // Odom is the local base frame in which the robot's pose is continuous, and may be subject to drift
+      odomFrame = new ROS2MutableFrame(ros2Node, "odom", mapFrame, new RigidBodyTransform(), true);
+      allROS2Frames.add(odomFrame);
+
+      // Fill reference frame tree with robot frames
+      fillTree(fullRobotModel.getRootJoint().getFrameAfterJoint());
+
+      // Add base_footprint frame
+      baseFootprintFrame = new ROS2MutableFrame(ros2Node, "base_footprint", baseLinkFrame, computeBaseFootprintToBaseLinkTransform(new RigidBodyTransform()));
+      allROS2Frames.add(baseFootprintFrame);
+
+      // Add toe frames
+      for (RobotSide side : RobotSide.values)
+      {
+         ROS2Frame toeFrame = new ROS2StaticFrame(ros2Node, SIDE_PREFIXES.get(side) + "toe", ankleFrames.get(side), new RigidBodyTransform());
+         toeFrames.put(side, toeFrame);
+         allROS2Frames.add(toeFrame);
+      }
+   }
+
+   private void fillTree(ReferenceFrame start)
+   {
+      // Create a ROS 2 frame copy of this frame
+      createFrameCopy(start);
+
+      // Repeat for all its child frames
+      int childrenCount = start.getNumberOfChildren();
+      for (int i = 0; i < childrenCount; ++i)
+         fillTree(start.getChild(i));
+   }
+
+   private void createFrameCopy(ReferenceFrame frameToCopy)
+   {
+      ROS2Frame ros2FrameCopy = null;
+
+      /*
+       * First, check whether the frame we're copying is specified by REP 120 (https://ros.org/reps/rep-0120.html)
+       * If it is, we create it with the name specified by REP 120 and give it a sensible parent frame
+       */
+      if (frameToCopy.equals(fullRobotModel.getRootJoint().getFrameAfterJoint()))
+      {  // base link == frame before root joint
+         baseLinkFrame = new ROS2FollowingFrame(ros2Node, "base_link", odomFrame, frameToCopy);
+         ros2FrameCopy = baseLinkFrame;
+      }
+      else if (frameToCopy.equals(humanoidFrames.getChestFrame()))
+      {  // torso == chest
+         ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), baseLinkFrame);
+         torsoFrame = new ROS2FollowingFrame(ros2Node, "torso", parentFrame, frameToCopy);
+         ros2FrameCopy = torsoFrame;
+      }
+      else if (frameToCopy.equals(humanoidFrames.getHeadFrame()))
+      {  // gaze == head
+         ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), torsoFrame);
+         gazeFrame = new ROS2FollowingFrame(ros2Node, "gaze", parentFrame, frameToCopy);
+         ros2FrameCopy = gazeFrame;
+      }
+      else
+      {
+         for (RobotSide side : RobotSide.values)
+         {
+            if (ros2FrameCopy != null)
+               break;
+
+            String sidePrefix = SIDE_PREFIXES.get(side);
+
+            if (frameToCopy.equals(fullRobotModel.getHand(side).getParentJoint().getFrameAfterJoint()))
+            {  // wrist == parent joint frame of hand
+               ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), torsoFrame);
+               ROS2Frame wristFrame = new ROS2FollowingFrame(ros2Node, sidePrefix + "wrist", parentFrame, frameToCopy);
+               wristFrames.put(side, wristFrame);
+               ros2FrameCopy = wristFrame;
+            }
+            else if (frameToCopy.equals(fullRobotModel.getHandControlFrame(side)))
+            {  // gripper == hand control frame
+               ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), wristFrames.get(side));
+               ROS2Frame gripperFrame = new ROS2FollowingFrame(ros2Node, sidePrefix + "gripper", parentFrame, frameToCopy);
+               gripperFrames.put(side, gripperFrame);
+               ros2FrameCopy = gripperFrame;
+            }
+            else if (frameToCopy.equals(humanoidFrames.getFootFrame(side)))
+            {  // ankle == foot frame
+               ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), baseLinkFrame);
+               ROS2Frame ankleFrame = new ROS2FollowingFrame(ros2Node, sidePrefix + "ankle", parentFrame, frameToCopy);
+               ankleFrames.put(side, ankleFrame);
+               ros2FrameCopy = ankleFrame;
+            }
+            else if (frameToCopy.equals(humanoidFrames.getSoleFrame(side)))
+            {  // sole == sole 👍
+               ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), ankleFrames.get(side));
+               ROS2Frame soleFrame = new ROS2FollowingFrame(ros2Node, sidePrefix + "sole", parentFrame, frameToCopy);
+               soleFrames.put(side, soleFrame);
+               ros2FrameCopy = soleFrame;
+            }
+         }
+      }
+
+      // No ROS 2 specific frame -- default to ros2_frameName
+      if (ros2FrameCopy == null)
+      {
+         ROS2Frame parentFrame = ros2FrameCopyMap.getOrDefault(frameToCopy.getParent(), baseLinkFrame);
+         ros2FrameCopy = new ROS2FollowingFrame(ros2Node, "ros2_" + frameToCopy.getName(), parentFrame, frameToCopy);
+      }
+
+      ros2FrameCopyMap.put(frameToCopy, ros2FrameCopy);
+      allROS2Frames.add(ros2FrameCopy);
+   }
+
+   private RigidBodyTransform computeBaseFootprintToBaseLinkTransform(RigidBodyTransform transformToPack)
+   {
+      humanoidFrames.getMidFootZUpGroundFrame().getTransformToDesiredFrame(transformToPack, baseLinkFrame);
+      Orientation3DBasics rotation = transformToPack.getRotation();
+      rotation.setYawPitchRoll(0.0, rotation.getPitch(), rotation.getRoll());
+      return transformToPack;
+   }
+
+   /**
+    * Update all {@code ROS2Frames}. The frames will publish the tf messages.
+    */
+   public void update()
+   {
+      baseFootprintFrame.setNewTransformToParent(this::computeBaseFootprintToBaseLinkTransform);
+      allROS2Frames.forEach(ReferenceFrame::update);
+   }
+
+   public ROS2Frame getMapFrame()
+   {
+      return mapFrame;
+   }
+
+   public ROS2Frame getOdomFrame()
+   {
+      return odomFrame;
+   }
+
+   public ROS2Frame getBaseLinkFrame()
+   {
+      return baseLinkFrame;
+   }
+
+   public ROS2Frame getBaseFootprintFrame()
+   {
+      return baseFootprintFrame;
+   }
+
+   public ROS2Frame getTorsoFrame()
+   {
+      return torsoFrame;
+   }
+
+   public ROS2Frame getGazeFrame()
+   {
+      return gazeFrame;
+   }
+
+   public ROS2Frame getWristFrame(RobotSide side)
+   {
+      return getWristFrames().get(side);
+   }
+
+   public SideDependentList<ROS2Frame> getWristFrames()
+   {
+      return wristFrames;
+   }
+
+   public ROS2Frame getGripperFrame(RobotSide side)
+   {
+      return getGripperFrames().get(side);
+   }
+
+   public SideDependentList<ROS2Frame> getGripperFrames()
+   {
+      return gripperFrames;
+   }
+
+   public ROS2Frame getAnkleFrame(RobotSide side)
+   {
+      return getAnkleFrames().get(side);
+   }
+
+   public SideDependentList<ROS2Frame> getAnkleFrames()
+   {
+      return ankleFrames;
+   }
+
+   public ROS2Frame getSoleFrame(RobotSide side)
+   {
+      return getSoleFrames().get(side);
+   }
+
+   public SideDependentList<ROS2Frame> getSoleFrames()
+   {
+      return soleFrames;
+   }
+
+   public ROS2Frame getToeFrame(RobotSide side)
+   {
+      return getToeFrames().get(side);
+   }
+
+   public SideDependentList<ROS2Frame> getToeFrames()
+   {
+      return toeFrames;
+   }
+
+   public ROS2Frame getROS2FrameCopy(ReferenceFrame referenceFrame)
+   {
+      return ros2FrameCopyMap.get(referenceFrame);
+   }
+
+   public void remove()
+   {
+      allROS2Frames.forEach(ReferenceFrame::remove);
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FollowingFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FollowingFrame.java
@@ -1,0 +1,34 @@
+package us.ihmc.communication.ros2.tf2;
+
+import geometry_msgs.msg.dds.TransformStamped;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.ros2.ROS2Node;
+
+/**
+ * ROS 2 frame that follows another reference frame in root.
+ */
+public class ROS2FollowingFrame extends ROS2Frame
+{
+   private final ReferenceFrame frameToFollow;
+
+   public ROS2FollowingFrame(ROS2Node ros2Node, String id, ReferenceFrame parentFrame, ReferenceFrame frameToFollow)
+   {
+      super(ros2Node, id, parentFrame, null, parentFrame.isAStationaryFrame() && frameToFollow.isAStationaryFrame(), frameToFollow.isZupFrame(), false);
+
+      this.frameToFollow = frameToFollow;
+   }
+
+   @Override
+   protected void onNewTransformReceived(TransformStamped newTransform)
+   {
+      // Do nothing
+   }
+
+   @Override
+   protected void updateTransformToParent(RigidBodyTransform transformToParent)
+   {
+      frameToFollow.getTransformToDesiredFrame(transformToParent, getParent());
+      publishTFMessages();
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
@@ -27,7 +27,7 @@ public abstract class ROS2Frame extends ReferenceFrame
    private int lastPublishTimestampSeconds;
    private int lastPublishTimestampNanos;
 
-   private int skipData = 0;
+   private volatile boolean readyToTakeData = false;
 
    protected ROS2Frame(ROS2Node ros2Node,
                        String id,
@@ -63,17 +63,16 @@ public abstract class ROS2Frame extends ReferenceFrame
       }
 
       publishTFMessages();
+
+      readyToTakeData = true;
    }
 
    private void receiveTFMessage(@SuppressWarnings("deprecation") Subscriber<TFMessage> subscriber)
    {
-      // Skip the first 50 messages to avoid a race condition that causes createSubscription to hang on KEEP_HISTORY QoS
+      // Don't take data while initializing to avoid a race condition that causes createSubscription to hang on KEEP_HISTORY QoS
       // TODO: Remove once race condition is fixed
-      if (skipData < 50)
-      {
-         ++skipData;
+      if (!readyToTakeData)
          return;
-      }
 
       // Read the new message
       subscriber.takeNextData(tfMessageToReceive, null);

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
@@ -59,6 +59,8 @@ public abstract class ROS2Frame extends ReferenceFrame
          tfSubscription = null;
          tfMessageToReceive = null;
       }
+
+      publishTFMessages();
    }
 
    private void receiveTFMessage(@SuppressWarnings("deprecation") Subscriber<TFMessage> subscriber)

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
@@ -3,62 +3,61 @@ package us.ihmc.communication.ros2.tf2;
 import geometry_msgs.msg.dds.TransformStamped;
 import tf2_msgs.msg.dds.TFMessage;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
-import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.pubsub.subscriber.Subscriber;
 import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Publisher;
 import us.ihmc.ros2.ROS2Subscription;
-import us.ihmc.ros2.ROS2Topic;
 
-import java.time.Instant;
 import java.util.List;
 
-import static us.ihmc.communication.ros2.tf2.ROS2FrameTools.TF_STATIC_TOPIC;
-import static us.ihmc.communication.ros2.tf2.ROS2FrameTools.TF_TOPIC;
+import static us.ihmc.communication.ros2.tf2.ROS2FrameTools.*;
 
 public abstract class ROS2Frame extends ReferenceFrame
 {
-   private final ROS2Publisher<TFMessage> transformPublisher;
-   private final ROS2Subscription<TFMessage> tfSubscription;
    private final TFMessage tfMessageToPublish;
-   private final TFMessage tfMessageToReceive;
+   private final ROS2Publisher<TFMessage> tfPublisher;
 
-   protected int lastUpdateTimestampSeconds;
-   protected int lastUpdateTimestampNanos;
+   private final TFMessage tfStaticMessageToPublish;
+   private final ROS2Publisher<TFMessage> tfStaticPublisher;
+
+   private final TFMessage tfMessageToReceive;
+   private final ROS2Subscription<TFMessage> tfSubscription;
+
+   private int lastPublishTimestampSeconds;
+   private int lastPublishTimestampNanos;
 
    protected ROS2Frame(ROS2Node ros2Node,
                        String id,
-                       ROS2Frame parentFrame,
+                       ReferenceFrame parentFrame,
                        RigidBodyTransformReadOnly transformToParent,
-                       int transformTimestampSeconds,
-                       int transformTimestampNanos,
                        boolean isAStationaryFrame,
                        boolean isZUpFrame,
                        boolean isStatic)
    {
       super(id, parentFrame, transformToParent, isAStationaryFrame, isZUpFrame, isStatic);
 
-      lastUpdateTimestampSeconds = transformTimestampSeconds;
-      lastUpdateTimestampNanos = transformTimestampNanos;
-
       if (ros2Node != null)
       {
-         ROS2Topic<TFMessage> tfTopic = isStatic ? TF_STATIC_TOPIC : TF_TOPIC;
-
          tfMessageToPublish = new TFMessage();
-         transformPublisher = ros2Node.createPublisher(tfTopic);
+         tfPublisher = ros2Node.createPublisher(TF_TOPIC);
+
+         tfStaticMessageToPublish = new TFMessage();
+         tfStaticPublisher = ros2Node.createPublisher(TF_STATIC_TOPIC);
 
          tfMessageToReceive = new TFMessage();
-         tfSubscription = ros2Node.createSubscription(tfTopic, this::receiveTFMessage);
+         tfSubscription = ros2Node.createSubscription(isStatic ? TF_STATIC_TOPIC : TF_TOPIC, this::receiveTFMessage);
       }
       else
       {
+         tfPublisher = null;
          tfMessageToPublish = null;
-         transformPublisher = null;
 
-         tfMessageToReceive = null;
+         tfStaticPublisher = null;
+         tfStaticMessageToPublish = null;
+
          tfSubscription = null;
+         tfMessageToReceive = null;
       }
    }
 
@@ -92,14 +91,31 @@ public abstract class ROS2Frame extends ReferenceFrame
       // Check whether the matching transform is newer than our transform. If it is, trigger onNewTransformReceived method.
       int matchingTimestampSeconds = matchingTransform.getHeader().getStamp().getSec();
       int matchingTimestampNanos = (int) matchingTransform.getHeader().getStamp().getNanosec();
-      if (matchingTimestampSeconds > lastUpdateTimestampSeconds || (matchingTimestampSeconds == lastUpdateTimestampSeconds
-                                                                    && matchingTimestampNanos > lastUpdateTimestampNanos))
+      if (matchingTimestampSeconds > lastPublishTimestampSeconds || (matchingTimestampSeconds == lastPublishTimestampSeconds
+                                                                     && matchingTimestampNanos > lastPublishTimestampNanos))
       {
          onNewTransformReceived(matchingTransform);
       }
    }
 
    protected abstract void onNewTransformReceived(TransformStamped newTransform);
+
+   protected void publishTFMessages()
+   {
+      long currentTimeMillis = System.currentTimeMillis();
+      lastPublishTimestampSeconds = (int) (currentTimeMillis / 1000);
+      lastPublishTimestampNanos = (int) (currentTimeMillis % 1000) * 1000000;
+
+      tfMessageToPublish.getTransforms().clear();
+      tfStaticMessageToPublish.getTransforms().clear();
+
+      packTFMessages(this, lastPublishTimestampSeconds, lastPublishTimestampNanos, tfMessageToPublish, tfStaticMessageToPublish);
+
+      if (!tfMessageToPublish.getTransforms().isEmpty())
+         tfPublisher.publish(tfMessageToPublish);
+      if (!tfStaticMessageToPublish.getTransforms().isEmpty())
+         tfStaticPublisher.publish(tfStaticMessageToPublish);
+   }
 
    /**
     * Get this frame's id string.
@@ -113,64 +129,14 @@ public abstract class ROS2Frame extends ReferenceFrame
       return getName();
    }
 
-   public Instant getLastUpdateTimestamp()
-   {
-      return Instant.ofEpochSecond(lastUpdateTimestampSeconds, lastUpdateTimestampNanos);
-   }
-
-   public int getLastUpdateTimestampSeconds()
-   {
-      return lastUpdateTimestampSeconds;
-   }
-
-   public int getLastUpdateTimestampNanos()
-   {
-      return lastUpdateTimestampNanos;
-   }
-
-   public void publish()
-   {
-      if (transformPublisher == null || getParent() == null)
-         return;
-
-      tfMessageToPublish.getTransforms().clear();
-      TransformStamped transformMessage = tfMessageToPublish.getTransforms().add();
-
-      transformMessage.getHeader().getStamp().setSec(lastUpdateTimestampSeconds);
-      transformMessage.getHeader().getStamp().setNanosec(lastUpdateTimestampNanos);
-      transformMessage.getHeader().setFrameId(getParent().getFrameId());
-      transformMessage.getTransform().set(getTransformToParent());
-      transformMessage.setChildFrameId(getFrameId());
-
-      transformPublisher.publish(tfMessageToPublish);
-   }
-
-   @Override
-   public boolean isWorldFrame()
-   {
-      return this == ROS2FrameTools.getWorldFrame();
-   }
-
-   @Override
-   public ROS2Frame getParent()
-   {
-      return (ROS2Frame) super.getParent();
-   }
-
-   @Override
-   public RigidBodyTransform getTransformToWorldFrame()
-   {
-      RigidBodyTransform ret = new RigidBodyTransform();
-      getTransformToDesiredFrame(ret, ROS2FrameTools.getWorldFrame());
-      return ret;
-   }
-
    @Override
    public void remove()
    {
       super.remove();
-      if (transformPublisher != null)
-         transformPublisher.remove();
+      if (tfPublisher != null)
+         tfPublisher.remove();
+      if (tfStaticPublisher != null)
+         tfStaticPublisher.remove();
       if (tfSubscription != null)
          tfSubscription.remove();
    }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
@@ -27,6 +27,8 @@ public abstract class ROS2Frame extends ReferenceFrame
    private int lastPublishTimestampSeconds;
    private int lastPublishTimestampNanos;
 
+   private int skipData = 0;
+
    protected ROS2Frame(ROS2Node ros2Node,
                        String id,
                        ReferenceFrame parentFrame,
@@ -65,6 +67,14 @@ public abstract class ROS2Frame extends ReferenceFrame
 
    private void receiveTFMessage(@SuppressWarnings("deprecation") Subscriber<TFMessage> subscriber)
    {
+      // Skip the first 50 messages to avoid a race condition that causes createSubscription to hang on KEEP_HISTORY QoS
+      // TODO: Remove once race condition is fixed
+      if (skipData < 50)
+      {
+         ++skipData;
+         return;
+      }
+
       // Read the new message
       subscriber.takeNextData(tfMessageToReceive, null);
 

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
@@ -1,0 +1,121 @@
+package us.ihmc.communication.ros2.tf2;
+
+import geometry_msgs.msg.dds.TransformStamped;
+import tf2_msgs.msg.dds.TFMessage;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2Publisher;
+
+import java.time.Instant;
+
+import static us.ihmc.communication.ros2.tf2.ROS2FrameTools.TF_STATIC_TOPIC;
+import static us.ihmc.communication.ros2.tf2.ROS2FrameTools.TF_TOPIC;
+
+public abstract class ROS2Frame extends ReferenceFrame
+{
+   private final ROS2Publisher<TFMessage> transformPublisher;
+   private final TFMessage tfMessage;
+
+   protected int lastUpdateTimestampSeconds;
+   protected int lastUpdateTimestampNanos;
+
+   protected ROS2Frame(ROS2Node ros2Node,
+                       String id,
+                       ROS2Frame parentFrame,
+                       RigidBodyTransformReadOnly transformToParent,
+                       int transformTimestampSeconds,
+                       int transformTimestampNanos,
+                       boolean isAStationaryFrame,
+                       boolean isZUpFrame,
+                       boolean isStatic)
+   {
+      super(id, parentFrame, transformToParent, isAStationaryFrame, isZUpFrame, isStatic);
+
+      lastUpdateTimestampSeconds = transformTimestampSeconds;
+      lastUpdateTimestampNanos = transformTimestampNanos;
+
+      if (ros2Node != null)
+      {
+         transformPublisher = ros2Node.createPublisher(isStatic ? TF_STATIC_TOPIC : TF_TOPIC);
+         tfMessage = new TFMessage();
+      }
+      else
+      {
+         transformPublisher = null;
+         tfMessage = null;
+      }
+   }
+
+   /**
+    * Get this frame's id string.
+    * <p>
+    * Same as {@link #getName()}.
+    *
+    * @return This frame's id string.
+    */
+   public String getFrameId()
+   {
+      return getName();
+   }
+
+   public Instant getLastUpdateTimestamp()
+   {
+      return Instant.ofEpochSecond(lastUpdateTimestampSeconds, lastUpdateTimestampNanos);
+   }
+
+   public int getLastUpdateTimestampSeconds()
+   {
+      return lastUpdateTimestampSeconds;
+   }
+
+   public int getLastUpdateTimestampNanos()
+   {
+      return lastUpdateTimestampNanos;
+   }
+
+   public void publish()
+   {
+      if (transformPublisher == null)
+         return;
+
+      tfMessage.getTransforms().clear();
+      TransformStamped transformMessage = tfMessage.getTransforms().add();
+
+      transformMessage.getHeader().getStamp().setSec(lastUpdateTimestampSeconds);
+      transformMessage.getHeader().getStamp().setNanosec(lastUpdateTimestampNanos);
+      transformMessage.getHeader().setFrameId(getFrameId());
+      transformMessage.getTransform().set(getTransformToParent());
+
+      transformPublisher.publish(tfMessage);
+   }
+
+   @Override
+   public boolean isWorldFrame()
+   {
+      return this == ROS2FrameTools.getWorldFrame();
+   }
+
+   @Override
+   public ROS2Frame getParent()
+   {
+      return (ROS2Frame) super.getParent();
+   }
+
+   @Override
+   public RigidBodyTransform getTransformToWorldFrame()
+   {
+      RigidBodyTransform ret = new RigidBodyTransform();
+      getTransformToDesiredFrame(ret, ROS2FrameTools.getWorldFrame());
+      return ret;
+   }
+
+   @Override
+   public void remove()
+   {
+      super.remove();
+      if (transformPublisher != null)
+         transformPublisher.remove();
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
@@ -5,10 +5,14 @@ import tf2_msgs.msg.dds.TFMessage;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.pubsub.subscriber.Subscriber;
 import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Publisher;
+import us.ihmc.ros2.ROS2Subscription;
+import us.ihmc.ros2.ROS2Topic;
 
 import java.time.Instant;
+import java.util.List;
 
 import static us.ihmc.communication.ros2.tf2.ROS2FrameTools.TF_STATIC_TOPIC;
 import static us.ihmc.communication.ros2.tf2.ROS2FrameTools.TF_TOPIC;
@@ -16,7 +20,9 @@ import static us.ihmc.communication.ros2.tf2.ROS2FrameTools.TF_TOPIC;
 public abstract class ROS2Frame extends ReferenceFrame
 {
    private final ROS2Publisher<TFMessage> transformPublisher;
-   private final TFMessage tfMessage;
+   private final ROS2Subscription<TFMessage> tfSubscription;
+   private final TFMessage tfMessageToPublish;
+   private final TFMessage tfMessageToReceive;
 
    protected int lastUpdateTimestampSeconds;
    protected int lastUpdateTimestampNanos;
@@ -38,15 +44,62 @@ public abstract class ROS2Frame extends ReferenceFrame
 
       if (ros2Node != null)
       {
-         transformPublisher = ros2Node.createPublisher(isStatic ? TF_STATIC_TOPIC : TF_TOPIC);
-         tfMessage = new TFMessage();
+         ROS2Topic<TFMessage> tfTopic = isStatic ? TF_STATIC_TOPIC : TF_TOPIC;
+
+         tfMessageToPublish = new TFMessage();
+         transformPublisher = ros2Node.createPublisher(tfTopic);
+
+         tfMessageToReceive = new TFMessage();
+         tfSubscription = ros2Node.createSubscription(tfTopic, this::receiveTFMessage);
       }
       else
       {
+         tfMessageToPublish = null;
          transformPublisher = null;
-         tfMessage = null;
+
+         tfMessageToReceive = null;
+         tfSubscription = null;
       }
    }
+
+   private void receiveTFMessage(@SuppressWarnings("deprecation") Subscriber<TFMessage> subscriber)
+   {
+      // Read the new message
+      subscriber.takeNextData(tfMessageToReceive, null);
+
+      // Ignore null or empty messages
+      if (tfMessageToReceive == null || tfMessageToReceive.getTransforms().isEmpty())
+         return;
+
+      // Find the matching transform (if it exists)
+      List<TransformStamped> transforms = tfMessageToReceive.getTransforms();
+      TransformStamped matchingTransform = null;
+      //noinspection ForLoopReplaceableByForEach
+      for (int i = 0; i < transforms.size(); ++i)
+      {
+         TransformStamped transform = transforms.get(i);
+         if (transform.getChildFrameIdAsString().equals(getFrameId()))
+         {
+            matchingTransform = transform;
+            break;
+         }
+      }
+
+      // Do nothing if the message doesn't contain a matching transform
+      if (matchingTransform == null)
+         return;
+
+      // Check whether the matching transform is newer than our transform. If it is, trigger onNewTransformReceived method.
+      int matchingTimestampSeconds = matchingTransform.getHeader().getStamp().getSec();
+      int matchingTimestampNanos = (int) matchingTransform.getHeader().getStamp().getNanosec();
+      if (matchingTimestampSeconds > lastUpdateTimestampSeconds || (matchingTimestampSeconds == lastUpdateTimestampSeconds
+                                                                    && matchingTimestampNanos > lastUpdateTimestampNanos))
+      {
+         onNewTransformReceived(matchingTransform);
+      }
+   }
+
+   protected abstract void onNewTransformReceived(TransformStamped newTransform);
 
    /**
     * Get this frame's id string.
@@ -77,18 +130,19 @@ public abstract class ROS2Frame extends ReferenceFrame
 
    public void publish()
    {
-      if (transformPublisher == null)
+      if (transformPublisher == null || getParent() == null)
          return;
 
-      tfMessage.getTransforms().clear();
-      TransformStamped transformMessage = tfMessage.getTransforms().add();
+      tfMessageToPublish.getTransforms().clear();
+      TransformStamped transformMessage = tfMessageToPublish.getTransforms().add();
 
       transformMessage.getHeader().getStamp().setSec(lastUpdateTimestampSeconds);
       transformMessage.getHeader().getStamp().setNanosec(lastUpdateTimestampNanos);
-      transformMessage.getHeader().setFrameId(getFrameId());
+      transformMessage.getHeader().setFrameId(getParent().getFrameId());
       transformMessage.getTransform().set(getTransformToParent());
+      transformMessage.setChildFrameId(getFrameId());
 
-      transformPublisher.publish(tfMessage);
+      transformPublisher.publish(tfMessageToPublish);
    }
 
    @Override
@@ -117,5 +171,7 @@ public abstract class ROS2Frame extends ReferenceFrame
       super.remove();
       if (transformPublisher != null)
          transformPublisher.remove();
+      if (tfSubscription != null)
+         tfSubscription.remove();
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FrameTools.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FrameTools.java
@@ -12,12 +12,12 @@ public class ROS2FrameTools
 {
    public static final ROS2Topic<TFMessage> TF_TOPIC = new ROS2Topic<>().withModule("tf").withQoS(ROS2QosProfile.RELIABLE()).withType(TFMessage.class);
    public static final ROS2Topic<TFMessage> TF_STATIC_TOPIC = new ROS2Topic<>().withModule("tf_static")
-                                                                               .withQoS(ROS2QosProfile.KEEP_HISTORY(5))
+                                                                               .withQoS(ROS2QosProfile.KEEP_HISTORY(1))
                                                                                .withType(TFMessage.class);
 
    public static void packTransformMessage(ReferenceFrame frame, int timestampSeconds, int timestampNanos, TransformStamped messageToPack)
    {
-      if (frame.getParent() == null)
+      if (frame.isRootFrame())
          throw new IllegalArgumentException("Cannot pack the transform message for a root frame");
 
       messageToPack.getHeader().getStamp().setSec(timestampSeconds);

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FrameTools.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FrameTools.java
@@ -1,19 +1,70 @@
 package us.ihmc.communication.ros2.tf2;
 
+import geometry_msgs.msg.dds.TransformStamped;
 import tf2_msgs.msg.dds.TFMessage;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2QosProfile;
 import us.ihmc.ros2.ROS2Topic;
 
 public class ROS2FrameTools
 {
-   public static final ROS2Topic<TFMessage> TF_TOPIC = new ROS2Topic<>().withModule("tf").withType(TFMessage.class);
-   public static final ROS2Topic<TFMessage> TF_STATIC_TOPIC = new ROS2Topic<>().withModule("tf_static").withType(TFMessage.class);
+   public static final ROS2Topic<TFMessage> TF_TOPIC = new ROS2Topic<>().withModule("tf").withQoS(ROS2QosProfile.RELIABLE()).withType(TFMessage.class);
+   public static final ROS2Topic<TFMessage> TF_STATIC_TOPIC = new ROS2Topic<>().withModule("tf_static")
+                                                                               .withQoS(ROS2QosProfile.KEEP_HISTORY(5))
+                                                                               .withType(TFMessage.class);
 
-   public static final String WORLD_FRAME_ID = "world";
-
-   private static final ROS2StaticFrame WORLD_FRAME = ROS2StaticFrame.constructARootFrame(WORLD_FRAME_ID);
-
-   public static synchronized ROS2StaticFrame getWorldFrame()
+   public static void packTransformMessage(ReferenceFrame frame, int timestampSeconds, int timestampNanos, TransformStamped messageToPack)
    {
-      return WORLD_FRAME;
+      if (frame.getParent() == null)
+         throw new IllegalArgumentException("Cannot pack the transform message for a root frame");
+
+      messageToPack.getHeader().getStamp().setSec(timestampSeconds);
+      messageToPack.getHeader().getStamp().setNanosec(timestampNanos);
+      messageToPack.getHeader().setFrameId(frame.getParent().getName());
+      messageToPack.getTransform().set(frame.getTransformToParent());
+      messageToPack.setChildFrameId(frame.getName());
+   }
+
+   public static void packTFMessages(ReferenceFrame frame, int timestampSeconds, int timestampNanos, TFMessage tfMessage, TFMessage tfStaticMessage)
+   {
+      // Once we have no parent (frame is root), we stop
+      if (frame.isRootFrame())
+         return;
+
+      // Get the message we want to pack into
+      TFMessage messageToPack = frame.isFixedInParent() ? tfStaticMessage : tfMessage;
+
+      // Add a transform message and pack it
+      ROS2FrameTools.packTransformMessage(frame, timestampSeconds, timestampNanos, messageToPack.getTransforms().add());
+
+      // If the parent isn't a ROS2Frame, pack the parent into the TFMessage to ensure full TF tree
+      if (!(frame.getParent() instanceof ROS2Frame))
+         packTFMessages(frame.getParent(), timestampSeconds, timestampNanos, tfMessage, tfStaticMessage);
+   }
+
+   public static ROS2Frame createFollowingFrame(ROS2Node ros2Node, String frameId, ReferenceFrame referenceFrameToFollow)
+   {
+      return new ROS2Frame(ros2Node,
+                           frameId,
+                           referenceFrameToFollow.getParent(),
+                           referenceFrameToFollow.getTransformToParent(),
+                           referenceFrameToFollow.isAStationaryFrame(),
+                           referenceFrameToFollow.isZupFrame(),
+                           referenceFrameToFollow.isFixedInParent())
+      {
+         @Override
+         protected void onNewTransformReceived(TransformStamped newTransform)
+         {
+            // Do nothing
+         }
+
+         @Override
+         protected void updateTransformToParent(RigidBodyTransform transformToParent)
+         {
+            transformToParent.set(referenceFrameToFollow.getTransformToParent());
+         }
+      };
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FrameTools.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FrameTools.java
@@ -3,8 +3,6 @@ package us.ihmc.communication.ros2.tf2;
 import geometry_msgs.msg.dds.TransformStamped;
 import tf2_msgs.msg.dds.TFMessage;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
-import us.ihmc.euclid.transform.RigidBodyTransform;
-import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2QosProfile;
 import us.ihmc.ros2.ROS2Topic;
 
@@ -42,29 +40,5 @@ public class ROS2FrameTools
       // If the parent isn't a ROS2Frame, pack the parent into the TFMessage to ensure full TF tree
       if (!(frame.getParent() instanceof ROS2Frame))
          packTFMessages(frame.getParent(), timestampSeconds, timestampNanos, tfMessage, tfStaticMessage);
-   }
-
-   public static ROS2Frame createFollowingFrame(ROS2Node ros2Node, String frameId, ReferenceFrame referenceFrameToFollow)
-   {
-      return new ROS2Frame(ros2Node,
-                           frameId,
-                           referenceFrameToFollow.getParent(),
-                           referenceFrameToFollow.getTransformToParent(),
-                           referenceFrameToFollow.isAStationaryFrame(),
-                           referenceFrameToFollow.isZupFrame(),
-                           referenceFrameToFollow.isFixedInParent())
-      {
-         @Override
-         protected void onNewTransformReceived(TransformStamped newTransform)
-         {
-            // Do nothing
-         }
-
-         @Override
-         protected void updateTransformToParent(RigidBodyTransform transformToParent)
-         {
-            transformToParent.set(referenceFrameToFollow.getTransformToParent());
-         }
-      };
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FrameTools.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2FrameTools.java
@@ -1,0 +1,19 @@
+package us.ihmc.communication.ros2.tf2;
+
+import tf2_msgs.msg.dds.TFMessage;
+import us.ihmc.ros2.ROS2Topic;
+
+public class ROS2FrameTools
+{
+   public static final ROS2Topic<TFMessage> TF_TOPIC = new ROS2Topic<>().withModule("tf").withType(TFMessage.class);
+   public static final ROS2Topic<TFMessage> TF_STATIC_TOPIC = new ROS2Topic<>().withModule("tf_static").withType(TFMessage.class);
+
+   public static final String WORLD_FRAME_ID = "world";
+
+   private static final ROS2StaticFrame WORLD_FRAME = ROS2StaticFrame.constructARootFrame(WORLD_FRAME_ID);
+
+   public static synchronized ROS2StaticFrame getWorldFrame()
+   {
+      return WORLD_FRAME;
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2MutableFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2MutableFrame.java
@@ -1,11 +1,12 @@
 package us.ihmc.communication.ros2.tf2;
 
 import geometry_msgs.msg.dds.TransformStamped;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.ros2.ROS2Node;
 
-import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * A ROS 2 frame with a changing transform to parent.
@@ -13,6 +14,7 @@ import java.time.Instant;
 public class ROS2MutableFrame extends ROS2Frame
 {
    private final RigidBodyTransform newestTransformToParent;
+   private final AtomicBoolean hasNewTransform = new AtomicBoolean(false);
 
    /**
     * Constructs a non-root frame.
@@ -21,7 +23,7 @@ public class ROS2MutableFrame extends ROS2Frame
     * @param id          The frame's id.
     * @param parentFrame The parent frame.
     */
-   public ROS2MutableFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame)
+   public ROS2MutableFrame(ROS2Node ros2Node, String id, ReferenceFrame parentFrame)
    {
       this(ros2Node, id, parentFrame, null);
    }
@@ -29,48 +31,17 @@ public class ROS2MutableFrame extends ROS2Frame
    /**
     * Constructs a non-root frame.
     *
-    * @param ros2Node          ROS 2 node to publish the TFMessage on.
-    * @param id                The frame's id.
-    * @param parentFrame       The parent frame.
-    * @param transformToParent Transform to the parent frame.
-    */
-   public ROS2MutableFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame, RigidBodyTransformReadOnly transformToParent)
-   {
-      this(ros2Node, id, parentFrame, transformToParent, Instant.now());
-   }
-
-   /**
-    * Constructs a non-root frame.
-    *
-    * @param ros2Node           ROS 2 node to publish the TFMessage on.
-    * @param id                 The frame's id.
-    * @param parentFrame        The parent frame.
-    * @param transformToParent  Transform to the parent frame.
-    * @param transformTimestamp Timestamp of the transform.
-    */
-   public ROS2MutableFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame, RigidBodyTransformReadOnly transformToParent, Instant transformTimestamp)
-   {
-      this(ros2Node, id, parentFrame, transformToParent, (int) transformTimestamp.getEpochSecond(), transformTimestamp.getNano());
-   }
-
-   /**
-    * Constructs a non-root frame.
-    *
     * @param ros2Node                  ROS 2 node to publish the TFMessage on.
     * @param id                        The frame's id.
     * @param parentFrame               The parent frame.
     * @param transformToParent         Transform to the parent frame.
-    * @param transformTimestampSeconds Timestamp of the transform, in seconds.
-    * @param transformTimestampNanos   Additional nanoseconds to the timestamp seconds.
     */
    public ROS2MutableFrame(ROS2Node ros2Node,
                            String id,
-                           ROS2Frame parentFrame,
-                           RigidBodyTransformReadOnly transformToParent,
-                           int transformTimestampSeconds,
-                           int transformTimestampNanos)
+                           ReferenceFrame parentFrame,
+                           RigidBodyTransformReadOnly transformToParent)
    {
-      this(ros2Node, id, parentFrame, transformToParent, transformTimestampSeconds, transformTimestampNanos, false);
+      this(ros2Node, id, parentFrame, transformToParent, false);
    }
 
    /**
@@ -80,69 +51,51 @@ public class ROS2MutableFrame extends ROS2Frame
     * @param id                        The frame's id.
     * @param parentFrame               The parent frame.
     * @param transformToParent         Transform to the parent frame.
-    * @param transformTimestampSeconds Timestamp of the transform, in seconds.
-    * @param transformTimestampNanos   Additional nanoseconds to the timestamp seconds.
     * @param isZUpFrame                Whether this frame has its Z-axis aligned with root frame at all times.
     */
    public ROS2MutableFrame(ROS2Node ros2Node,
                            String id,
-                           ROS2Frame parentFrame,
+                           ReferenceFrame parentFrame,
                            RigidBodyTransformReadOnly transformToParent,
-                           int transformTimestampSeconds,
-                           int transformTimestampNanos,
                            boolean isZUpFrame)
    {
-      super(ros2Node, id, parentFrame, transformToParent, transformTimestampSeconds, transformTimestampNanos, false, isZUpFrame, false);
+      super(ros2Node, id, parentFrame, transformToParent, false, isZUpFrame, false);
 
       newestTransformToParent = new RigidBodyTransform();
       getTransformToParent(newestTransformToParent);
+
+      publishTFMessages();
    }
 
    /**
-    * Update this frame's transform to parent with the transform timestamp set as now.
+    * Set this frame's transform to parent.
+    * Will be applied on the next call to {@link #update()}.
     *
     * @param newTransformToParent The new transform to parent for this frame.
     */
-   public void updateTransform(RigidBodyTransformReadOnly newTransformToParent)
-   {
-      updateTransform(newTransformToParent, Instant.now());
-   }
-
-   /**
-    * Update this frame's transform to parent.
-    *
-    * @param newTransformToParent The new transform to parent for this frame.
-    * @param timestamp            Timestamp of the new transform.
-    */
-   public void updateTransform(RigidBodyTransformReadOnly newTransformToParent, Instant timestamp)
-   {
-      updateTransform(newTransformToParent, (int) timestamp.getEpochSecond(), timestamp.getNano());
-   }
-
-   /**
-    * Update this frame's transform to parent.
-    *
-    * @param newTransformToParent The new transform to parent for this frame.
-    * @param timestampSeconds     Seconds of the timestamp of the new transform.
-    * @param timestampNanos       Nanoseconds of the timestamp of the new transform.
-    */
-   public void updateTransform(RigidBodyTransformReadOnly newTransformToParent, int timestampSeconds, int timestampNanos)
+   public void setNewTransformToParent(RigidBodyTransformReadOnly newTransformToParent)
    {
       newestTransformToParent.set(newTransformToParent);
-      lastUpdateTimestampSeconds = timestampSeconds;
-      lastUpdateTimestampNanos = timestampNanos;
-      update();
+      hasNewTransform.set(true);
    }
 
    @Override
    protected void updateTransformToParent(RigidBodyTransform transformToParent)
    {
-      transformToParent.set(newestTransformToParent);
+      if (hasNewTransform.getAndSet(false))
+         transformToParent.set(newestTransformToParent);
    }
 
    @Override
    protected void onNewTransformReceived(TransformStamped newTransform)
    {
-      updateTransform(newTransform.getTransform(), newTransform.getHeader().getStamp().getSec(), (int) newTransform.getHeader().getStamp().getNanosec());
+      setNewTransformToParent(newTransform.getTransform());
+   }
+
+   @Override
+   public void update()
+   {
+      super.update();
+      publishTFMessages();
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2MutableFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2MutableFrame.java
@@ -1,0 +1,141 @@
+package us.ihmc.communication.ros2.tf2;
+
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.ros2.ROS2Node;
+
+import java.time.Instant;
+
+/**
+ * A ROS 2 frame with a changing transform to parent.
+ */
+public class ROS2MutableFrame extends ROS2Frame
+{
+   private final RigidBodyTransform newestTransformToParent;
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node    ROS 2 node to publish the TFMessage on.
+    * @param id          The frame's id.
+    * @param parentFrame The parent frame.
+    */
+   public ROS2MutableFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame)
+   {
+      this(ros2Node, id, parentFrame, null);
+   }
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node          ROS 2 node to publish the TFMessage on.
+    * @param id                The frame's id.
+    * @param parentFrame       The parent frame.
+    * @param transformToParent Transform to the parent frame.
+    */
+   public ROS2MutableFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame, RigidBodyTransformReadOnly transformToParent)
+   {
+      this(ros2Node, id, parentFrame, transformToParent, Instant.now());
+   }
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node           ROS 2 node to publish the TFMessage on.
+    * @param id                 The frame's id.
+    * @param parentFrame        The parent frame.
+    * @param transformToParent  Transform to the parent frame.
+    * @param transformTimestamp Timestamp of the transform.
+    */
+   public ROS2MutableFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame, RigidBodyTransformReadOnly transformToParent, Instant transformTimestamp)
+   {
+      this(ros2Node, id, parentFrame, transformToParent, (int) transformTimestamp.getEpochSecond(), transformTimestamp.getNano());
+   }
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node                  ROS 2 node to publish the TFMessage on.
+    * @param id                        The frame's id.
+    * @param parentFrame               The parent frame.
+    * @param transformToParent         Transform to the parent frame.
+    * @param transformTimestampSeconds Timestamp of the transform, in seconds.
+    * @param transformTimestampNanos   Additional nanoseconds to the timestamp seconds.
+    */
+   public ROS2MutableFrame(ROS2Node ros2Node,
+                           String id,
+                           ROS2Frame parentFrame,
+                           RigidBodyTransformReadOnly transformToParent,
+                           int transformTimestampSeconds,
+                           int transformTimestampNanos)
+   {
+      this(ros2Node, id, parentFrame, transformToParent, transformTimestampSeconds, transformTimestampNanos, false);
+   }
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node                  ROS 2 node to publish the TFMessage on.
+    * @param id                        The frame's id.
+    * @param parentFrame               The parent frame.
+    * @param transformToParent         Transform to the parent frame.
+    * @param transformTimestampSeconds Timestamp of the transform, in seconds.
+    * @param transformTimestampNanos   Additional nanoseconds to the timestamp seconds.
+    * @param isZUpFrame                Whether this frame has its Z-axis aligned with root frame at all times.
+    */
+   public ROS2MutableFrame(ROS2Node ros2Node,
+                           String id,
+                           ROS2Frame parentFrame,
+                           RigidBodyTransformReadOnly transformToParent,
+                           int transformTimestampSeconds,
+                           int transformTimestampNanos,
+                           boolean isZUpFrame)
+   {
+      super(ros2Node, id, parentFrame, transformToParent, transformTimestampSeconds, transformTimestampNanos, false, isZUpFrame, false);
+
+      newestTransformToParent = new RigidBodyTransform();
+      getTransformToParent(newestTransformToParent);
+   }
+
+   /**
+    * Update this frame's transform to parent with the transform timestamp set as now.
+    *
+    * @param newTransformToParent The new transform to parent for this frame.
+    */
+   public void updateTransform(RigidBodyTransformReadOnly newTransformToParent)
+   {
+      updateTransform(newTransformToParent, Instant.now());
+   }
+
+   /**
+    * Update this frame's transform to parent.
+    *
+    * @param newTransformToParent The new transform to parent for this frame.
+    * @param timestamp            Timestamp of the new transform.
+    */
+   public void updateTransform(RigidBodyTransformReadOnly newTransformToParent, Instant timestamp)
+   {
+      updateTransform(newTransformToParent, (int) timestamp.getEpochSecond(), timestamp.getNano());
+   }
+
+   /**
+    * Update this frame's transform to parent.
+    *
+    * @param newTransformToParent The new transform to parent for this frame.
+    * @param timestampSeconds     Seconds of the timestamp of the new transform.
+    * @param timestampNanos       Nanoseconds of the timestamp of the new transform.
+    */
+   public void updateTransform(RigidBodyTransformReadOnly newTransformToParent, int timestampSeconds, int timestampNanos)
+   {
+      newestTransformToParent.set(newTransformToParent);
+      lastUpdateTimestampSeconds = timestampSeconds;
+      lastUpdateTimestampNanos = timestampNanos;
+      update();
+   }
+
+   @Override
+   protected void updateTransformToParent(RigidBodyTransform transformToParent)
+   {
+      transformToParent.set(newestTransformToParent);
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2MutableFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2MutableFrame.java
@@ -7,6 +7,7 @@ import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.ros2.ROS2Node;
 
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
 
 /**
  * A ROS 2 frame with a changing transform to parent.
@@ -63,8 +64,6 @@ public class ROS2MutableFrame extends ROS2Frame
 
       newestTransformToParent = new RigidBodyTransform();
       getTransformToParent(newestTransformToParent);
-
-      publishTFMessages();
    }
 
    /**
@@ -76,6 +75,18 @@ public class ROS2MutableFrame extends ROS2Frame
    public void setNewTransformToParent(RigidBodyTransformReadOnly newTransformToParent)
    {
       newestTransformToParent.set(newTransformToParent);
+      hasNewTransform.set(true);
+   }
+
+   /**
+    * Set this frame's transform to parent.
+    * Will be applied on the next call to {@link #update()}.
+    *
+    * @param transformUpdater Method applied to this frame's transform to parent.
+    */
+   public void setNewTransformToParent(Consumer<RigidBodyTransform> transformUpdater)
+   {
+      transformUpdater.accept(newestTransformToParent);
       hasNewTransform.set(true);
    }
 

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2MutableFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2MutableFrame.java
@@ -1,5 +1,6 @@
 package us.ihmc.communication.ros2.tf2;
 
+import geometry_msgs.msg.dds.TransformStamped;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.ros2.ROS2Node;
@@ -137,5 +138,11 @@ public class ROS2MutableFrame extends ROS2Frame
    protected void updateTransformToParent(RigidBodyTransform transformToParent)
    {
       transformToParent.set(newestTransformToParent);
+   }
+
+   @Override
+   protected void onNewTransformReceived(TransformStamped newTransform)
+   {
+      updateTransform(newTransform.getTransform(), newTransform.getHeader().getStamp().getSec(), (int) newTransform.getHeader().getStamp().getNanosec());
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2StaticFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2StaticFrame.java
@@ -1,0 +1,146 @@
+package us.ihmc.communication.ros2.tf2;
+
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.ros2.ROS2Node;
+
+import java.time.Instant;
+
+/**
+ * A ROS 2 frame with a static transform to parent.
+ */
+public class ROS2StaticFrame extends ROS2Frame
+{
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node          ROS 2 node to publish the TFMessage on.
+    * @param id                The frame's id.
+    * @param parentFrame       The parent frame.
+    * @param transformToParent Transform to the parent frame.
+    */
+   public ROS2StaticFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame, RigidBodyTransformReadOnly transformToParent)
+   {
+      this(ros2Node, id, parentFrame, transformToParent, Instant.now());
+   }
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node           ROS 2 node to publish the TFMessage on.
+    * @param id                 The frame's id.
+    * @param parentFrame        The parent frame.
+    * @param transformToParent  Transform to the parent frame.
+    * @param transformTimestamp Timestamp of the transform.
+    */
+   public ROS2StaticFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame, RigidBodyTransformReadOnly transformToParent, Instant transformTimestamp)
+   {
+      this(ros2Node, id, parentFrame, transformToParent, (int) transformTimestamp.getEpochSecond(), transformTimestamp.getNano());
+   }
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node                  ROS 2 node to publish the TFMessage on.
+    * @param id                        The frame's id.
+    * @param parentFrame               The parent frame.
+    * @param transformToParent         Transform to the parent frame.
+    * @param transformTimestampSeconds Timestamp of the transform, in seconds.
+    * @param transformTimestampNanos   Additional nanoseconds to the timestamp seconds.
+    */
+   public ROS2StaticFrame(ROS2Node ros2Node,
+                          String id,
+                          ROS2Frame parentFrame,
+                          RigidBodyTransformReadOnly transformToParent,
+                          int transformTimestampSeconds,
+                          int transformTimestampNanos)
+   {
+      this(ros2Node, id, parentFrame, transformToParent, transformTimestampSeconds, transformTimestampNanos, false, false);
+   }
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node           ROS 2 node to publish the TFMessage on.
+    * @param id                 The frame's id.
+    * @param parentFrame        The parent frame.
+    * @param transformToParent  Transform to the parent frame.
+    * @param transformTimestamp Timestamp of the transform.
+    * @param isAStationaryFrame Whether this frame is stationary with respect to root frame.
+    * @param isZUpFrame         Whether this frame has its Z-axis aligned with root frame at all times.
+    */
+   public ROS2StaticFrame(ROS2Node ros2Node,
+                          String id,
+                          ROS2Frame parentFrame,
+                          RigidBodyTransformReadOnly transformToParent,
+                          Instant transformTimestamp,
+                          boolean isAStationaryFrame,
+                          boolean isZUpFrame)
+   {
+      this(ros2Node,
+           id,
+           parentFrame,
+           transformToParent,
+           (int) transformTimestamp.getEpochSecond(),
+           transformTimestamp.getNano(),
+           isAStationaryFrame,
+           isZUpFrame);
+   }
+
+   /**
+    * Constructs a non-root frame.
+    *
+    * @param ros2Node                  ROS 2 node to publish the TFMessage on.
+    * @param id                        The frame's id.
+    * @param parentFrame               The parent frame.
+    * @param transformToParent         Transform to the parent frame.
+    * @param transformTimestampSeconds Timestamp of the transform, in seconds.
+    * @param transformTimestampNanos   Additional nanoseconds to the timestamp seconds.
+    * @param isAStationaryFrame        Whether this frame is stationary with respect to root frame.
+    * @param isZUpFrame                Whether this frame has its Z-axis aligned with root frame at all times.
+    */
+   public ROS2StaticFrame(ROS2Node ros2Node,
+                          String id,
+                          ROS2Frame parentFrame,
+                          RigidBodyTransformReadOnly transformToParent,
+                          int transformTimestampSeconds,
+                          int transformTimestampNanos,
+                          boolean isAStationaryFrame,
+                          boolean isZUpFrame)
+   {
+      super(ros2Node, id, parentFrame, transformToParent, transformTimestampSeconds, transformTimestampNanos, isAStationaryFrame, isZUpFrame, true);
+   }
+
+   private ROS2StaticFrame(String id, Instant now)
+   {
+      this(null, id, null, null, (int) now.getEpochSecond(), now.getNano(), true, true);
+   }
+
+   /**
+    * Constructs a root frame.
+    *
+    * @param id The frame's id.
+    * @return The root frame.
+    */
+   public static ROS2StaticFrame constructARootFrame(String id)
+   {
+      return constructARootFrame(id, Instant.now());
+   }
+
+   /**
+    * Constructs a root frame.
+    *
+    * @param id  The frame's id.
+    * @param now Current time.
+    * @return The root frame.
+    */
+   public static ROS2StaticFrame constructARootFrame(String id, Instant now)
+   {
+      return new ROS2StaticFrame(id, now);
+   }
+
+   @Override
+   protected void updateTransformToParent(RigidBodyTransform transformToParent)
+   {
+   }
+}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2StaticFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2StaticFrame.java
@@ -1,5 +1,6 @@
 package us.ihmc.communication.ros2.tf2;
 
+import geometry_msgs.msg.dds.TransformStamped;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.ros2.ROS2Node;
@@ -142,5 +143,18 @@ public class ROS2StaticFrame extends ROS2Frame
    @Override
    protected void updateTransformToParent(RigidBodyTransform transformToParent)
    {
+   }
+
+   @Override
+   protected void onNewTransformReceived(TransformStamped newTransform)
+   {
+      if (getParent() == null)
+         return;
+
+      if (!newTransform.getTransform().geometricallyEquals(getTransformToParent(), 1E-4))
+         throw new IllegalStateException("Transform of received message does not match static transform.");
+
+      lastUpdateTimestampSeconds = newTransform.getHeader().getStamp().getSec();
+      lastUpdateTimestampNanos = (int) newTransform.getHeader().getStamp().getNanosec();
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2StaticFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2StaticFrame.java
@@ -1,42 +1,32 @@
 package us.ihmc.communication.ros2.tf2;
 
 import geometry_msgs.msg.dds.TransformStamped;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.ros2.ROS2Node;
-
-import java.time.Instant;
 
 /**
  * A ROS 2 frame with a static transform to parent.
  */
 public class ROS2StaticFrame extends ROS2Frame
 {
-   /**
-    * Constructs a non-root frame.
-    *
-    * @param ros2Node          ROS 2 node to publish the TFMessage on.
-    * @param id                The frame's id.
-    * @param parentFrame       The parent frame.
-    * @param transformToParent Transform to the parent frame.
-    */
-   public ROS2StaticFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame, RigidBodyTransformReadOnly transformToParent)
-   {
-      this(ros2Node, id, parentFrame, transformToParent, Instant.now());
-   }
+   private final RigidBodyTransform previousTransformToRoot;
 
    /**
     * Constructs a non-root frame.
     *
-    * @param ros2Node           ROS 2 node to publish the TFMessage on.
-    * @param id                 The frame's id.
-    * @param parentFrame        The parent frame.
-    * @param transformToParent  Transform to the parent frame.
-    * @param transformTimestamp Timestamp of the transform.
+    * @param ros2Node                  ROS 2 node to publish the TFMessage on.
+    * @param id                        The frame's id.
+    * @param parentFrame               The parent frame.
+    * @param transformToParent         Transform to the parent frame.
     */
-   public ROS2StaticFrame(ROS2Node ros2Node, String id, ROS2Frame parentFrame, RigidBodyTransformReadOnly transformToParent, Instant transformTimestamp)
+   public ROS2StaticFrame(ROS2Node ros2Node,
+                          String id,
+                          ReferenceFrame parentFrame,
+                          RigidBodyTransformReadOnly transformToParent)
    {
-      this(ros2Node, id, parentFrame, transformToParent, (int) transformTimestamp.getEpochSecond(), transformTimestamp.getNano());
+      this(ros2Node, id, parentFrame, transformToParent, false, false);
    }
 
    /**
@@ -46,75 +36,26 @@ public class ROS2StaticFrame extends ROS2Frame
     * @param id                        The frame's id.
     * @param parentFrame               The parent frame.
     * @param transformToParent         Transform to the parent frame.
-    * @param transformTimestampSeconds Timestamp of the transform, in seconds.
-    * @param transformTimestampNanos   Additional nanoseconds to the timestamp seconds.
-    */
-   public ROS2StaticFrame(ROS2Node ros2Node,
-                          String id,
-                          ROS2Frame parentFrame,
-                          RigidBodyTransformReadOnly transformToParent,
-                          int transformTimestampSeconds,
-                          int transformTimestampNanos)
-   {
-      this(ros2Node, id, parentFrame, transformToParent, transformTimestampSeconds, transformTimestampNanos, false, false);
-   }
-
-   /**
-    * Constructs a non-root frame.
-    *
-    * @param ros2Node           ROS 2 node to publish the TFMessage on.
-    * @param id                 The frame's id.
-    * @param parentFrame        The parent frame.
-    * @param transformToParent  Transform to the parent frame.
-    * @param transformTimestamp Timestamp of the transform.
-    * @param isAStationaryFrame Whether this frame is stationary with respect to root frame.
-    * @param isZUpFrame         Whether this frame has its Z-axis aligned with root frame at all times.
-    */
-   public ROS2StaticFrame(ROS2Node ros2Node,
-                          String id,
-                          ROS2Frame parentFrame,
-                          RigidBodyTransformReadOnly transformToParent,
-                          Instant transformTimestamp,
-                          boolean isAStationaryFrame,
-                          boolean isZUpFrame)
-   {
-      this(ros2Node,
-           id,
-           parentFrame,
-           transformToParent,
-           (int) transformTimestamp.getEpochSecond(),
-           transformTimestamp.getNano(),
-           isAStationaryFrame,
-           isZUpFrame);
-   }
-
-   /**
-    * Constructs a non-root frame.
-    *
-    * @param ros2Node                  ROS 2 node to publish the TFMessage on.
-    * @param id                        The frame's id.
-    * @param parentFrame               The parent frame.
-    * @param transformToParent         Transform to the parent frame.
-    * @param transformTimestampSeconds Timestamp of the transform, in seconds.
-    * @param transformTimestampNanos   Additional nanoseconds to the timestamp seconds.
     * @param isAStationaryFrame        Whether this frame is stationary with respect to root frame.
     * @param isZUpFrame                Whether this frame has its Z-axis aligned with root frame at all times.
     */
    public ROS2StaticFrame(ROS2Node ros2Node,
                           String id,
-                          ROS2Frame parentFrame,
+                          ReferenceFrame parentFrame,
                           RigidBodyTransformReadOnly transformToParent,
-                          int transformTimestampSeconds,
-                          int transformTimestampNanos,
                           boolean isAStationaryFrame,
                           boolean isZUpFrame)
    {
-      super(ros2Node, id, parentFrame, transformToParent, transformTimestampSeconds, transformTimestampNanos, isAStationaryFrame, isZUpFrame, true);
+      super(ros2Node, id, parentFrame, transformToParent, isAStationaryFrame, isZUpFrame, true);
+
+      previousTransformToRoot = new RigidBodyTransform(getTransformToRoot());
+
+      publishTFMessages();
    }
 
-   private ROS2StaticFrame(String id, Instant now)
+   private ROS2StaticFrame(String id)
    {
-      this(null, id, null, null, (int) now.getEpochSecond(), now.getNano(), true, true);
+      this(null, id, null, null, true, true);
    }
 
    /**
@@ -125,36 +66,33 @@ public class ROS2StaticFrame extends ROS2Frame
     */
    public static ROS2StaticFrame constructARootFrame(String id)
    {
-      return constructARootFrame(id, Instant.now());
-   }
-
-   /**
-    * Constructs a root frame.
-    *
-    * @param id  The frame's id.
-    * @param now Current time.
-    * @return The root frame.
-    */
-   public static ROS2StaticFrame constructARootFrame(String id, Instant now)
-   {
-      return new ROS2StaticFrame(id, now);
+      return new ROS2StaticFrame(id);
    }
 
    @Override
    protected void updateTransformToParent(RigidBodyTransform transformToParent)
    {
+      // Transform to parent should not change in a static frame
    }
 
    @Override
    protected void onNewTransformReceived(TransformStamped newTransform)
    {
-      if (getParent() == null)
+      if (isRootFrame())
          return;
 
       if (!newTransform.getTransform().geometricallyEquals(getTransformToParent(), 1E-4))
          throw new IllegalStateException("Transform of received message does not match static transform.");
+   }
 
-      lastUpdateTimestampSeconds = newTransform.getHeader().getStamp().getSec();
-      lastUpdateTimestampNanos = (int) newTransform.getHeader().getStamp().getNanosec();
+   @Override
+   public void update()
+   {
+      super.update();
+
+      if (!previousTransformToRoot.geometricallyEquals(getTransformToRoot(), 1E-6))
+         publishTFMessages();
+
+      previousTransformToRoot.set(getTransformToRoot());
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2StaticFrame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2StaticFrame.java
@@ -11,7 +11,7 @@ import us.ihmc.ros2.ROS2Node;
  */
 public class ROS2StaticFrame extends ROS2Frame
 {
-   private final RigidBodyTransform previousTransformToRoot;
+   private final boolean publishMessage;
 
    /**
     * Constructs a non-root frame.
@@ -48,9 +48,7 @@ public class ROS2StaticFrame extends ROS2Frame
    {
       super(ros2Node, id, parentFrame, transformToParent, isAStationaryFrame, isZUpFrame, true);
 
-      previousTransformToRoot = new RigidBodyTransform(getTransformToRoot());
-
-      publishTFMessages();
+      publishMessage = shouldPublishMessage(parentFrame);
    }
 
    private ROS2StaticFrame(String id)
@@ -67,6 +65,17 @@ public class ROS2StaticFrame extends ROS2Frame
    public static ROS2StaticFrame constructARootFrame(String id)
    {
       return new ROS2StaticFrame(id);
+   }
+
+   private boolean shouldPublishMessage(ReferenceFrame parentFrame)
+   {
+      if (parentFrame instanceof ROS2Frame || parentFrame.isRootFrame())
+         return false;
+
+      if (!parentFrame.isFixedInParent())
+         return true;
+
+      return shouldPublishMessage(parentFrame.getParent());
    }
 
    @Override
@@ -90,9 +99,12 @@ public class ROS2StaticFrame extends ROS2Frame
    {
       super.update();
 
-      if (!previousTransformToRoot.geometricallyEquals(getTransformToRoot(), 1E-6))
+      if (publishMessage)
          publishTFMessages();
+   }
 
-      previousTransformToRoot.set(getTransformToRoot());
+   public boolean publishesMessageOnUpdate()
+   {
+      return publishMessage;
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Transform.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Transform.java
@@ -1,8 +1,0 @@
-package us.ihmc.communication.ros2.tf2;
-
-import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
-
-public interface ROS2Transform extends RigidBodyTransformReadOnly
-{
-
-}

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Transform.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Transform.java
@@ -1,0 +1,8 @@
+package us.ihmc.communication.ros2.tf2;
+
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+
+public interface ROS2Transform extends RigidBodyTransformReadOnly
+{
+
+}

--- a/ihmc-communication/src/test/java/us/ihmc/communication/ros2/tf2/ROS2FrameTest.java
+++ b/ihmc-communication/src/test/java/us/ihmc/communication/ros2/tf2/ROS2FrameTest.java
@@ -25,10 +25,11 @@ public class ROS2FrameTest
    {
       ROS2Node node = new ROS2NodeBuilder().build("test_node");
 
-      String id = "test_static_frame";
-      ReferenceFrame parentFrame = ReferenceFrameTools.getWorldFrame();
+      // Test basic static frame
+      String id = "test_static_frame_0";
+      ReferenceFrame worldFrame = ReferenceFrameTools.getWorldFrame();
       RigidBodyTransformReadOnly transformToParent = new RigidBodyTransform(new YawPitchRoll(0.1, 0.2, 0.3), new Vector3D(0.4, 0.5, 0.6));
-      ROS2Frame staticFrame = new ROS2StaticFrame(node, id, parentFrame, transformToParent);
+      ROS2StaticFrame staticFrame = new ROS2StaticFrame(node, id, worldFrame, transformToParent);
 
       assertFalse(staticFrame.isWorldFrame());
       assertFalse(staticFrame.isRootFrame());
@@ -38,10 +39,21 @@ public class ROS2FrameTest
 
       assertEquals(id, staticFrame.getFrameId());
       assertEquals(id, staticFrame.getName());
-      assertEquals(parentFrame, staticFrame.getParent());
+      assertEquals(worldFrame, staticFrame.getParent());
       EuclidCoreTestTools.assertEquals(transformToParent, staticFrame.getTransformToParent(), EPSILON);
 
+      assertFalse(staticFrame.publishesMessageOnUpdate());
+
+      // Test static frame that should publish its tf message every update
+      ReferenceFrame grandParentFrame = ReferenceFrameTools.constructFrameWithChangingTransformToParent("grandparent_frame", worldFrame, new RigidBodyTransform());
+      ReferenceFrame parentFrame = ReferenceFrameTools.constructFrameWithUnchangingTransformFromParent("parent_frame", grandParentFrame, new RigidBodyTransform());
+      String id2 = "test_static_frame_1";
+      ROS2StaticFrame staticFrame1 = new ROS2StaticFrame(node, id2, parentFrame, new RigidBodyTransform());
+
+      assertTrue(staticFrame1.publishesMessageOnUpdate());
+
       staticFrame.remove();
+      staticFrame1.remove();
       node.destroy();
    }
 

--- a/ihmc-communication/src/test/java/us/ihmc/communication/ros2/tf2/ROS2FrameTest.java
+++ b/ihmc-communication/src/test/java/us/ihmc/communication/ros2/tf2/ROS2FrameTest.java
@@ -129,7 +129,8 @@ public class ROS2FrameTest
                EuclidCoreTestTools.assertEquals(updatedTransformToParent, mutableFrame.getTransformToParent(), EPSILON);
 
                // Publish a message and wait for it to be received
-               correctMessagesReceived.wait(1000);
+               if (correctMessagesReceived.get() != i + 1)
+                  correctMessagesReceived.wait(1000);
 
                // Assert the message was correct
                assertEquals(i + 1, correctMessagesReceived.get());

--- a/ihmc-communication/src/test/java/us/ihmc/communication/ros2/tf2/ROS2FrameTest.java
+++ b/ihmc-communication/src/test/java/us/ihmc/communication/ros2/tf2/ROS2FrameTest.java
@@ -2,6 +2,7 @@ package us.ihmc.communication.ros2.tf2;
 
 import org.junit.jupiter.api.Test;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.referenceFrame.tools.ReferenceFrameTools;
 import us.ihmc.euclid.tools.EuclidCoreTestTools;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
@@ -10,7 +11,7 @@ import us.ihmc.euclid.yawPitchRoll.YawPitchRoll;
 import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2NodeBuilder;
 
-import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -20,35 +21,14 @@ public class ROS2FrameTest
    private static final double EPSILON = 1E-7;
 
    @Test
-   public void testWorldFrame()
-   {
-      ROS2StaticFrame worldFrame = ROS2FrameTools.getWorldFrame();
-
-      assertTrue(worldFrame.isWorldFrame());
-      assertTrue(worldFrame.isRootFrame());
-      assertTrue(worldFrame.isAStationaryFrame());
-      assertTrue(worldFrame.isZupFrame());
-      assertTrue(worldFrame.isFixedInParent());
-
-      assertDoesNotThrow(worldFrame::update);
-
-      assertNull(worldFrame.getParent());
-      assertEquals(worldFrame, worldFrame.getRootFrame());
-      assertEquals(ROS2FrameTools.WORLD_FRAME_ID, worldFrame.getFrameId());
-      EuclidCoreTestTools.assertEquals(ReferenceFrame.getWorldFrame().getTransformToWorldFrame(), worldFrame.getTransformToWorldFrame(), EPSILON);
-      EuclidCoreTestTools.assertEquals(ReferenceFrame.getWorldFrame().getTransformToRoot(), worldFrame.getTransformToRoot(), EPSILON);
-   }
-
-   @Test
    public void testConstructingStaticFrame()
    {
       ROS2Node node = new ROS2NodeBuilder().build("test_node");
 
       String id = "test_static_frame";
-      ROS2Frame parentFrame = ROS2FrameTools.getWorldFrame();
+      ReferenceFrame parentFrame = ReferenceFrameTools.getWorldFrame();
       RigidBodyTransformReadOnly transformToParent = new RigidBodyTransform(new YawPitchRoll(0.1, 0.2, 0.3), new Vector3D(0.4, 0.5, 0.6));
-      Instant timeAtConstruction = Instant.now();
-      ROS2Frame staticFrame = new ROS2StaticFrame(node, id, parentFrame, transformToParent, timeAtConstruction);
+      ROS2Frame staticFrame = new ROS2StaticFrame(node, id, parentFrame, transformToParent);
 
       assertFalse(staticFrame.isWorldFrame());
       assertFalse(staticFrame.isRootFrame());
@@ -58,7 +38,6 @@ public class ROS2FrameTest
 
       assertEquals(id, staticFrame.getFrameId());
       assertEquals(id, staticFrame.getName());
-      assertEquals(timeAtConstruction, staticFrame.getLastUpdateTimestamp());
       assertEquals(parentFrame, staticFrame.getParent());
       EuclidCoreTestTools.assertEquals(transformToParent, staticFrame.getTransformToParent(), EPSILON);
 
@@ -72,7 +51,7 @@ public class ROS2FrameTest
       ROS2Node node = new ROS2NodeBuilder().build("test_node");
 
       String id = "test_mutable_frame";
-      ROS2Frame parentFrame = ROS2FrameTools.getWorldFrame();
+      ReferenceFrame parentFrame = ReferenceFrameTools.getWorldFrame();
       ROS2MutableFrame mutableFrame = new ROS2MutableFrame(node, id, parentFrame);
 
       assertFalse(mutableFrame.isWorldFrame());
@@ -117,26 +96,27 @@ public class ROS2FrameTest
 
       // Construct a mutable frame
       String id = "test_mutable_frame";
-      ROS2Frame parentFrame = ROS2FrameTools.getWorldFrame();
+      ReferenceFrame parentFrame = ReferenceFrameTools.getWorldFrame();
       ROS2MutableFrame mutableFrame = new ROS2MutableFrame(node, id, parentFrame);
 
       // Run updates
       for (int i = 0; i < updatesToRun; ++i)
       {
-         // Update the frame
-         Instant updateTime = Instant.now();
-         mutableFrame.updateTransform(updatedTransformToParent, updateTime);
-
-         // Assert correct internal state
-         assertEquals(updateTime, mutableFrame.getLastUpdateTimestamp());
-         EuclidCoreTestTools.assertEquals(updatedTransformToParent, mutableFrame.getTransformToParent(), EPSILON);
+         updatedTransformToParent.appendTranslation(new Vector3D(0.1, 0.2, 0.3));
+         updatedTransformToParent.appendOrientation(new YawPitchRoll(0.1, 0.2, 0.3));
 
          synchronized (correctMessagesReceived)
          {
             try
             {
+               // Update the frame
+               mutableFrame.setNewTransformToParent(updatedTransformToParent);
+               mutableFrame.update();
+
+               // Assert correct internal state
+               EuclidCoreTestTools.assertEquals(updatedTransformToParent, mutableFrame.getTransformToParent(), EPSILON);
+
                // Publish a message and wait for it to be received
-               mutableFrame.publish();
                correctMessagesReceived.wait(1000);
 
                // Assert the message was correct
@@ -151,5 +131,118 @@ public class ROS2FrameTest
 
       mutableFrame.remove();
       node.destroy();
+   }
+
+   @Test
+   public void testPublishingMixedTree() throws InterruptedException
+   {
+      ROS2Node ros2Node = new ROS2NodeBuilder().build("test_node");
+
+      // Message counters to ensure correct messages
+      AtomicInteger messagesReceived = new AtomicInteger(0);
+
+      AtomicBoolean tfMessageReceived = new AtomicBoolean(false);
+      AtomicInteger transformsInTFMessage = new AtomicInteger(0);
+
+      AtomicBoolean tfStaticMessageReceived = new AtomicBoolean(false);
+      AtomicInteger transformsInTFStaticMessage = new AtomicInteger(0);
+
+      // Subscribe to /tf and /tf_static
+      ros2Node.createSubscription2(ROS2FrameTools.TF_TOPIC, tfMessage ->
+      {
+         synchronized (messagesReceived)
+         {
+            messagesReceived.getAndIncrement();
+            tfMessageReceived.set(true);
+            transformsInTFMessage.set(tfMessage.getTransforms().size());
+
+            messagesReceived.notify();
+         }
+      });
+
+      ros2Node.createSubscription2(ROS2FrameTools.TF_STATIC_TOPIC, tfMessage ->
+      {
+         synchronized (messagesReceived)
+         {
+            messagesReceived.getAndIncrement();
+            tfStaticMessageReceived.set(true);
+            transformsInTFStaticMessage.set(tfMessage.getTransforms().size());
+
+            messagesReceived.notify();
+         }
+      });
+
+      // Construct a reference frame tree (world <- map <- odom <- base_link <- wrist <- gripper)
+      ReferenceFrame worldFrame = ReferenceFrameTools.getWorldFrame();
+
+      RigidBodyTransform mapToWorldTransform = new RigidBodyTransform(new YawPitchRoll(0.1, 0.2, 0.3), new Vector3D(0.4, 0.5, 0.6));
+      ReferenceFrame mapFrame = ReferenceFrameTools.constructFrameWithUnchangingTransformToParent("map", worldFrame, mapToWorldTransform);
+
+      RigidBodyTransform odomToMapTransform = new RigidBodyTransform(new YawPitchRoll(0.7, 0.8, 0.9), new Vector3D(1.0, 1.1, 1.2));
+      ReferenceFrame odomFrame = ReferenceFrameTools.constructFrameWithChangingTransformToParent("odom", mapFrame, odomToMapTransform);
+
+      RigidBodyTransform baseLinkToOdomTransform = new RigidBodyTransform(new YawPitchRoll(1.3, 1.4, 1.5), new Vector3D(1.6, 1.7, 1.8));
+      ROS2MutableFrame ros2BaseLinkFrame = new ROS2MutableFrame(ros2Node, "base_link", odomFrame, baseLinkToOdomTransform);
+
+      RigidBodyTransform wristToBaseLinkTransform = new RigidBodyTransform(new YawPitchRoll(1.9, 2.0, 2.1), new Vector3D(2.2, 2.3, 2.4));
+      ReferenceFrame wristFrame = ReferenceFrameTools.constructFrameWithChangingTransformToParent("wrist", ros2BaseLinkFrame, wristToBaseLinkTransform);
+
+      RigidBodyTransform wristToGripperTransform = new RigidBodyTransform(new YawPitchRoll(2.5, 2.6, 2.7), new Vector3D(2.8, 2.9, 3.0));
+      ROS2StaticFrame ros2GripperFrame = new ROS2StaticFrame(ros2Node, "gripper", wristFrame, wristToGripperTransform);
+
+      for (int i = 0; i < 10; ++i)
+      {
+         // Update transforms
+         odomToMapTransform.getTranslation().add(0.1, 0.1, 0.1);
+         baseLinkToOdomTransform.getTranslation().add(0.2, 0.2, 0.2);
+         ros2BaseLinkFrame.setNewTransformToParent(baseLinkToOdomTransform);
+         wristToBaseLinkTransform.getTranslation().add(0.3, 0.3, 0.3);
+
+         // Update reference frames
+         mapFrame.update();
+         odomFrame.update();
+
+         synchronized (messagesReceived)
+         {
+            messagesReceived.set(0);
+            tfMessageReceived.set(false);
+            transformsInTFMessage.set(0);
+            tfStaticMessageReceived.set(false);
+            transformsInTFStaticMessage.set(0);
+
+            ros2BaseLinkFrame.update();
+
+            while (messagesReceived.get() < 2)
+               messagesReceived.wait();
+
+            assertTrue(tfMessageReceived.get());
+            assertEquals(2, transformsInTFMessage.get());
+
+            assertTrue(tfStaticMessageReceived.get());
+            assertEquals(1, transformsInTFStaticMessage.get());
+         }
+
+         wristFrame.update();
+
+         synchronized (messagesReceived)
+         {
+            messagesReceived.set(0);
+            tfMessageReceived.set(false);
+            transformsInTFMessage.set(0);
+            tfStaticMessageReceived.set(false);
+            transformsInTFStaticMessage.set(0);
+
+            ros2GripperFrame.update();
+
+            while (messagesReceived.get() < 2)
+               messagesReceived.wait();
+
+            assertTrue(tfMessageReceived.get());
+            assertEquals(1, transformsInTFMessage.get());
+
+            assertTrue(tfStaticMessageReceived.get());
+            assertEquals(1, transformsInTFStaticMessage.get());
+         }
+      }
    }
 }

--- a/ihmc-communication/src/test/java/us/ihmc/communication/ros2/tf2/ROS2FrameTest.java
+++ b/ihmc-communication/src/test/java/us/ihmc/communication/ros2/tf2/ROS2FrameTest.java
@@ -1,0 +1,155 @@
+package us.ihmc.communication.ros2.tf2;
+
+import org.junit.jupiter.api.Test;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.tools.EuclidCoreTestTools;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.yawPitchRoll.YawPitchRoll;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2NodeBuilder;
+
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ROS2FrameTest
+{
+   private static final double EPSILON = 1E-7;
+
+   @Test
+   public void testWorldFrame()
+   {
+      ROS2StaticFrame worldFrame = ROS2FrameTools.getWorldFrame();
+
+      assertTrue(worldFrame.isWorldFrame());
+      assertTrue(worldFrame.isRootFrame());
+      assertTrue(worldFrame.isAStationaryFrame());
+      assertTrue(worldFrame.isZupFrame());
+      assertTrue(worldFrame.isFixedInParent());
+
+      assertDoesNotThrow(worldFrame::update);
+
+      assertNull(worldFrame.getParent());
+      assertEquals(worldFrame, worldFrame.getRootFrame());
+      assertEquals(ROS2FrameTools.WORLD_FRAME_ID, worldFrame.getFrameId());
+      EuclidCoreTestTools.assertEquals(ReferenceFrame.getWorldFrame().getTransformToWorldFrame(), worldFrame.getTransformToWorldFrame(), EPSILON);
+      EuclidCoreTestTools.assertEquals(ReferenceFrame.getWorldFrame().getTransformToRoot(), worldFrame.getTransformToRoot(), EPSILON);
+   }
+
+   @Test
+   public void testConstructingStaticFrame()
+   {
+      ROS2Node node = new ROS2NodeBuilder().build("test_node");
+
+      String id = "test_static_frame";
+      ROS2Frame parentFrame = ROS2FrameTools.getWorldFrame();
+      RigidBodyTransformReadOnly transformToParent = new RigidBodyTransform(new YawPitchRoll(0.1, 0.2, 0.3), new Vector3D(0.4, 0.5, 0.6));
+      Instant timeAtConstruction = Instant.now();
+      ROS2Frame staticFrame = new ROS2StaticFrame(node, id, parentFrame, transformToParent, timeAtConstruction);
+
+      assertFalse(staticFrame.isWorldFrame());
+      assertFalse(staticFrame.isRootFrame());
+      assertFalse(staticFrame.isAStationaryFrame());
+      assertFalse(staticFrame.isZupFrame());
+      assertTrue(staticFrame.isFixedInParent());
+
+      assertEquals(id, staticFrame.getFrameId());
+      assertEquals(id, staticFrame.getName());
+      assertEquals(timeAtConstruction, staticFrame.getLastUpdateTimestamp());
+      assertEquals(parentFrame, staticFrame.getParent());
+      EuclidCoreTestTools.assertEquals(transformToParent, staticFrame.getTransformToParent(), EPSILON);
+
+      staticFrame.remove();
+      node.destroy();
+   }
+
+   @Test
+   public void testConstructingMutableFrame()
+   {
+      ROS2Node node = new ROS2NodeBuilder().build("test_node");
+
+      String id = "test_mutable_frame";
+      ROS2Frame parentFrame = ROS2FrameTools.getWorldFrame();
+      ROS2MutableFrame mutableFrame = new ROS2MutableFrame(node, id, parentFrame);
+
+      assertFalse(mutableFrame.isWorldFrame());
+      assertFalse(mutableFrame.isRootFrame());
+      assertFalse(mutableFrame.isAStationaryFrame());
+      assertFalse(mutableFrame.isZupFrame());
+      assertFalse(mutableFrame.isFixedInParent());
+
+      assertEquals(id, mutableFrame.getFrameId());
+      assertEquals(id, mutableFrame.getName());
+      assertEquals(parentFrame, mutableFrame.getParent());
+      EuclidCoreTestTools.assertEquals(new RigidBodyTransform(), mutableFrame.getTransformToParent(), EPSILON);
+
+      mutableFrame.remove();
+      node.destroy();
+   }
+
+   @Test
+   public void testUpdatingMutableFrame()
+   {
+      ROS2Node node = new ROS2NodeBuilder().build("test_node");
+
+      // We're going to run multiple update
+      final int updatesToRun = 10;
+
+      // Each update, this transform will be applied to the frame
+      RigidBodyTransform updatedTransformToParent = new RigidBodyTransform(new YawPitchRoll(1.0, 2.0, 3.0), new Vector3D(4.0, 5.0, 6.0));
+
+      // We'll also publish the updated transform, and ensure it's correct.
+      AtomicInteger correctMessagesReceived = new AtomicInteger(0);
+      node.createSubscription2(ROS2FrameTools.TF_TOPIC, message ->
+      {
+         synchronized (correctMessagesReceived)
+         {
+            RigidBodyTransform messageTransform = new RigidBodyTransform(message.getTransforms().get(0).getTransform());
+            if (messageTransform.epsilonEquals(updatedTransformToParent, EPSILON))
+               correctMessagesReceived.getAndIncrement();
+
+            correctMessagesReceived.notify();
+         }
+      });
+
+      // Construct a mutable frame
+      String id = "test_mutable_frame";
+      ROS2Frame parentFrame = ROS2FrameTools.getWorldFrame();
+      ROS2MutableFrame mutableFrame = new ROS2MutableFrame(node, id, parentFrame);
+
+      // Run updates
+      for (int i = 0; i < updatesToRun; ++i)
+      {
+         // Update the frame
+         Instant updateTime = Instant.now();
+         mutableFrame.updateTransform(updatedTransformToParent, updateTime);
+
+         // Assert correct internal state
+         assertEquals(updateTime, mutableFrame.getLastUpdateTimestamp());
+         EuclidCoreTestTools.assertEquals(updatedTransformToParent, mutableFrame.getTransformToParent(), EPSILON);
+
+         synchronized (correctMessagesReceived)
+         {
+            try
+            {
+               // Publish a message and wait for it to be received
+               mutableFrame.publish();
+               correctMessagesReceived.wait(1000);
+
+               // Assert the message was correct
+               assertEquals(i + 1, correctMessagesReceived.get());
+            }
+            catch (InterruptedException interruptedException)
+            {
+               throw new RuntimeException(interruptedException);
+            }
+         }
+      }
+
+      mutableFrame.remove();
+      node.destroy();
+   }
+}

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXROS2TF2Demo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXROS2TF2Demo.java
@@ -1,0 +1,181 @@
+package us.ihmc.rdx.perception;
+
+import com.badlogic.gdx.graphics.Color;
+import imgui.ImGui;
+import imgui.type.ImInt;
+import imgui.type.ImString;
+import us.ihmc.commons.thread.Throttler;
+import us.ihmc.communication.ros2.tf2.ROS2MutableFrame;
+import us.ihmc.communication.ros2.tf2.ROS2StaticFrame;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.referenceFrame.tools.ReferenceFrameTools;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.yawPitchRoll.YawPitchRoll;
+import us.ihmc.rdx.Lwjgl3ApplicationAdapter;
+import us.ihmc.rdx.ui.RDXBaseUI;
+import us.ihmc.rdx.ui.gizmo.RDXPose3DGizmo;
+import us.ihmc.rdx.ui.graphics.RDXReferenceFrameGraphic;
+import us.ihmc.ros2.ROS2Node;
+import us.ihmc.ros2.ROS2NodeBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class RDXROS2TF2Demo
+{
+   private final ROS2Node ros2Node = new ROS2NodeBuilder().build("tf2_demo_node");
+
+   private final Map<ROS2MutableFrame, RDXPose3DGizmo> mutableFrameMap = new HashMap<>();
+   private final Map<ROS2StaticFrame, RDXReferenceFrameGraphic> staticFrameMap = new HashMap<>();
+   private final Map<String, ReferenceFrame> allFrames = new TreeMap<>();
+   private String[] frameIds;
+
+   private final RDXBaseUI baseUI = new RDXBaseUI();
+
+   private final ImString frameIdToAdd = new ImString();
+   private final ImInt parentFrameIdIndex = new ImInt();
+
+   private final float[] transformYawPitchRoll = new float[3];
+   private final float[] transformTranslation = new float[3];
+
+   private final Throttler updateThrottler = new Throttler().setFrequency(60.0);
+
+   private final AtomicBoolean destroyed = new AtomicBoolean(false);
+
+   public RDXROS2TF2Demo()
+   {
+      Runtime.getRuntime().addShutdownHook(new Thread(this::destroy, "TF2DemoDestroy"));
+
+      baseUI.launchRDXApplication(new Lwjgl3ApplicationAdapter()
+      {
+         @Override
+         public void create()
+         {
+            addFrame(ReferenceFrameTools.getWorldFrame());
+            addFrame(new ROS2StaticFrame(ros2Node, "map", ReferenceFrame.getWorldFrame(), new RigidBodyTransform()));
+
+            baseUI.getImGuiPanelManager().addPanel("Settings", this::renderSettings);
+
+            baseUI.create();
+         }
+
+         @Override
+         public void render()
+         {
+            update();
+
+            baseUI.renderBeforeOnScreenUI();
+            baseUI.renderEnd();
+         }
+
+         private void renderSettings()
+         {
+            ImGui.inputText("Frame ID", frameIdToAdd);
+            ImGui.combo("Parent Frame", parentFrameIdIndex, frameIds);
+            ImGui.inputFloat3("Yaw Pitch Roll", transformYawPitchRoll);
+            ImGui.inputFloat3("Translation", transformTranslation);
+
+            ImGui.beginDisabled(allFrames.containsKey(frameIdToAdd.get()));
+
+            if (ImGui.button("Add as mutable frame"))
+            {
+               ReferenceFrame parentFrame = allFrames.get(frameIds[parentFrameIdIndex.get()]);
+               RigidBodyTransform initialOffset = new RigidBodyTransform(new YawPitchRoll(transformYawPitchRoll[0],
+                                                                                          transformYawPitchRoll[1],
+                                                                                          transformYawPitchRoll[2]),
+                                                                         new Vector3D(transformTranslation[0],
+                                                                                      transformTranslation[1],
+                                                                                      transformTranslation[2]));
+               ROS2MutableFrame mutableFrame = new ROS2MutableFrame(ros2Node, frameIdToAdd.get(), parentFrame, initialOffset);
+               addFrame(mutableFrame);
+            }
+
+            ImGui.sameLine();
+            if (ImGui.button("Add as static frame"))
+            {
+               ReferenceFrame parentFrame = allFrames.get(frameIds[parentFrameIdIndex.get()]);
+               RigidBodyTransform initialOffset = new RigidBodyTransform(new YawPitchRoll(transformYawPitchRoll[0],
+                                                                                          transformYawPitchRoll[1],
+                                                                                          transformYawPitchRoll[2]),
+                                                                         new Vector3D(transformTranslation[0],
+                                                                                      transformTranslation[1],
+                                                                                      transformTranslation[2]));
+               ROS2StaticFrame staticFrame = new ROS2StaticFrame(ros2Node, frameIdToAdd.get(), parentFrame, initialOffset);
+               addFrame(staticFrame);
+            }
+
+            ImGui.endDisabled();
+         }
+
+         @Override
+         public void dispose()
+         {
+            staticFrameMap.values().forEach(RDXReferenceFrameGraphic::dispose);
+            baseUI.dispose();
+            destroy();
+         }
+      });
+   }
+
+   private void addFrame(ReferenceFrame frame)
+   {
+      allFrames.put(frame.getName(), frame);
+      frameIds = new String[allFrames.size()];
+      int i = 0;
+      for (String id : allFrames.keySet())
+      {
+         frameIds[i++] = id;
+      }
+
+      if (frame instanceof ROS2StaticFrame staticFrame)
+      {
+         RDXReferenceFrameGraphic referenceFrameGraphic = new RDXReferenceFrameGraphic(0.3, Color.RED);
+         referenceFrameGraphic.setToReferenceFrame(staticFrame);
+         baseUI.getPrimaryScene().addRenderableProvider(referenceFrameGraphic);
+         staticFrameMap.put(staticFrame, referenceFrameGraphic);
+      }
+      else if (frame instanceof ROS2MutableFrame mutableFrame)
+      {
+         RDXPose3DGizmo poseGizmo = new RDXPose3DGizmo(mutableFrame, mutableFrame.getTransformToParent());
+         poseGizmo.createAndSetupDefault(baseUI.getPrimary3DPanel());
+         baseUI.getPrimaryScene().addRenderableProvider(poseGizmo);
+         mutableFrameMap.put(mutableFrame, poseGizmo);
+      }
+   }
+
+   private void update()
+   {
+      // Update mutable reference frames from the graphics
+      mutableFrameMap.forEach((frame, gizmo) ->
+      {
+         if (!frame.getTransformToParent().geometricallyEquals(gizmo.getTransformToParent(), 1E-4))
+         {
+            frame.setNewTransformToParent(gizmo.getTransformToParent());
+         }
+      });
+
+      // Update static frame graphics from the frame
+      staticFrameMap.values().forEach(RDXReferenceFrameGraphic::updateFromLastGivenFrame);
+
+      // Update all frames
+      if (updateThrottler.run()) // TODO: remove update throttler
+         allFrames.values().forEach(ReferenceFrame::update);
+   }
+
+   private void destroy()
+   {
+      if (destroyed.getAndSet(false))
+      {
+         allFrames.values().forEach(ReferenceFrame::remove);
+         ros2Node.destroy();
+      }
+   }
+
+   public static void main(String[] args)
+   {
+      new RDXROS2TF2Demo();
+   }
+}

--- a/ihmc-high-level-behaviors/src/libgdx/resources/configurations/RDXROS2TF2Demo/ImGuiPanels.json
+++ b/ihmc-high-level-behaviors/src/libgdx/resources/configurations/RDXROS2TF2Demo/ImGuiPanels.json
@@ -1,0 +1,7 @@
+{
+  "dockspacePanels" : { },
+  "windows" : {
+    "3D View" : true,
+    "Settings" : true
+  }
+}

--- a/ihmc-high-level-behaviors/src/libgdx/resources/configurations/RDXROS2TF2Demo/ImGuiSettings.ini
+++ b/ihmc-high-level-behaviors/src/libgdx/resources/configurations/RDXROS2TF2Demo/ImGuiSettings.ini
@@ -1,0 +1,27 @@
+[Window][DockSpaceViewport_11111111]
+Pos=0,22
+Size=909,1085
+Collapsed=0
+
+[Window][Settings]
+Pos=0,22
+Size=299,1085
+Collapsed=0
+DockId=0x00000001,0
+
+[Window][3D View]
+Pos=301,22
+Size=608,1085
+Collapsed=0
+DockId=0x00000002,0
+
+[Window][Debug##Default]
+Pos=60,60
+Size=400,400
+Collapsed=0
+
+[Docking][Data]
+DockSpace   ID=0x8B93E3BD Window=0xA787BDB4 Pos=999,103 Size=909,1085 Split=X Selected=0x2E64DC63
+  DockNode  ID=0x00000001 Parent=0x8B93E3BD SizeRef=299,1085 Selected=0x1C33C293
+  DockNode  ID=0x00000002 Parent=0x8B93E3BD SizeRef=608,1085 CentralNode=1 Selected=0x2E64DC63
+


### PR DESCRIPTION
Adds an abstract `ROS2Frame`, a `ReferenceFrame` that publishes and subscribes to`TFMessages` on the `/tf` or `/tf_static` topic (depending on whether it is a static frame). 

Three classes extend `ROS2Frame`: 
 - `ROS2MutableFrame` can move with respect to its parent, 
 - `ROS2StaticFrame` is fixed in its parent,
 - and `ROS2FollowingFrame` is a frame that follows another `ReferenceFrame` around. 

Also adds `ROS2HumanoidFrames` which makes ROS2 copies of all robot frames, and adds some `ROS2Frames` specified by [REP 120 - Coordinate Frames for Humanoid Robots](https://ros.org/reps/rep-0120.html)


https://github.com/user-attachments/assets/c9cf1999-01fb-4e23-b56c-ceda840b8a8c


