### PR TITLE
[Feature] Publish Standard ROS 2 Image and CameraInfo Message

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/ROS2HumanoidFrames.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/ROS2HumanoidFrames.java
@@ -98,7 +98,11 @@ public class ROS2HumanoidFrames
       // Repeat for all its child frames
       int childrenCount = start.getNumberOfChildren();
       for (int i = 0; i < childrenCount; ++i)
-         fillTree(start.getChild(i));
+      {
+         ReferenceFrame childFrame = start.getChild(i);
+         if (childFrame != null)
+            fillTree(childFrame);
+      }
    }
 
    private void createFrameCopy(ReferenceFrame frameToCopy)

--- a/ihmc-communication/src/main/java/us/ihmc/communication/PerceptionAPI.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/PerceptionAPI.java
@@ -7,6 +7,8 @@ import controller_msgs.msg.dds.StereoVisionPointCloudMessage;
 import ihmc_common_msgs.msg.dds.StampedPosePacket;
 import ihmc_common_msgs.msg.dds.TextToSpeechPacket;
 import perception_msgs.msg.dds.*;
+import sensor_msgs.msg.dds.CameraInfo;
+import sensor_msgs.msg.dds.Image;
 import std_msgs.msg.dds.Empty;
 import std_msgs.msg.dds.Float64;
 import std_msgs.msg.dds.Int64;
@@ -292,6 +294,30 @@ public final class PerceptionAPI
    }
 
    public static final ROS2Topic<DetectedDoorListMessage> DETECTED_DOORS = IHMC_ROOT.withModule("door_detection").withType(DetectedDoorListMessage.class);
+
+   /* STANDARD ROS 2 PERCEPTION MESSAGE TOPICS */
+   // ZED topics
+   private static final ROS2Topic<?> ROS2_ZED = new ROS2Topic<>().withPrefix("zed").withQoS(ROS2QosProfile.RELIABLE());
+
+   private static final ROS2Topic<?> ROS2_ZED_COLOR = ROS2_ZED.withModule("color");
+   public static final ROS2Topic<Image> ROS2_ZED_COLOR_IMAGE = ROS2_ZED_COLOR.withSuffix("image").withType(Image.class);
+   public static final ROS2Topic<CameraInfo> ROS2_ZED_COLOR_CAMERA_INFO = ROS2_ZED_COLOR.withSuffix("camera_info").withType(CameraInfo.class);
+
+   private static final ROS2Topic<?> ROS2_ZED_DEPTH = ROS2_ZED.withModule("depth");
+   public static final ROS2Topic<Image> ROS2_ZED_DEPTH_IMAGE = ROS2_ZED_DEPTH.withSuffix("image").withType(Image.class);
+   public static final ROS2Topic<CameraInfo> ROS2_ZED_DEPTH_CAMERA_INFO = ROS2_ZED_DEPTH.withSuffix("camera_info").withType(CameraInfo.class);
+
+   // D455 topics
+   private static final ROS2Topic<?> ROS2_D455 = new ROS2Topic<>().withPrefix("d455").withQoS(ROS2QosProfile.RELIABLE());
+
+   private static final ROS2Topic<?> ROS2_D455_COLOR = ROS2_D455.withModule("color");
+   public static final ROS2Topic<Image> ROS2_D455_COLOR_IMAGE = ROS2_D455_COLOR.withSuffix("image").withType(Image.class);
+   public static final ROS2Topic<CameraInfo> ROS2_D455_COLOR_CAMERA_INFO = ROS2_D455_COLOR.withSuffix("camera_info").withType(CameraInfo.class);
+
+   private static final ROS2Topic<?> ROS2_D455_DEPTH = ROS2_D455.withModule("depth");
+   public static final ROS2Topic<Image> ROS2_D455_DEPTH_IMAGE = ROS2_D455_DEPTH.withSuffix("image").withType(Image.class);
+   public static final ROS2Topic<CameraInfo> ROS2_D455_DEPTH_CAMERA_INFO = ROS2_D455_DEPTH.withSuffix("camera_info").withType(CameraInfo.class);
+
 
    /* VIDEO STREAMING STUFF */
    /**

--- a/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/ros2/tf2/ROS2Frame.java
@@ -28,6 +28,7 @@ public abstract class ROS2Frame extends ReferenceFrame
    private int lastPublishTimestampNanos;
 
    private volatile boolean readyToTakeData = false;
+   private volatile boolean hasBeenRemoved = false;
 
    protected ROS2Frame(ROS2Node ros2Node,
                        String id,
@@ -74,6 +75,9 @@ public abstract class ROS2Frame extends ReferenceFrame
       if (!readyToTakeData)
          return;
 
+      if (hasBeenRemoved)
+         return;
+
       // Read the new message
       subscriber.takeNextData(tfMessageToReceive, null);
 
@@ -113,6 +117,9 @@ public abstract class ROS2Frame extends ReferenceFrame
 
    protected void publishTFMessages()
    {
+      if (hasBeenRemoved)
+         return;
+
       long currentTimeMillis = System.currentTimeMillis();
       lastPublishTimestampSeconds = (int) (currentTimeMillis / 1000);
       lastPublishTimestampNanos = (int) (currentTimeMillis % 1000) * 1000000;
@@ -143,6 +150,10 @@ public abstract class ROS2Frame extends ReferenceFrame
    @Override
    public void remove()
    {
+      if (hasBeenRemoved)
+         return;
+      hasBeenRemoved = true;
+
       super.remove();
       if (tfPublisher != null)
          tfPublisher.remove();

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXSceneGraphDemo.java
@@ -50,8 +50,6 @@ import us.ihmc.sensors.zed.ZEDModelData;
 import us.ihmc.sensors.zed.ZEDSVOPlaybackSensor;
 import us.ihmc.tools.IHMCCommonPaths;
 
-import java.util.Map;
-
 import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_NEURAL;
 import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
 
@@ -162,10 +160,10 @@ public class RDXSceneGraphDemo
             zedSVOPlayer.useTrackedPose(true);
             zedSVOPlayer.run(true);
 
-            zedPublishThread = new ImageSensorPublishThread(ros2Node, zedSVOPlayer,
-                                                            Map.of(PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.LEFT), ZEDImageSensor.LEFT_COLOR_IMAGE_KEY,
-                                                                   PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.RIGHT), ZEDImageSensor.RIGHT_COLOR_IMAGE_KEY,
-                                                                   PerceptionAPI.ZED2_DEPTH, ZEDImageSensor.DEPTH_IMAGE_KEY));
+            zedPublishThread = new ImageSensorPublishThread(ros2Node, zedSVOPlayer);
+            zedPublishThread.addTopic(PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.LEFT), ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);
+            zedPublishThread.addTopic(PerceptionAPI.ZED2_COLOR_IMAGES.get(RobotSide.RIGHT), ZEDImageSensor.RIGHT_COLOR_IMAGE_KEY);
+            zedPublishThread.addTopic(PerceptionAPI.ZED2_DEPTH, ZEDImageSensor.DEPTH_IMAGE_KEY);
             zedPublishThread.startRepeating();
 
             zedSVORecorderPanel = new RDXZEDSVORecorderPanel(ros2Helper);

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/StandAloneRealsenseProcess.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/perception/StandAloneRealsenseProcess.java
@@ -2,24 +2,21 @@ package us.ihmc.perception;
 
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import us.ihmc.avatar.drcRobot.ROS2SyncedRobotModel;
-import us.ihmc.communication.ros2.ROS2TunedRigidBodyTransform;
-import us.ihmc.humanoidRobotics.communication.ControllerFootstepQueueMonitor;
 import us.ihmc.commons.thread.RepeatingTaskThread;
 import us.ihmc.communication.PerceptionAPI;
-import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.ros2.ROS2DemandGraphNode;
 import us.ihmc.communication.ros2.ROS2Helper;
+import us.ihmc.communication.ros2.ROS2TunedRigidBodyTransform;
+import us.ihmc.humanoidRobotics.communication.ControllerFootstepQueueMonitor;
 import us.ihmc.perception.gpuHeightMap.RapidHeightMapManager;
 import us.ihmc.perception.heightMap.TerrainMapData;
-import us.ihmc.sensorProcessing.heightMap.HeightMapParameters;
-import us.ihmc.sensors.realsense.RealSenseConfiguration;
 import us.ihmc.robotics.robotSide.RobotSide;
 import us.ihmc.ros2.ROS2Node;
-import us.ihmc.ros2.ROS2Topic;
 import us.ihmc.sensorProcessing.heightMap.HeightMapData;
+import us.ihmc.sensorProcessing.heightMap.HeightMapParameters;
+import us.ihmc.sensors.realsense.RealSenseConfiguration;
 import us.ihmc.sensors.realsense.RealSenseImageSensor;
 
-import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadFactory;
@@ -31,10 +28,6 @@ import java.util.concurrent.TimeUnit;
 public class StandAloneRealsenseProcess
 {
    public static final String STAND_ALONE_REALSENSE_PROCESS = "StandAloneRealsenseProcess";
-   private static final Map<ROS2Topic<? extends Packet<?>>, Integer> D455_IMAGE_TOPIC_MAP = Map.of(PerceptionAPI.SRT_REALSENSE_COLOR_STREAM_STATUS,
-                                                                                                   RealSenseImageSensor.COLOR_IMAGE_KEY,
-                                                                                                   PerceptionAPI.D455_DEPTH_IMAGE,
-                                                                                                   RealSenseImageSensor.DEPTH_IMAGE_KEY);
 
    private final ROS2DemandGraphNode realsenseDemandNode;
    private final HeightMapParameters heightMapParameters;
@@ -85,7 +78,9 @@ public class StandAloneRealsenseProcess
       d455Sensor.setSensorFrame(syncedRobot.getReferenceFrames().getSteppingCameraFrame());
       loopOnDemand(d455Sensor.getGrabThread(), realsenseDemandNode);
 
-      d455PublishThread = new ImageSensorPublishThread(ros2Node, d455Sensor, D455_IMAGE_TOPIC_MAP);
+      d455PublishThread = new ImageSensorPublishThread(ros2Node, d455Sensor);
+      d455PublishThread.addTopic(PerceptionAPI.SRT_REALSENSE_COLOR_STREAM_STATUS, RealSenseImageSensor.COLOR_IMAGE_KEY);
+      d455PublishThread.addTopic(PerceptionAPI.D455_DEPTH_IMAGE, RealSenseImageSensor.DEPTH_IMAGE_KEY);
       loopOnDemand(d455PublishThread, realsensePublishDemandNode);
 
       initializeHeightMap(controllerFootstepQueueMonitor);

--- a/ihmc-perception/src/main/java/us/ihmc/perception/ImageSensorPublishThread.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/ImageSensorPublishThread.java
@@ -3,6 +3,13 @@ package us.ihmc.perception;
 import sensor_msgs.msg.dds.CameraInfo;
 import us.ihmc.commons.thread.RepeatingTaskThread;
 import us.ihmc.communication.packets.Packet;
+import us.ihmc.communication.ros2.tf2.ROS2FollowingFrame;
+import us.ihmc.communication.ros2.tf2.ROS2StaticFrame;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.transform.RigidBodyTransform;
+import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
+import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.euclid.yawPitchRoll.YawPitchRoll;
 import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Topic;
 import us.ihmc.sensors.ImageSensor;
@@ -13,22 +20,38 @@ import java.util.Map.Entry;
 
 public class ImageSensorPublishThread extends RepeatingTaskThread
 {
-   private final Map<ROS2Topic<? extends Packet<?>>, Integer> topicToImageKeyMap;
+   // Read about optical frames here: https://ros.org/reps/rep-0103.html
+   private static final RigidBodyTransformReadOnly CAMERA_TO_OPTICAL_TRANSFORM = new RigidBodyTransform(new YawPitchRoll(-0.5 * Math.PI, 0.0, -0.5 * Math.PI),
+                                                                                                        new Vector3D());
+
+   private final ROS2Node ros2Node;
+
+   private final Map<ROS2Topic<? extends Packet<?>>, Integer> topicToImageKeyMap = new HashMap<>();
    private final Map<ROS2Topic<? extends Packet<?>>, Long> lastPublishedSequenceNumbers = new HashMap<>();
    private final RawImagePublisher publisher;
    private boolean publishingIsThrottled = false;
 
    private final ImageSensor imageSensor;
 
+   private final Map<Integer, ROS2FollowingFrame> ros2CameraFrames = new HashMap<>();
+   private final Map<Integer, ROS2StaticFrame> ros2OpticalFrames = new HashMap<>();
+
+   private boolean ros2FramesEnabled = false;
    private int cameraInfoPublishModulus = 1;
 
-   public ImageSensorPublishThread(ROS2Node ros2Node, ImageSensor sensorToPublish, Map<ROS2Topic<? extends Packet<?>>, Integer> topicToImageKeyMap)
+   public ImageSensorPublishThread(ROS2Node ros2Node, ImageSensor sensorToPublish)
    {
       super(sensorToPublish.getSensorName() + "PublishThread");
 
+      this.ros2Node = ros2Node;
+
       imageSensor = sensorToPublish;
-      this.topicToImageKeyMap = topicToImageKeyMap;
       publisher = new RawImagePublisher(ros2Node);
+   }
+
+   public void addTopic(ROS2Topic<? extends Packet<?>> topicToPublishOn, int imageKey)
+   {
+      topicToImageKeyMap.put(topicToPublishOn, imageKey);
    }
 
    @Override
@@ -37,6 +60,20 @@ public class ImageSensorPublishThread extends RepeatingTaskThread
       super.setFrequencyLimit(publishFrequencyLimit);
       publishingIsThrottled = publishFrequencyLimit > 0.0;
       return this;
+   }
+
+   /**
+    * If enabled, this thread will manage a ROS 2 frame for each image frame,
+    * and a corresponding optical frame.
+    * <p>
+    * For more info on optical frames, see
+    * <a href="https://ros.org/reps/rep-0103.html">ROS REP 103 - Standard Units of Measure and Coordinate Conventions</a>.
+    *
+    * @param enable Whether to enable adding ROS 2 frames for the image frames.
+    */
+   public void enableROS2Frames(boolean enable)
+   {
+      ros2FramesEnabled = enable;
    }
 
    /**
@@ -83,12 +120,57 @@ public class ImageSensorPublishThread extends RepeatingTaskThread
             // Store the sequence number to avoid re-publishing this image
             lastPublishedSequenceNumbers.put(imageTopic, imageToPublish.getSequenceNumber());
 
+            // Update sensor frames
+            ReferenceFrame imageFrame = imageSensor.getImageFrame(imageKey);
+            if (ros2FramesEnabled)
+            {
+               updateROS2Frames(imageKey);
+               imageFrame = ros2OpticalFrames.get(imageKey);
+            }
+
             // Publish the image
-            publisher.publishImage(imageTopic, imageToPublish);
+            publisher.publishImage(imageTopic, imageToPublish, imageFrame);
             imageToPublish.release();
          }
       }
       catch (InterruptedException ignored) {}
+   }
+
+   private void updateROS2Frames(int imageKey)
+   {
+      ReferenceFrame imageFrame = imageSensor.getImageFrame(imageKey);
+
+      ROS2FollowingFrame cameraFrame = ros2CameraFrames.get(imageKey);
+      ROS2StaticFrame opticalFrame = ros2OpticalFrames.get(imageKey);
+
+      // Ensure we've added these frames
+      if (cameraFrame == null)
+      {
+         cameraFrame = new ROS2FollowingFrame(ros2Node, "ros2_" + imageFrame.getName(), imageSensor.getSensorFrame(), imageFrame);
+         ros2CameraFrames.put(imageKey, cameraFrame);
+      }
+
+      if (opticalFrame == null)
+      {
+         opticalFrame = new ROS2StaticFrame(ros2Node, cameraFrame.getFrameId() + "_optical", cameraFrame, CAMERA_TO_OPTICAL_TRANSFORM);
+         ros2OpticalFrames.put(imageKey, opticalFrame);
+      }
+
+      // If sensor frame changed, update our frames as well
+      if (!cameraFrame.getParent().equals(imageSensor.getSensorFrame()))
+      {
+         cameraFrame.remove();
+         opticalFrame.remove();
+
+         cameraFrame = new ROS2FollowingFrame(ros2Node, "ros2_" + imageFrame.getName(), imageSensor.getSensorFrame(), imageFrame);
+         opticalFrame = new ROS2StaticFrame(ros2Node, cameraFrame.getFrameId() + "_optical", cameraFrame, CAMERA_TO_OPTICAL_TRANSFORM);
+
+         ros2CameraFrames.replace(imageKey, cameraFrame);
+         ros2OpticalFrames.replace(imageKey, opticalFrame);
+      }
+
+      cameraFrame.update();
+      opticalFrame.update();
    }
 
    @Override
@@ -97,6 +179,8 @@ public class ImageSensorPublishThread extends RepeatingTaskThread
       super.kill();
       interrupt();
 
+      ros2CameraFrames.values().forEach(ReferenceFrame::remove);
+      ros2OpticalFrames.values().forEach(ReferenceFrame::remove);
       publisher.close();
    }
 }

--- a/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/RawImagePublisher.java
@@ -2,30 +2,24 @@ package us.ihmc.perception;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.bytedeco.javacpp.BytePointer;
-import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.global.opencv_cudaimgproc;
 import org.bytedeco.opencv.global.opencv_imgproc;
 import org.bytedeco.opencv.opencv_core.GpuMat;
-import org.bytedeco.opencv.opencv_core.Mat;
 import perception_msgs.msg.dds.ImageMessage;
 import perception_msgs.msg.dds.SRTStreamStatus;
 import sensor_msgs.msg.dds.CameraInfo;
 import sensor_msgs.msg.dds.Image;
 import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.ros2.ROS2Helper;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.perception.cuda.CUDACompressionTools;
 import us.ihmc.perception.cuda.CUDAJPEGProcessor;
 import us.ihmc.perception.imageMessage.CompressionType;
-import us.ihmc.perception.imageMessage.PixelFormat;
 import us.ihmc.perception.opencv.OpenCVTools;
 import us.ihmc.perception.streaming.ROS2SRTSensorStreamer;
 import us.ihmc.perception.tools.PerceptionMessageTools;
 import us.ihmc.ros2.ROS2Node;
 import us.ihmc.ros2.ROS2Topic;
-
-import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
-import java.time.Instant;
 
 import static us.ihmc.perception.imageMessage.CompressionType.NVJPEG;
 import static us.ihmc.perception.imageMessage.CompressionType.ZSTD_NVJPEG_HYBRID;
@@ -53,8 +47,13 @@ public class RawImagePublisher implements AutoCloseable
       ros2Image = new Image();
    }
 
+   public void publishImage(ROS2Topic<? extends Packet<?>> imageTopic, RawImage imageToPublish)
+   {
+      publishImage(imageTopic, imageToPublish, null);
+   }
+
    @SuppressWarnings("unchecked") // Trust me bro, I know what I'm doing
-   public synchronized void publishImage(ROS2Topic<? extends Packet<?>> imageTopic, RawImage imageToPublish)
+   public synchronized void publishImage(ROS2Topic<? extends Packet<?>> imageTopic, RawImage imageToPublish, ReferenceFrame sensorFrame)
    {
       if (destroyed)
          return;
@@ -65,16 +64,19 @@ public class RawImagePublisher implements AutoCloseable
       }
       else if (imageTopic.getType().equals(Image.class))
       {  // Topic is a standard ROS2 Image topic -> publish as standard ROS2 Image message
-         publishAsROS2Image((ROS2Topic<Image>) imageTopic, imageToPublish);
+         publishAsROS2Image((ROS2Topic<Image>) imageTopic, imageToPublish, sensorFrame);
       }
       else if (imageTopic.getType().equals(CameraInfo.class))
       {  // Topic is a camera info topic -> publish the image's camera info
-         publishCameraInfo((ROS2Topic<CameraInfo>) imageTopic, imageToPublish);
+         publishCameraInfo((ROS2Topic<CameraInfo>) imageTopic, imageToPublish, sensorFrame);
       }
       else if (imageTopic.getType().equals(SRTStreamStatus.class))
       {  // Topic is an SRT stream topic -> stream video over SRT
          sensorStreamer.sendFrame((ROS2Topic<SRTStreamStatus>) imageTopic, imageToPublish);
       }
+      else
+         throw new IllegalArgumentException(
+               getClass().getSimpleName() + " doesn't know how to publish this message type (" + imageTopic.getType().getSimpleName() + ")");
    }
 
    private void publishAsImageMessage(ROS2Topic<ImageMessage> imageTopic, RawImage imageToPublish)
@@ -121,149 +123,26 @@ public class RawImagePublisher implements AutoCloseable
       ros2Helper.publish(imageTopic, imageMessage);
    }
 
-   private void publishAsROS2Image(ROS2Topic<Image> imageTopic, RawImage imageToPublish)
+   private void publishAsROS2Image(ROS2Topic<Image> imageTopic, RawImage imageToPublish, ReferenceFrame sensorFrame)
    {
-      // Set the header
-      Instant imageAcquisitionTime = imageToPublish.getAcquisitionTime();
-      ros2Image.getHeader().getStamp().setSec((int) imageAcquisitionTime.getEpochSecond());
-      ros2Image.getHeader().getStamp().setNanosec(imageAcquisitionTime.getNano());
-      ros2Image.getHeader().setFrameId("world"); // TODO: Figure out how to do frame ids with RawImage
+      if (sensorFrame == null)
+         throw new IllegalArgumentException("A sensor frame must be provided to publish ROS 2 Image messages");
 
-      // Set dimensions
-      ros2Image.setWidth(imageToPublish.getWidth());
-      ros2Image.setHeight(imageToPublish.getHeight());
-
-      // Set encoding
-      PixelFormat pixelFormat = imageToPublish.getPixelFormat();
-      String encoding = switch (pixelFormat)
-      {
-         case BGR8, BGRA8, RGB8, RGBA8 -> pixelFormat.name().toLowerCase();
-         case GRAY8, GRAY16 -> pixelFormat.name().toLowerCase().replace("gray", "mono");
-         default -> getOpenCVTypeString(imageToPublish.getOpenCVType());
-      };
-      ros2Image.setEncoding(encoding);
-
-      // Get the message's internal buffer
-      ByteBuffer dataBuffer = ros2Image.getData().getBuffer();
-
-      // Set byte order
-      ros2Image.setIsBigendian((byte) (dataBuffer.order().equals(ByteOrder.BIG_ENDIAN) ? 1 : 0));
-
-      // Set step
-      Mat cpuImage = imageToPublish.getCpuImageMat();
-      ros2Image.setStep(cpuImage.step());
-
-      // Set data
-      int memorySize = (int) OpenCVTools.memorySize(cpuImage);
-      dataBuffer.position(0).put(cpuImage.data().limit(memorySize).asByteBuffer());
+      // Pack the Image message
+      PerceptionMessageTools.packImageMessage(imageToPublish, sensorFrame.getName(), ros2Image);
 
       // Publish the image
       ros2Helper.publish(imageTopic, ros2Image);
    }
 
-   private String getOpenCVTypeString(int openCVType)
+   private void publishCameraInfo(ROS2Topic<CameraInfo> cameraInfoTopic, RawImage image, ReferenceFrame sensorFrame)
    {
-      // Reverse the opencv_core.CV_MAKETYPE method to get the type depth and number of channels
-      int depth = openCVType & opencv_core.CV_MAT_DEPTH_MASK;
-      int channels = ((openCVType - depth) >> opencv_core.CV_CN_SHIFT) + 1;
+      if (sensorFrame == null)
+         throw new IllegalArgumentException("A sensor frame must be provided to publish ROS 2 CameraInfo messages");
 
-      StringBuilder typeString = new StringBuilder(5);
-      switch (depth)
-      {
-         case opencv_core.CV_8U -> typeString.append("8UC");
-         case opencv_core.CV_8S -> typeString.append("8SC");
-         case opencv_core.CV_16U -> typeString.append("16UC");
-         case opencv_core.CV_16S -> typeString.append("16SC");
-         case opencv_core.CV_32S -> typeString.append("32SC");
-         case opencv_core.CV_32F -> typeString.append("32FC");
-         case opencv_core.CV_64F -> typeString.append("64FC");
-      }
-
-      typeString.append(channels);
-
-      return typeString.toString();
-   }
-
-   // TODO: Support non-rectified images and stereo images
-   private void publishCameraInfo(ROS2Topic<CameraInfo> cameraInfoTopic, RawImage image)
-   {
+      // Create and pack a CameraInfo message
       CameraInfo cameraInfo = new CameraInfo();
-
-      // Set the header
-      Instant imageAcquisitionTime = image.getAcquisitionTime();
-      cameraInfo.getHeader().getStamp().setSec((int) imageAcquisitionTime.getEpochSecond());
-      cameraInfo.getHeader().getStamp().setNanosec(imageAcquisitionTime.getNano());
-      cameraInfo.getHeader().setFrameId("world"); // TODO: should be camera frame
-
-      // Set the calibration parameters
-      // Image dimensions
-      cameraInfo.setHeight(image.getHeight());
-      cameraInfo.setWidth(image.getWidth());
-
-      // Distortion model
-      cameraInfo.setDistortionModel("plumb_bob");
-      cameraInfo.getD().clear(5);
-      cameraInfo.getD().add(new double[]{0.0, 0.0, 0.0, 0.0, 0.0}); // We (mostly) work with rectified images, so assume no distortion
-
-      /*
-       * Set the intrinsics matrix
-       *      [fx  0 cx]
-       *  K = [ 0 fy cy]
-       *      [ 0  0  1]
-       */
-      cameraInfo.getK()[0] = image.getFocalLengthX();
-      cameraInfo.getK()[1] = 0.0;
-      cameraInfo.getK()[2] = image.getPrincipalPointX();
-      cameraInfo.getK()[3] = 0.0;
-      cameraInfo.getK()[4] = image.getFocalLengthY();
-      cameraInfo.getK()[5] = image.getPrincipalPointY();
-      cameraInfo.getK()[6] = 0.0;
-      cameraInfo.getK()[7] = 0.0;
-      cameraInfo.getK()[8] = 1.0;
-
-      // Set the rotation matrix (only used for stereo images, so we assume identity)
-      cameraInfo.getR()[0] = 1.0;
-      cameraInfo.getR()[1] = 0.0;
-      cameraInfo.getR()[2] = 0.0;
-      cameraInfo.getR()[3] = 0.0;
-      cameraInfo.getR()[4] = 1.0;
-      cameraInfo.getR()[5] = 0.0;
-      cameraInfo.getR()[6] = 0.0;
-      cameraInfo.getR()[7] = 0.0;
-      cameraInfo.getR()[8] = 1.0;
-
-      /*
-       * Set the projection matrix
-       *     [fx'  0  cx' Tx]
-       * P = [ 0  fy' cy' Ty]
-       *     [ 0   0   1   0]
-       * Since we're not using stereo images, Tx = Ty = 0
-       * We also assume fx` = fx, cx` = cx, etc.
-       */
-      cameraInfo.getP()[0] = image.getFocalLengthX();
-      cameraInfo.getP()[1] = 0.0;
-      cameraInfo.getP()[2] = image.getPrincipalPointX();
-      cameraInfo.getP()[3] = 0.0;
-      cameraInfo.getP()[4] = 0.0;
-      cameraInfo.getP()[5] = image.getFocalLengthY();
-      cameraInfo.getP()[6] = image.getPrincipalPointY();
-      cameraInfo.getP()[7] = 0.0;
-      cameraInfo.getP()[8] = 0.0;
-      cameraInfo.getP()[9] = 0.0;
-      cameraInfo.getP()[10] = 1.0;
-      cameraInfo.getP()[11] = 0.0;
-
-      // Set "Operational Parameters"
-      // Assume no binning
-      cameraInfo.setBinningX(0);
-      cameraInfo.setBinningY(0);
-
-      // Set the ROI to the full image
-      cameraInfo.getRoi().setXOffset(0);
-      cameraInfo.getRoi().setYOffset(0);
-      cameraInfo.getRoi().setHeight(0);
-      cameraInfo.getRoi().setWidth(0);
-      cameraInfo.getRoi().setDoRectify(false);
+      PerceptionMessageTools.packCameraInfo(image, sensorFrame.getName(), cameraInfo);
 
       // Publish the message
       ros2Helper.publish(cameraInfoTopic, cameraInfo);

--- a/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDATools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/cuda/CUDATools.java
@@ -6,6 +6,7 @@ import org.bytedeco.cuda.global.cudart;
 import org.bytedeco.cuda.global.nvcomp;
 import org.bytedeco.cuda.global.nvjpeg;
 import org.bytedeco.javacpp.BytePointer;
+import org.bytedeco.javacpp.FloatPointer;
 import org.bytedeco.javacpp.IntPointer;
 import org.bytedeco.javacpp.Loader;
 import org.bytedeco.javacpp.Pointer;

--- a/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/demo/ROS2ImagePublishingDemo.java
@@ -3,8 +3,8 @@ package us.ihmc.perception.demo;
 import sensor_msgs.msg.dds.CameraInfo;
 import sensor_msgs.msg.dds.Image;
 import us.ihmc.commons.thread.RepeatingTaskThread;
-import us.ihmc.communication.packets.Packet;
 import us.ihmc.communication.ros2.ROS2Helper;
+import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.log.LogTools;
 import us.ihmc.perception.ImageSensorPublishThread;
 import us.ihmc.perception.RawImage;
@@ -17,8 +17,6 @@ import us.ihmc.sensors.zed.ZEDImageSensor;
 import us.ihmc.sensors.zed.ZEDModelData;
 import us.ihmc.sensors.zed.ZEDSVOPlaybackSensor;
 import us.ihmc.tools.IHMCCommonPaths;
-
-import java.util.Map;
 
 import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
 
@@ -42,14 +40,14 @@ import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
  * {@code
  * source /opt/ros/humble/setup.bash
  * export ROS_DOMAIN_ID=[your-domain-id] # insert your domain ID
- * ros2 run rviz2 rviz2
+ * rviz2
  * }
  * </pre>
  * In RViz2, add two Image display by clicking the Add button,
  * and in the By topic options selecting the Image displays under
  * the /zed/color/image_raw topic, and again under the /zed/depth/image_raw topic.
  * <p>
- * To show a point cloud, set the Fixed Frame (under Global Options) to "world".
+ * To show a point cloud, set the Fixed Frame (under Global Options) to "World".
  * Then, click Add, select DepthCloud, and click Ok.
  * Under the DepthCloud options, set the options as such:
  * <ul>
@@ -58,8 +56,6 @@ import static us.ihmc.zed.global.zed.SL_DEPTH_MODE_PERFORMANCE;
  *    <li>Color Image Topic = /zed/color/image_raw</li>
  * </ul>
  * <p>
- * You may notice the orientation of the point cloud is incorrect
- * as this demo does not publish a tf tree.
  */
 class ROS2ImagePublishingDemo
 {
@@ -104,6 +100,7 @@ class ROS2ImagePublishingDemo
 
       // Create a ZED sensor (in this case we use an SVO playback)
       zed = new ZEDSVOPlaybackSensor(new ROS2Helper(ros2Node), 0, ZEDModelData.ZED_2, SL_DEPTH_MODE_PERFORMANCE, SVO_FILE);
+      zed.useTrackedPose(true);
 
       // Add shutdown hook to properly close/destroy everything
       Runtime.getRuntime().addShutdownHook(new Thread(this::destroy, getClass().getSimpleName() + "Shutdown"));
@@ -123,15 +120,19 @@ class ROS2ImagePublishingDemo
 
    private void startPredefinedPublishThread()
    {
-      // Define a topic to image key map
-      Map<ROS2Topic<? extends Packet<?>>, Integer> zedTopicMap =
-            Map.of(colorImageTopic, ZEDImageSensor.LEFT_COLOR_IMAGE_KEY,       // Color image topic requires ZED's left color image
-                   colorCameraInfoTopic, ZEDImageSensor.LEFT_COLOR_IMAGE_KEY,  // Color camera info topic requires ZED's left color image
-                   depthImageTopic, ZEDImageSensor.DEPTH_IMAGE_KEY,            // Depth image topic requires ZED's depth image
-                   depthCameraInfoTopic, ZEDImageSensor.DEPTH_IMAGE_KEY);      // Depth camera info topic requires ZED's depth image
+      // Create the predefined publish thread
+      imageSensorPublishThread = new ImageSensorPublishThread(ros2Node, zed);
 
-      // Create the predefined publish thread and set its parameters
-      imageSensorPublishThread = new ImageSensorPublishThread(ros2Node, zed, zedTopicMap);
+      // Give it the topics it should publish on
+      imageSensorPublishThread.addTopic(colorImageTopic, ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);        // Color image topic requires ZED's left color image
+      imageSensorPublishThread.addTopic(colorCameraInfoTopic, ZEDImageSensor.LEFT_COLOR_IMAGE_KEY);   // Color camera info topic requires ZED's left color image
+      imageSensorPublishThread.addTopic(depthImageTopic, ZEDImageSensor.DEPTH_IMAGE_KEY);             // Depth image topic requires ZED's depth image
+      imageSensorPublishThread.addTopic(depthCameraInfoTopic, ZEDImageSensor.DEPTH_IMAGE_KEY);        // Depth camera info topic requires ZED's depth image
+
+      // Enable ROS 2 frames in the publish thread.
+      imageSensorPublishThread.enableROS2Frames(true);
+
+      // We don't need to publish CameraInfo every time, so we set a skip count
       imageSensorPublishThread.setCameraInfoPublishGrabSkipCount(CAMERA_INFO_PUBLISH_SKIP);
 
       // Start the thread
@@ -165,15 +166,15 @@ class ROS2ImagePublishingDemo
 
          // Publish the images
          LogTools.info("Publishing images {}", color.getSequenceNumber());
-         rawImagePublisher.publishImage(colorImageTopic, color);
-         rawImagePublisher.publishImage(depthImageTopic, depth);
+         rawImagePublisher.publishImage(colorImageTopic, color, ReferenceFrame.getWorldFrame());
+         rawImagePublisher.publishImage(depthImageTopic, depth, ReferenceFrame.getWorldFrame());
 
          // Publish the camera info
          if (color.getSequenceNumber() % (CAMERA_INFO_PUBLISH_SKIP + 1) == 0)
          {
             LogTools.info("Publishing camera info");
-            rawImagePublisher.publishImage(colorCameraInfoTopic, color);
-            rawImagePublisher.publishImage(depthCameraInfoTopic, depth);
+            rawImagePublisher.publishImage(colorCameraInfoTopic, color, ReferenceFrame.getWorldFrame());
+            rawImagePublisher.publishImage(depthCameraInfoTopic, depth, ReferenceFrame.getWorldFrame());
          }
 
          // Release the images

--- a/ihmc-perception/src/main/java/us/ihmc/perception/tools/PerceptionMessageTools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/tools/PerceptionMessageTools.java
@@ -8,6 +8,8 @@ import org.bytedeco.opencv.opencv_core.Mat;
 import perception_msgs.msg.dds.FramePlanarRegionsListMessage;
 import perception_msgs.msg.dds.HeightMapMessage;
 import perception_msgs.msg.dds.ImageMessage;
+import sensor_msgs.msg.dds.CameraInfo;
+import sensor_msgs.msg.dds.Image;
 import us.ihmc.communication.packets.MessageTools;
 import us.ihmc.communication.packets.PlanarRegionMessageConverter;
 import us.ihmc.communication.ros2.ROS2Helper;
@@ -20,6 +22,7 @@ import us.ihmc.perception.camera.CameraIntrinsics;
 import us.ihmc.perception.heightMap.TerrainMapData;
 import us.ihmc.perception.imageMessage.CompressionType;
 import us.ihmc.perception.imageMessage.PixelFormat;
+import us.ihmc.perception.opencv.OpenCVTools;
 import us.ihmc.robotics.geometry.FramePlanarRegionsList;
 import us.ihmc.ros2.ROS2Publisher;
 import us.ihmc.ros2.ROS2Topic;
@@ -29,6 +32,7 @@ import us.ihmc.sensorProcessing.heightMap.HeightMapTools;
 
 import javax.annotation.Nullable;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.time.Instant;
 
 public class PerceptionMessageTools
@@ -182,6 +186,146 @@ public class PerceptionMessageTools
          MessageTools.packIDLSequence(ousterBeamAltitudeAngles, imageMessageToPack.getOusterBeamAltitudeAngles());
       if (ousterBeamAzimuthAngles != null)
          MessageTools.packIDLSequence(ousterBeamAzimuthAngles, imageMessageToPack.getOusterBeamAzimuthAngles());
+   }
+
+   public static void packImageMessage(RawImage image, String cameraFrameId, Image messageToPack)
+   {
+      // Set the header
+      Instant imageAcquisitionTime = image.getAcquisitionTime();
+      messageToPack.getHeader().getStamp().setSec((int) imageAcquisitionTime.getEpochSecond());
+      messageToPack.getHeader().getStamp().setNanosec(imageAcquisitionTime.getNano());
+      messageToPack.getHeader().setFrameId(cameraFrameId);
+
+      // Set dimensions
+      messageToPack.setWidth(image.getWidth());
+      messageToPack.setHeight(image.getHeight());
+
+      // Set encoding
+      PixelFormat pixelFormat = image.getPixelFormat();
+      String encoding = switch (pixelFormat)
+      {
+         case BGR8, BGRA8, RGB8, RGBA8 -> pixelFormat.name().toLowerCase();
+         case GRAY8, GRAY16 -> pixelFormat.name().toLowerCase().replace("gray", "mono");
+         default -> getOpenCVTypeString(image.getOpenCVType());
+      };
+      messageToPack.setEncoding(encoding);
+
+      // Get the message's internal buffer
+      ByteBuffer dataBuffer = messageToPack.getData().getBuffer();
+
+      // Set byte order
+      messageToPack.setIsBigendian((byte) (dataBuffer.order().equals(ByteOrder.BIG_ENDIAN) ? 1 : 0));
+
+      // Set step
+      Mat cpuImage = image.getCpuImageMat();
+      messageToPack.setStep(cpuImage.step());
+
+      // Set data
+      int memorySize = (int) OpenCVTools.memorySize(cpuImage);
+      dataBuffer.position(0).put(cpuImage.data().limit(memorySize).asByteBuffer());
+   }
+
+   private static String getOpenCVTypeString(int openCVType)
+   {
+      // Reverse the opencv_core.CV_MAKETYPE method to get the type depth and number of channels
+      int depth = openCVType & opencv_core.CV_MAT_DEPTH_MASK;
+      int channels = ((openCVType - depth) >> opencv_core.CV_CN_SHIFT) + 1;
+
+      StringBuilder typeString = new StringBuilder(5);
+      switch (depth)
+      {
+         case opencv_core.CV_8U -> typeString.append("8UC");
+         case opencv_core.CV_8S -> typeString.append("8SC");
+         case opencv_core.CV_16U -> typeString.append("16UC");
+         case opencv_core.CV_16S -> typeString.append("16SC");
+         case opencv_core.CV_32S -> typeString.append("32SC");
+         case opencv_core.CV_32F -> typeString.append("32FC");
+         case opencv_core.CV_64F -> typeString.append("64FC");
+      }
+
+      typeString.append(channels);
+
+      return typeString.toString();
+   }
+
+   // TODO: Support non-rectified images and stereo images
+   public static void packCameraInfo(RawImage image, String cameraFrameId, CameraInfo cameraInfoToPack)
+   {
+      // Set the header
+      Instant imageAcquisitionTime = image.getAcquisitionTime();
+      cameraInfoToPack.getHeader().getStamp().setSec((int) imageAcquisitionTime.getEpochSecond());
+      cameraInfoToPack.getHeader().getStamp().setNanosec(imageAcquisitionTime.getNano());
+      cameraInfoToPack.getHeader().setFrameId(cameraFrameId);
+
+      // Set the calibration parameters
+      // Image dimensions
+      cameraInfoToPack.setHeight(image.getHeight());
+      cameraInfoToPack.setWidth(image.getWidth());
+
+      // Distortion model
+      cameraInfoToPack.setDistortionModel("plumb_bob");
+      cameraInfoToPack.getD().clear(5);
+      cameraInfoToPack.getD().add(new double[]{0.0, 0.0, 0.0, 0.0, 0.0}); // We (mostly) work with rectified images, so assume no distortion
+
+      /*
+       * Set the intrinsics matrix
+       *      [fx  0 cx]
+       *  K = [ 0 fy cy]
+       *      [ 0  0  1]
+       */
+      cameraInfoToPack.getK()[0] = image.getFocalLengthX();
+      cameraInfoToPack.getK()[1] = 0.0;
+      cameraInfoToPack.getK()[2] = image.getPrincipalPointX();
+      cameraInfoToPack.getK()[3] = 0.0;
+      cameraInfoToPack.getK()[4] = image.getFocalLengthY();
+      cameraInfoToPack.getK()[5] = image.getPrincipalPointY();
+      cameraInfoToPack.getK()[6] = 0.0;
+      cameraInfoToPack.getK()[7] = 0.0;
+      cameraInfoToPack.getK()[8] = 1.0;
+
+      // Set the rotation matrix (only used for stereo images, so we assume identity)
+      cameraInfoToPack.getR()[0] = 1.0;
+      cameraInfoToPack.getR()[1] = 0.0;
+      cameraInfoToPack.getR()[2] = 0.0;
+      cameraInfoToPack.getR()[3] = 0.0;
+      cameraInfoToPack.getR()[4] = 1.0;
+      cameraInfoToPack.getR()[5] = 0.0;
+      cameraInfoToPack.getR()[6] = 0.0;
+      cameraInfoToPack.getR()[7] = 0.0;
+      cameraInfoToPack.getR()[8] = 1.0;
+
+      /*
+       * Set the projection matrix
+       *     [fx'  0  cx' Tx]
+       * P = [ 0  fy' cy' Ty]
+       *     [ 0   0   1   0]
+       * Since we're not using stereo images, Tx = Ty = 0
+       * We also assume fx` = fx, cx` = cx, etc.
+       */
+      cameraInfoToPack.getP()[0] = image.getFocalLengthX();
+      cameraInfoToPack.getP()[1] = 0.0;
+      cameraInfoToPack.getP()[2] = image.getPrincipalPointX();
+      cameraInfoToPack.getP()[3] = 0.0;
+      cameraInfoToPack.getP()[4] = 0.0;
+      cameraInfoToPack.getP()[5] = image.getFocalLengthY();
+      cameraInfoToPack.getP()[6] = image.getPrincipalPointY();
+      cameraInfoToPack.getP()[7] = 0.0;
+      cameraInfoToPack.getP()[8] = 0.0;
+      cameraInfoToPack.getP()[9] = 0.0;
+      cameraInfoToPack.getP()[10] = 1.0;
+      cameraInfoToPack.getP()[11] = 0.0;
+
+      // Set "Operational Parameters"
+      // Assume no binning
+      cameraInfoToPack.setBinningX(0);
+      cameraInfoToPack.setBinningY(0);
+
+      // Set the ROI to the full image
+      cameraInfoToPack.getRoi().setXOffset(0);
+      cameraInfoToPack.getRoi().setYOffset(0);
+      cameraInfoToPack.getRoi().setHeight(0);
+      cameraInfoToPack.getRoi().setWidth(0);
+      cameraInfoToPack.getRoi().setDoRectify(false);
    }
 
    public static void copyToFloatPointer(IDLSequence.Float sourceIDLSequence, FloatPointer floatPointerToPack, int startIndex)

--- a/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/sensors/zed/ZEDImageSensor.java
@@ -71,7 +71,7 @@ public class ZEDImageSensor extends ImageSensor
    protected final SL_RuntimeParameters zedRuntimeParameters = new SL_RuntimeParameters();
 
    private boolean positionalTrackingEnabled = false;
-   private final MutableReferenceFrame trackedSensorFrame = new MutableReferenceFrame();
+   private final MutableReferenceFrame trackedSensorFrame;
    private final SL_Quaternion sensorRotation = new SL_Quaternion();
    private final SL_Vector3 sensorTranslation = new SL_Vector3();
 
@@ -83,6 +83,8 @@ public class ZEDImageSensor extends ImageSensor
       this.zedModel = zedModel;
       this.slInputType = slInputType;
       this.slDepthMode = slDepthMode;
+
+      trackedSensorFrame = new MutableReferenceFrame(getSensorName() + "_tracked", ReferenceFrameTools.getWorldFrame());
 
       sensorCenterToCameraDistanceY = (float) zedModel.getCenterToCameraDistance();
       updateReferenceFrames();


### PR DESCRIPTION
Changes: 
 - Bugfixes
   - `ROS2Frame` doesn't throw exceptions after being removed
   - `ROS2HumanoidFrames` doesn't crash when a frame is `null`
 - Added `ROS2Topic`s for standard ROS 2 perception messages (`Image`, and `CameraInfo`)
 - Instead of giving `ImageSensorPublishThread` a map of ROS 2 topics to image keys during construction, add topics to publish on one-by-one
 - `ImageSensorPublishThread` now can manage ROS 2 frames of the image frames. This enables us to provide the correct image frame in the CameraInfo messages