### PR TITLE
[Bugfix] Speedup YOLO

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXYOLOv8Node.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/sceneGraph/RDXYOLOv8Node.java
@@ -1,31 +1,19 @@
 package us.ihmc.rdx.perception.sceneGraph;
 
-import com.badlogic.gdx.graphics.Color;
-import com.badlogic.gdx.graphics.g3d.Renderable;
-import com.badlogic.gdx.utils.Array;
-import com.badlogic.gdx.utils.Pool;
 import imgui.ImGui;
 import imgui.flag.ImGuiCol;
-import us.ihmc.euclid.tuple3D.Point3D32;
 import us.ihmc.perception.sceneGraph.SceneGraph;
 import us.ihmc.perception.sceneGraph.modification.SceneGraphModificationQueue;
 import us.ihmc.perception.sceneGraph.yolo.YOLOv8Node;
-import us.ihmc.rdx.RDXPointCloudRendererOld;
 import us.ihmc.rdx.imgui.ImGuiPlot;
 import us.ihmc.rdx.imgui.ImGuiTools;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
-import us.ihmc.rdx.sceneManager.RDXSceneLevel;
-
-import java.util.List;
-import java.util.Set;
 
 public class RDXYOLOv8Node extends RDXDetectableSceneNode
 {
    private final YOLOv8Node yoloNode;
 
    private final ImGuiPlot confidencePlot;
-
-   private final RDXPointCloudRendererOld objectPointCloudRenderer = new RDXPointCloudRendererOld();
 
    public RDXYOLOv8Node(YOLOv8Node yoloNode, ImGuiUniqueLabelMap labels)
    {
@@ -34,8 +22,6 @@ public class RDXYOLOv8Node extends RDXDetectableSceneNode
 
       confidencePlot = new ImGuiPlot(labels.get("Confidence"), 1000, 230, 22);
       confidencePlot.setYScale(0.0f, 1.0f);
-
-      objectPointCloudRenderer.create(5000);
    }
 
    @Override
@@ -47,23 +33,5 @@ public class RDXYOLOv8Node extends RDXDetectableSceneNode
       ImGui.pushStyleColor(ImGuiCol.PlotLines, ImGuiTools.greenRedGradientColor((float) yoloNode.getConfidence(), 1.0f, 0.0f));
       confidencePlot.render(yoloNode.getConfidence());
       ImGui.popStyleColor();
-   }
-
-   @Override
-   public void getRenderables(Array<Renderable> renderables, Pool<Renderable> pool, Set<RDXSceneLevel> sceneLevels)
-   {
-      super.getRenderables(renderables, pool, sceneLevels);
-      List<Point3D32> renderablePointCloud = yoloNode.getObjectPointCloud();
-      objectPointCloudRenderer.setPointsToRender(renderablePointCloud, Color.GREEN);
-      objectPointCloudRenderer.updateMesh();
-      objectPointCloudRenderer.getRenderables(renderables, pool);
-   }
-
-   @Override
-   public void destroy()
-   {
-      super.destroy();
-
-      objectPointCloudRenderer.dispose();
    }
 }

--- a/ihmc-interfaces/src/main/generated-idl/perception_msgs/msg/YOLOv8NodeMessage_.idl
+++ b/ihmc-interfaces/src/main/generated-idl/perception_msgs/msg/YOLOv8NodeMessage_.idl
@@ -1,7 +1,6 @@
 #ifndef __perception_msgs__msg__YOLOv8NodeMessage__idl__
 #define __perception_msgs__msg__YOLOv8NodeMessage__idl__
 
-#include "geometry_msgs/msg/./Point32_.idl"
 #include "geometry_msgs/msg/./Pose_.idl"
 #include "geometry_msgs/msg/./Transform_.idl"
 #include "perception_msgs/msg/./DetectableSceneNodeMessage_.idl"
@@ -23,7 +22,6 @@ module perception_msgs
          */
         perception_msgs::msg::dds::DetectableSceneNodeMessage detectable_scene_node;
         double confidence;
-        sequence<geometry_msgs::msg::dds::Point32, 511> object_point_cloud;
         /**
          * YOLOv8Node data
          */

--- a/ihmc-interfaces/src/main/generated-java/perception_msgs/msg/dds/SceneGraphMessagePubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/perception_msgs/msg/dds/SceneGraphMessagePubSubType.java
@@ -15,7 +15,7 @@ public class SceneGraphMessagePubSubType implements us.ihmc.pubsub.TopicDataType
    @Override
    public final java.lang.String getDefinitionChecksum()
    {
-   		return "a725c0f085e2d8e03426d808d4f3bd87b8a17b6d3d348a66369929b6706bc153";
+   		return "b873554986310af4dc93a685153bea6d4be2ac2f7881e52a6589d62acb845da5";
    }
    
    @Override

--- a/ihmc-interfaces/src/main/generated-java/perception_msgs/msg/dds/YOLOv8NodeMessage.java
+++ b/ihmc-interfaces/src/main/generated-java/perception_msgs/msg/dds/YOLOv8NodeMessage.java
@@ -16,7 +16,6 @@ public class YOLOv8NodeMessage extends Packet<YOLOv8NodeMessage> implements Sett
             */
    public perception_msgs.msg.dds.DetectableSceneNodeMessage detectable_scene_node_;
    public double confidence_;
-   public us.ihmc.idl.IDLSequence.Object<us.ihmc.euclid.tuple3D.Point3D32>  object_point_cloud_;
    /**
             * YOLOv8Node data
             */
@@ -27,11 +26,9 @@ public class YOLOv8NodeMessage extends Packet<YOLOv8NodeMessage> implements Sett
    public YOLOv8NodeMessage()
    {
       detectable_scene_node_ = new perception_msgs.msg.dds.DetectableSceneNodeMessage();
-      object_point_cloud_ = new us.ihmc.idl.IDLSequence.Object<us.ihmc.euclid.tuple3D.Point3D32> (511, new geometry_msgs.msg.dds.Point32PubSubType());
       centroid_to_object_transform_ = new us.ihmc.euclid.transform.QuaternionBasedTransform();
       object_pose_ = new us.ihmc.euclid.geometry.Pose3D();
       filtered_object_pose_ = new us.ihmc.euclid.geometry.Pose3D();
-
    }
 
    public YOLOv8NodeMessage(YOLOv8NodeMessage other)
@@ -45,7 +42,6 @@ public class YOLOv8NodeMessage extends Packet<YOLOv8NodeMessage> implements Sett
       perception_msgs.msg.dds.DetectableSceneNodeMessagePubSubType.staticCopy(other.detectable_scene_node_, detectable_scene_node_);
       confidence_ = other.confidence_;
 
-      object_point_cloud_.set(other.object_point_cloud_);
       geometry_msgs.msg.dds.TransformPubSubType.staticCopy(other.centroid_to_object_transform_, centroid_to_object_transform_);
       geometry_msgs.msg.dds.PosePubSubType.staticCopy(other.object_pose_, object_pose_);
       geometry_msgs.msg.dds.PosePubSubType.staticCopy(other.filtered_object_pose_, filtered_object_pose_);
@@ -67,12 +63,6 @@ public class YOLOv8NodeMessage extends Packet<YOLOv8NodeMessage> implements Sett
    public double getConfidence()
    {
       return confidence_;
-   }
-
-
-   public us.ihmc.idl.IDLSequence.Object<us.ihmc.euclid.tuple3D.Point3D32>  getObjectPointCloud()
-   {
-      return object_point_cloud_;
    }
 
 
@@ -117,13 +107,6 @@ public class YOLOv8NodeMessage extends Packet<YOLOv8NodeMessage> implements Sett
       if (!this.detectable_scene_node_.epsilonEquals(other.detectable_scene_node_, epsilon)) return false;
       if (!us.ihmc.idl.IDLTools.epsilonEqualsPrimitive(this.confidence_, other.confidence_, epsilon)) return false;
 
-      if (this.object_point_cloud_.size() != other.object_point_cloud_.size()) { return false; }
-      else
-      {
-         for (int i = 0; i < this.object_point_cloud_.size(); i++)
-         {  if (!this.object_point_cloud_.get(i).epsilonEquals(other.object_point_cloud_.get(i), epsilon)) return false; }
-      }
-
       if (!this.centroid_to_object_transform_.epsilonEquals(other.centroid_to_object_transform_, epsilon)) return false;
       if (!this.object_pose_.epsilonEquals(other.object_pose_, epsilon)) return false;
       if (!this.filtered_object_pose_.epsilonEquals(other.filtered_object_pose_, epsilon)) return false;
@@ -143,7 +126,6 @@ public class YOLOv8NodeMessage extends Packet<YOLOv8NodeMessage> implements Sett
       if (!this.detectable_scene_node_.equals(otherMyClass.detectable_scene_node_)) return false;
       if(this.confidence_ != otherMyClass.confidence_) return false;
 
-      if (!this.object_point_cloud_.equals(otherMyClass.object_point_cloud_)) return false;
       if (!this.centroid_to_object_transform_.equals(otherMyClass.centroid_to_object_transform_)) return false;
       if (!this.object_pose_.equals(otherMyClass.object_pose_)) return false;
       if (!this.filtered_object_pose_.equals(otherMyClass.filtered_object_pose_)) return false;
@@ -161,8 +143,6 @@ public class YOLOv8NodeMessage extends Packet<YOLOv8NodeMessage> implements Sett
       builder.append(this.detectable_scene_node_);      builder.append(", ");
       builder.append("confidence=");
       builder.append(this.confidence_);      builder.append(", ");
-      builder.append("object_point_cloud=");
-      builder.append(this.object_point_cloud_);      builder.append(", ");
       builder.append("centroid_to_object_transform=");
       builder.append(this.centroid_to_object_transform_);      builder.append(", ");
       builder.append("object_pose=");

--- a/ihmc-interfaces/src/main/generated-java/perception_msgs/msg/dds/YOLOv8NodeMessagePubSubType.java
+++ b/ihmc-interfaces/src/main/generated-java/perception_msgs/msg/dds/YOLOv8NodeMessagePubSubType.java
@@ -15,7 +15,7 @@ public class YOLOv8NodeMessagePubSubType implements us.ihmc.pubsub.TopicDataType
    @Override
    public final java.lang.String getDefinitionChecksum()
    {
-   		return "96aede51c877070e23c6eb9ed71b88f1a592f674f1d20b7dcfdd03d98ebae0d6";
+   		return "bb65616a302bf3450df193cda29cb22cdf4a3a29a8fb7edf04bc56487736a7fb";
    }
    
    @Override
@@ -56,9 +56,6 @@ public class YOLOv8NodeMessagePubSubType implements us.ihmc.pubsub.TopicDataType
 
       current_alignment += 8 + us.ihmc.idl.CDR.alignment(current_alignment, 8);
 
-      current_alignment += 4 + us.ihmc.idl.CDR.alignment(current_alignment, 4);for(int i0 = 0; i0 < 511; ++i0)
-      {
-          current_alignment += geometry_msgs.msg.dds.Point32PubSubType.getMaxCdrSerializedSize(current_alignment);}
       current_alignment += geometry_msgs.msg.dds.TransformPubSubType.getMaxCdrSerializedSize(current_alignment);
 
       current_alignment += geometry_msgs.msg.dds.PosePubSubType.getMaxCdrSerializedSize(current_alignment);
@@ -83,11 +80,6 @@ public class YOLOv8NodeMessagePubSubType implements us.ihmc.pubsub.TopicDataType
       current_alignment += 8 + us.ihmc.idl.CDR.alignment(current_alignment, 8);
 
 
-      current_alignment += 4 + us.ihmc.idl.CDR.alignment(current_alignment, 4);
-      for(int i0 = 0; i0 < data.getObjectPointCloud().size(); ++i0)
-      {
-          current_alignment += geometry_msgs.msg.dds.Point32PubSubType.getCdrSerializedSize(data.getObjectPointCloud().get(i0), current_alignment);}
-
       current_alignment += geometry_msgs.msg.dds.TransformPubSubType.getCdrSerializedSize(data.getCentroidToObjectTransform(), current_alignment);
 
       current_alignment += geometry_msgs.msg.dds.PosePubSubType.getCdrSerializedSize(data.getObjectPose(), current_alignment);
@@ -103,10 +95,6 @@ public class YOLOv8NodeMessagePubSubType implements us.ihmc.pubsub.TopicDataType
       perception_msgs.msg.dds.DetectableSceneNodeMessagePubSubType.write(data.getDetectableSceneNode(), cdr);
       cdr.write_type_6(data.getConfidence());
 
-      if(data.getObjectPointCloud().size() <= 511)
-      cdr.write_type_e(data.getObjectPointCloud());else
-          throw new RuntimeException("object_point_cloud field exceeds the maximum length: %d > %d".formatted(data.getObjectPointCloud().size(), 511));
-
       geometry_msgs.msg.dds.TransformPubSubType.write(data.getCentroidToObjectTransform(), cdr);
       geometry_msgs.msg.dds.PosePubSubType.write(data.getObjectPose(), cdr);
       geometry_msgs.msg.dds.PosePubSubType.write(data.getFilteredObjectPose(), cdr);
@@ -117,7 +105,6 @@ public class YOLOv8NodeMessagePubSubType implements us.ihmc.pubsub.TopicDataType
       perception_msgs.msg.dds.DetectableSceneNodeMessagePubSubType.read(data.getDetectableSceneNode(), cdr);	
       data.setConfidence(cdr.read_type_6());
       	
-      cdr.read_type_e(data.getObjectPointCloud());	
       geometry_msgs.msg.dds.TransformPubSubType.read(data.getCentroidToObjectTransform(), cdr);	
       geometry_msgs.msg.dds.PosePubSubType.read(data.getObjectPose(), cdr);	
       geometry_msgs.msg.dds.PosePubSubType.read(data.getFilteredObjectPose(), cdr);	
@@ -130,7 +117,6 @@ public class YOLOv8NodeMessagePubSubType implements us.ihmc.pubsub.TopicDataType
       ser.write_type_a("detectable_scene_node", new perception_msgs.msg.dds.DetectableSceneNodeMessagePubSubType(), data.getDetectableSceneNode());
 
       ser.write_type_6("confidence", data.getConfidence());
-      ser.write_type_e("object_point_cloud", data.getObjectPointCloud());
       ser.write_type_a("centroid_to_object_transform", new geometry_msgs.msg.dds.TransformPubSubType(), data.getCentroidToObjectTransform());
 
       ser.write_type_a("object_pose", new geometry_msgs.msg.dds.PosePubSubType(), data.getObjectPose());
@@ -145,7 +131,6 @@ public class YOLOv8NodeMessagePubSubType implements us.ihmc.pubsub.TopicDataType
       ser.read_type_a("detectable_scene_node", new perception_msgs.msg.dds.DetectableSceneNodeMessagePubSubType(), data.getDetectableSceneNode());
 
       data.setConfidence(ser.read_type_6("confidence"));
-      ser.read_type_e("object_point_cloud", data.getObjectPointCloud());
       ser.read_type_a("centroid_to_object_transform", new geometry_msgs.msg.dds.TransformPubSubType(), data.getCentroidToObjectTransform());
 
       ser.read_type_a("object_pose", new geometry_msgs.msg.dds.PosePubSubType(), data.getObjectPose());

--- a/ihmc-interfaces/src/main/messages/ihmc_interfaces/perception_msgs/msg/YOLOv8NodeMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ihmc_interfaces/perception_msgs/msg/YOLOv8NodeMessage.msg
@@ -4,7 +4,6 @@
 perception_msgs/DetectableSceneNodeMessage detectable_scene_node
 
 float64 confidence
-geometry_msgs/Point32[<=511] object_point_cloud
 
 # YOLOv8Node data
 geometry_msgs/Transform centroid_to_object_transform

--- a/ihmc-interfaces/src/main/messages/ros1/perception_msgs/msg/YOLOv8NodeMessage.msg
+++ b/ihmc-interfaces/src/main/messages/ros1/perception_msgs/msg/YOLOv8NodeMessage.msg
@@ -5,8 +5,6 @@ perception_msgs/DetectableSceneNodeMessage detectable_scene_node
 
 float64 confidence
 
-geometry_msgs/Point32[] object_point_cloud
-
 # YOLOv8Node data
 geometry_msgs/Transform centroid_to_object_transform
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8DetectionExecutor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8DetectionExecutor.java
@@ -108,7 +108,7 @@ public class YOLOv8DetectionExecutor
       updateThread.setDaemon(true);
       updateThread.startRepeating();
 
-      taskQueue = new ArrayBlockingQueue<>(2 * availableModels.size());
+      taskQueue = new ArrayBlockingQueue<>(4);
       taskExecutorThread.setDaemon(true);
       taskExecutorThread.startRepeating();
 

--- a/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/ros2/ROS2SceneGraphTools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/ros2/ROS2SceneGraphTools.java
@@ -96,7 +96,6 @@ public class ROS2SceneGraphTools
          sceneNode = new YOLOv8Node(nodeID,
                                     nodeName,
                                     subscriptionNode.getYOLONodeMessage().getConfidence(),
-                                    subscriptionNode.getYOLONodeMessage().getObjectPointCloud(),
                                     subscriptionNode.getYOLONodeMessage().getCentroidToObjectTransform(),
                                     subscriptionNode.getYOLONodeMessage().getObjectPose(),
                                     crdtInfo);

--- a/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/yolo/YOLOv8Node.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/sceneGraph/yolo/YOLOv8Node.java
@@ -9,8 +9,6 @@ import us.ihmc.euclid.orientation.interfaces.Orientation3DBasics;
 import us.ihmc.euclid.orientation.interfaces.Orientation3DReadOnly;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
-import us.ihmc.euclid.tuple3D.Point3D32;
-import us.ihmc.euclid.tuple3D.interfaces.Point3DReadOnly;
 import us.ihmc.perception.detections.PersistentDetection;
 import us.ihmc.perception.detections.yolo.YOLOv8InstantDetection;
 import us.ihmc.perception.sceneGraph.DetectableSceneNode;
@@ -18,8 +16,6 @@ import us.ihmc.perception.sceneGraph.SceneGraph;
 import us.ihmc.perception.sceneGraph.modification.SceneGraphModificationQueue;
 
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.List;
 
 public class YOLOv8Node extends DetectableSceneNode
 {
@@ -27,7 +23,6 @@ public class YOLOv8Node extends DetectableSceneNode
 
    // PersistentDetection values stored locally for syncing purposes
    private double confidence = 0.0;
-   private List<Point3D32> objectPointCloud = new ArrayList<>();
 
    // YOLOv8Node specific variables
    private final RigidBodyTransform centroidToObjectTransform = new RigidBodyTransform();
@@ -37,14 +32,10 @@ public class YOLOv8Node extends DetectableSceneNode
    /**
     * Constructor used when the node does not have access to the persistent detection (e.g. UI side).
     * All values that would typically come from the persistent detection must be synced separately.
-    *
-    * NOTE: the object point cloud is not deep copied. This means any changes to the data contained in the point cloud will affect
-    * this object.
     */
    public YOLOv8Node(long id,
                      String name,
                      double confidence,
-                     List<Point3D32> objectPointCloud,
                      RigidBodyTransformReadOnly centroidToObjectTransform,
                      Pose3DReadOnly objectPose,
                      CRDTInfo crdtInfo)
@@ -54,7 +45,6 @@ public class YOLOv8Node extends DetectableSceneNode
       this.centroidToObjectTransform.set(centroidToObjectTransform);
       this.objectPose = new Pose3D(objectPose);
       this.confidence = confidence;
-      this.objectPointCloud = objectPointCloud;
       yoloDetection = null;
    }
 
@@ -76,7 +66,6 @@ public class YOLOv8Node extends DetectableSceneNode
       Instant secondsAgo = Instant.now().minusSeconds(1);
       setCurrentlyDetected(mostRecentDetection.getDetectionTime().isAfter(secondsAgo) && yoloDetection.isStable());
       setConfidence(mostRecentDetection.getConfidence());
-      setObjectPointCloud(mostRecentDetection.getObjectPointCloud());
 
       objectPose.set(mostRecentDetection.getPose());
       objectPose.appendTransform(centroidToObjectTransform);
@@ -100,16 +89,6 @@ public class YOLOv8Node extends DetectableSceneNode
       return confidence;
    }
 
-   public List<Point3D32> getObjectPointCloud()
-   {
-      return objectPointCloud;
-   }
-
-   public Point3DReadOnly getObjectPoint(int index)
-   {
-      return objectPointCloud.get(index);
-   }
-
    public Pose3DReadOnly getObjectPose()
    {
       return objectPose;
@@ -118,11 +97,6 @@ public class YOLOv8Node extends DetectableSceneNode
    public void toMessage(YOLOv8NodeMessage message)
    {
       message.setConfidence(getConfidence());
-      message.getObjectPointCloud().clear();
-      for (int i = 0; i < message.getObjectPointCloud().getCurrentCapacity() && i < getObjectPointCloud().size(); ++i)
-      {
-         message.getObjectPointCloud().add().set(getObjectPoint(i));
-      }
       message.getCentroidToObjectTransform().set(getCentroidToObjectTransform());
       message.getObjectPose().set(getObjectPose());
       message.getFilteredObjectPose().set(getObjectPose()); // FIXME Maybe set this to something else?
@@ -131,7 +105,6 @@ public class YOLOv8Node extends DetectableSceneNode
    public void fromMessage(YOLOv8NodeMessage message)
    {
       setConfidence(message.getConfidence());
-      setObjectPointCloud(message.getObjectPointCloud());
       setCentroidToObjectTransform(message.getCentroidToObjectTransform());
       setObjectPose(message.getObjectPose());
    }
@@ -139,11 +112,6 @@ public class YOLOv8Node extends DetectableSceneNode
    public void setConfidence(double confidence)
    {
       this.confidence = confidence;
-   }
-
-   public void setObjectPointCloud(List<Point3D32> objectPointCloud)
-   {
-      this.objectPointCloud = objectPointCloud;
    }
 
    public void setObjectPose(Pose3DReadOnly objectPose)


### PR DESCRIPTION
Comparing YOLO annotated image vs ZED left color image visualizers
Before:
![YOLOBeforeCut](https://github.com/user-attachments/assets/6f70fc8d-fa21-4b08-8833-24a837df1719)

After:
![YOLOAfterCut](https://github.com/user-attachments/assets/1ec55f7a-f29a-4c78-96fb-1ae312e0eac1)

There's still delay but it's significantly reduces. 
