### PR TITLE
Add pelvis trajectory splitting between CoM height and orientation commands

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
@@ -127,6 +127,7 @@ public class RDXTeleoperationManager extends RDXPanel
    private final LogToolsLogger logToolsLogger = new LogToolsLogger();
 
    /** For post-processing WBMPC commands */
+   private final ImBoolean WBCCoMCommandsEnabled = new ImBoolean(false);
    private final FramePoint3D tempCurrentCoMPosition = new FramePoint3D();
    private final FramePoint3D tempDesiredPelvisPosition = new FramePoint3D();
    private final FramePoint3D tempCurrentPelvisPosition = new FramePoint3D();
@@ -268,8 +269,7 @@ public class RDXTeleoperationManager extends RDXPanel
                   {
                      if (!wholeBodyIKManager.getEnabled())
                      {
-                        boolean flag = true;
-                        if (flag)
+                        if (WBCCoMCommandsEnabled.get())
                            processWBMPCCommand();
                         else
                            // Old version
@@ -353,7 +353,7 @@ public class RDXTeleoperationManager extends RDXPanel
          baseUI.getPrimary3DPanel().addImGui3DViewInputProcessor(this::process3DViewInput);
          baseUI.getPrimary3DPanel().addImGuiOverlayAddition(this::renderTooltipsAndContextMenus);
          interactablesEnabled.set(true);
-
+         WBCCoMCommandsEnabled.set(false);
          demoPoses = new RDXHumanoidDemoPoses(robotModel, syncedRobot, ros2Helper, teleoperationParameters);
          addChild(demoPoses);
       }
@@ -606,6 +606,8 @@ public class RDXTeleoperationManager extends RDXPanel
       {
          ImGui.checkbox("Interactables Enabled", interactablesEnabled);
       }
+
+      ImGui.checkbox("WBCoM Commands Enabled", WBCCoMCommandsEnabled);
 
       if (ImGui.collapsingHeader(labels.get("Interactable Selections"), interactableSelections))
       {

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
@@ -21,7 +21,7 @@ import us.ihmc.euclid.referenceFrame.FramePoint3D;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.tuple3D.Point3D;
-import us.ihmc.euclid.referenceFrame.interfaces.FrameQuaternionReadOnly;
+import us.ihmc.euclid.referenceFrame.interfaces.FramePose3DReadOnly;
 import us.ihmc.footstepPlanning.LocomotionParameters;
 import us.ihmc.graphicsDescription.appearance.YoAppearance;
 import us.ihmc.humanoidRobotics.communication.packets.HumanoidMessageTools;
@@ -484,7 +484,8 @@ public class RDXTeleoperationManager extends RDXPanel
    private void processWBMPCCommand()
    {
       // Get the current and desired poses for comparison
-      FrameQuaternionReadOnly desiredOrientation = interactablePelvis.getPose().getOrientation();
+
+      FramePose3DReadOnly desiredOrientation = interactablePelvis.getPose();
 
       // Get the current Center of Mass height in MidFeetZUpFrame
       FramePoint3D currentCoMPosition = new FramePoint3D(syncedRobot.getReferenceFrames().getCenterOfMassFrame());
@@ -522,8 +523,8 @@ public class RDXTeleoperationManager extends RDXPanel
       else
       {
          // Send orientation-only trajectory for other movements
-         RDXBaseUI.pushNotification("Commanding pelvis orientation trajectory...");
-         ros2Helper.publishToController(HumanoidMessageTools.createPelvisOrientationTrajectoryMessage(
+         RDXBaseUI.pushNotification("Commanding pelvis trajectory...");
+         ros2Helper.publishToController(HumanoidMessageTools.createPelvisTrajectoryMessage(
                teleoperationParameters.getTrajectoryTime(),
                desiredOrientation));
       }

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
@@ -7,7 +7,6 @@ import imgui.ImGui;
 import imgui.flag.ImGuiInputTextFlags;
 import imgui.type.ImBoolean;
 import imgui.type.ImString;
-import org.jfree.util.Log;
 import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.ROS2SyncedRobotModel;
 import us.ihmc.avatar.ros2.ROS2ControllerHelper;
@@ -25,7 +24,6 @@ import us.ihmc.euclid.referenceFrame.interfaces.FramePose3DReadOnly;
 import us.ihmc.footstepPlanning.LocomotionParameters;
 import us.ihmc.graphicsDescription.appearance.YoAppearance;
 import us.ihmc.humanoidRobotics.communication.packets.HumanoidMessageTools;
-import us.ihmc.log.LogTools;
 import us.ihmc.rdx.imgui.ImGuiTools;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
 import us.ihmc.rdx.imgui.RDXPanel;
@@ -127,7 +125,7 @@ public class RDXTeleoperationManager extends RDXPanel
    private final LogToolsLogger logToolsLogger = new LogToolsLogger();
 
    /** For post-processing WBMPC commands */
-   private final ImBoolean WBCCoMCommandsEnabled = new ImBoolean(false);
+   private final ImBoolean CoMDirectControlEnabled = new ImBoolean(false);
    private final FramePoint3D tempCurrentCoMPosition = new FramePoint3D();
    private final FramePoint3D tempDesiredPelvisPosition = new FramePoint3D();
    private final FramePoint3D tempCurrentPelvisPosition = new FramePoint3D();
@@ -269,11 +267,10 @@ public class RDXTeleoperationManager extends RDXPanel
                   {
                      if (!wholeBodyIKManager.getEnabled())
                      {
-                        if (WBCCoMCommandsEnabled.get())
-                           processWBMPCCommand();
+                        if (CoMDirectControlEnabled.get())
+                           processCoMDirectCommand();
                         else
-                           // Old version
-                           processIKStreamingCommand();
+                           processPelvis6DCommand();
                      }
                   });
                   allInteractableRobotLinks.add(interactablePelvis);
@@ -353,7 +350,7 @@ public class RDXTeleoperationManager extends RDXPanel
          baseUI.getPrimary3DPanel().addImGui3DViewInputProcessor(this::process3DViewInput);
          baseUI.getPrimary3DPanel().addImGuiOverlayAddition(this::renderTooltipsAndContextMenus);
          interactablesEnabled.set(true);
-         WBCCoMCommandsEnabled.set(false);
+         CoMDirectControlEnabled.set(false);
          demoPoses = new RDXHumanoidDemoPoses(robotModel, syncedRobot, ros2Helper, teleoperationParameters);
          addChild(demoPoses);
       }
@@ -492,7 +489,7 @@ public class RDXTeleoperationManager extends RDXPanel
     *  displacements in the other directions
     * @comment: Investigate which cases causes it to freak out
     */
-   private void processWBMPCCommand()
+   private void processCoMDirectCommand()
    {
       FramePose3DReadOnly desiredOrientation = interactablePelvis.getPose();
 
@@ -529,7 +526,7 @@ public class RDXTeleoperationManager extends RDXPanel
       }
    }
 
-   private void processIKStreamingCommand()
+   private void processPelvis6DCommand()
    {
       RDXBaseUI.pushNotification("Commanding pelvis  trajectory...");
       ros2Helper.publishToController(HumanoidMessageTools.createPelvisTrajectoryMessage(
@@ -607,7 +604,7 @@ public class RDXTeleoperationManager extends RDXPanel
          ImGui.checkbox("Interactables Enabled", interactablesEnabled);
       }
 
-      ImGui.checkbox("WBCoM Commands Enabled", WBCCoMCommandsEnabled);
+      ImGui.checkbox("CoM Direct Commands Enabled", CoMDirectControlEnabled);
 
       if (ImGui.collapsingHeader(labels.get("Interactable Selections"), interactableSelections))
       {

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
@@ -126,6 +126,12 @@ public class RDXTeleoperationManager extends RDXPanel
    private final ControllerStatusTracker controllerStatusTracker;
    private final LogToolsLogger logToolsLogger = new LogToolsLogger();
 
+   /** For post-processing WBMPC commands */
+   private final FramePoint3D tempCurrentCoMPosition = new FramePoint3D();
+   private final FramePoint3D tempDesiredPelvisPosition = new FramePoint3D();
+   private final FramePoint3D tempCurrentPelvisPosition = new FramePoint3D();
+   private static final double HEIGHT_TOLERANCE = 0.01;
+
    /**
     * For use without interactables available. May crash if a YoVariableClient is needed.
     */
@@ -266,10 +272,8 @@ public class RDXTeleoperationManager extends RDXPanel
                         if (flag)
                            processWBMPCCommand();
                         else
-                           RDXBaseUI.pushNotification("Commanding pelvis  trajectory...");
-                           ros2Helper.publishToController(HumanoidMessageTools.createPelvisTrajectoryMessage(
-                                 teleoperationParameters.getTrajectoryTime(),
-                                 interactablePelvis.getPose()));
+                           // Old version
+                           processIKStreamingCommand();
                      }
                   });
                   allInteractableRobotLinks.add(interactablePelvis);
@@ -481,44 +485,39 @@ public class RDXTeleoperationManager extends RDXPanel
       }
    }
 
+   /**
+    * Function that routes the corresponding height displacement as CoM Trajectory Command, and the orientation
+    * as a Pelvis Trajectory Command
+    * @comment: For now, it can only process z displacements, it will be easy to extend it's funcionality for
+    *  displacements in the other directions
+    * @comment: Investigate which cases causes it to freak out
+    */
    private void processWBMPCCommand()
    {
-      // Get the current and desired poses for comparison
-
       FramePose3DReadOnly desiredOrientation = interactablePelvis.getPose();
 
-      // Get the current Center of Mass height in MidFeetZUpFrame
-      FramePoint3D currentCoMPosition = new FramePoint3D(syncedRobot.getReferenceFrames().getCenterOfMassFrame());
-      currentCoMPosition.changeFrame(syncedRobot.getReferenceFrames().getMidFeetZUpFrame());
+      // Get all positions in world frame
+      tempCurrentCoMPosition.setToZero(syncedRobot.getReferenceFrames().getCenterOfMassFrame());
+      tempCurrentCoMPosition.changeFrame(syncedRobot.getReferenceFrames().getWorldFrame());
 
-      // Get the desired pelvis height in MidFeetZUpFrame
-      FramePoint3D desiredPelvisPosition = new FramePoint3D();
-      desiredPelvisPosition.setIncludingFrame(interactablePelvis.getPose().getPosition());
-      desiredPelvisPosition.changeFrame(syncedRobot.getReferenceFrames().getMidFeetZUpFrame());
+      tempDesiredPelvisPosition.setIncludingFrame(desiredOrientation.getPosition());
+      tempDesiredPelvisPosition.changeFrame(syncedRobot.getReferenceFrames().getWorldFrame());
 
-      // Calculate the actual offset between current CoM and current pelvis
-      FramePoint3D currentPelvisPosition = new FramePoint3D(syncedRobot.getReferenceFrames().getPelvisFrame());
-      currentPelvisPosition.changeFrame(syncedRobot.getReferenceFrames().getMidFeetZUpFrame());
+      tempCurrentPelvisPosition.setToZero(syncedRobot.getReferenceFrames().getPelvisFrame());
+      tempCurrentPelvisPosition.changeFrame(syncedRobot.getReferenceFrames().getWorldFrame());
 
-      double currentComToPelvisOffset = currentCoMPosition.getZ() - currentPelvisPosition.getZ();
-      double desiredCoMHeight = desiredPelvisPosition.getZ() + currentComToPelvisOffset;
+      // Calculate desired CoM height maintaining current offset
+      double currentComToPelvisOffset = tempCurrentCoMPosition.getZ() - tempCurrentPelvisPosition.getZ();
+      double desiredCoMHeight = tempDesiredPelvisPosition.getZ() + currentComToPelvisOffset;
+      double deltaZ = Math.abs(desiredCoMHeight - tempCurrentCoMPosition.getZ());
 
-      // Calculate Z displacement only
-      double deltaZ = Math.abs(desiredCoMHeight - currentCoMPosition.getZ());
-
-      // Tolerance for height movement
-      double heightTolerance = 0.01; // 1cm tolerance
-
-      LogTools.info("Current CoM height: {}, Desired CoM height: {}, Delta: {}",
-                    currentCoMPosition.getZ(), desiredCoMHeight, deltaZ);
-
-      if (deltaZ > heightTolerance)
+      if (deltaZ > HEIGHT_TOLERANCE)
       {
          // Send center of mass height trajectory
-         RDXBaseUI.pushNotification("Commanding center of mass height trajectory...");
+         RDXBaseUI.pushNotification("Commanding CoM height trajectory...");
          ros2Helper.publishToController(HumanoidMessageTools.createCenterOfMassTrajectoryMessage(
-               2*teleoperationParameters.getTrajectoryTime(),
-               new Point3D(0.0, 0.0, desiredCoMHeight)));
+               teleoperationParameters.getTrajectoryTime(),
+               new Point3D(tempCurrentCoMPosition.getX(), tempCurrentCoMPosition.getY(), desiredCoMHeight)));
       }
       else
       {
@@ -528,6 +527,14 @@ public class RDXTeleoperationManager extends RDXPanel
                teleoperationParameters.getTrajectoryTime(),
                desiredOrientation));
       }
+   }
+
+   private void processIKStreamingCommand()
+   {
+      RDXBaseUI.pushNotification("Commanding pelvis  trajectory...");
+      ros2Helper.publishToController(HumanoidMessageTools.createPelvisTrajectoryMessage(
+            teleoperationParameters.getTrajectoryTime(),
+            interactablePelvis.getPose()));
    }
 
    private void calculate3DViewPick(ImGui3DViewInput input)

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
@@ -20,9 +20,8 @@ import us.ihmc.commons.FormattingTools;
 import us.ihmc.euclid.referenceFrame.FramePoint3D;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
-import us.ihmc.euclid.referenceFrame.interfaces.FramePoint3DReadOnly;
+import us.ihmc.euclid.tuple3D.Point3D;
 import us.ihmc.euclid.referenceFrame.interfaces.FrameQuaternionReadOnly;
-import us.ihmc.euclid.tuple3D.interfaces.Vector3DBasics;
 import us.ihmc.footstepPlanning.LocomotionParameters;
 import us.ihmc.graphicsDescription.appearance.YoAppearance;
 import us.ihmc.humanoidRobotics.communication.packets.HumanoidMessageTools;
@@ -485,26 +484,40 @@ public class RDXTeleoperationManager extends RDXPanel
    private void processWBMPCCommand()
    {
       // Get the current and desired poses for comparison
-      double xyTolerance = 0.01; // 1cm tolerance for x,y movement
-      Vector3DBasics currentPosition = syncedRobot.getReferenceFrames().getPelvisFrame().getTransformToWorldFrame().getTranslation();
-      FramePoint3DReadOnly desiredPosition = interactablePelvis.getPose().getPosition();
       FrameQuaternionReadOnly desiredOrientation = interactablePelvis.getPose().getOrientation();
 
-      LogTools.info("This is the current position vector of the robot in the WF: {}", desiredPosition);
-      LogTools.info("This is the current desired position vector in the WF: {}", currentPosition );
+      // Get the current Center of Mass height in MidFeetZUpFrame
+      FramePoint3D currentCoMPosition = new FramePoint3D(syncedRobot.getReferenceFrames().getCenterOfMassFrame());
+      currentCoMPosition.changeFrame(syncedRobot.getReferenceFrames().getMidFeetZUpFrame());
 
-      // @TODO: preallocate these variables - Calculate position difference
-      double deltaZ = Math.abs(desiredPosition.getZ() - currentPosition.getZ());
-      // Define tolerance for considering movement as "z-only"
+      // Get the desired pelvis height in MidFeetZUpFrame
+      FramePoint3D desiredPelvisPosition = new FramePoint3D();
+      desiredPelvisPosition.setIncludingFrame(interactablePelvis.getPose().getPosition());
+      desiredPelvisPosition.changeFrame(syncedRobot.getReferenceFrames().getMidFeetZUpFrame());
 
-      boolean isZOnlyMovement = (deltaZ > xyTolerance);
-      if (isZOnlyMovement)
+      // Calculate the actual offset between current CoM and current pelvis
+      FramePoint3D currentPelvisPosition = new FramePoint3D(syncedRobot.getReferenceFrames().getPelvisFrame());
+      currentPelvisPosition.changeFrame(syncedRobot.getReferenceFrames().getMidFeetZUpFrame());
+
+      double currentComToPelvisOffset = currentCoMPosition.getZ() - currentPelvisPosition.getZ();
+      double desiredCoMHeight = desiredPelvisPosition.getZ() + currentComToPelvisOffset;
+
+      // Calculate Z displacement only
+      double deltaZ = Math.abs(desiredCoMHeight - currentCoMPosition.getZ());
+
+      // Tolerance for height movement
+      double heightTolerance = 0.01; // 1cm tolerance
+
+      LogTools.info("Current CoM height: {}, Desired CoM height: {}, Delta: {}",
+                    currentCoMPosition.getZ(), desiredCoMHeight, deltaZ);
+
+      if (deltaZ > heightTolerance)
       {
-         // Send center of mass trajectory for z-only movement
-         RDXBaseUI.pushNotification("Commanding center of mass trajectory...");
+         // Send center of mass height trajectory
+         RDXBaseUI.pushNotification("Commanding center of mass height trajectory...");
          ros2Helper.publishToController(HumanoidMessageTools.createCenterOfMassTrajectoryMessage(
                teleoperationParameters.getTrajectoryTime(),
-               desiredPosition));
+               new Point3D(0.0, 0.0, desiredCoMHeight)));
       }
       else
       {

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
@@ -516,7 +516,7 @@ public class RDXTeleoperationManager extends RDXPanel
          // Send center of mass height trajectory
          RDXBaseUI.pushNotification("Commanding center of mass height trajectory...");
          ros2Helper.publishToController(HumanoidMessageTools.createCenterOfMassTrajectoryMessage(
-               teleoperationParameters.getTrajectoryTime(),
+               2*teleoperationParameters.getTrajectoryTime(),
                new Point3D(0.0, 0.0, desiredCoMHeight)));
       }
       else

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/teleoperation/RDXTeleoperationManager.java
@@ -7,6 +7,7 @@ import imgui.ImGui;
 import imgui.flag.ImGuiInputTextFlags;
 import imgui.type.ImBoolean;
 import imgui.type.ImString;
+import org.jfree.util.Log;
 import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.drcRobot.ROS2SyncedRobotModel;
 import us.ihmc.avatar.ros2.ROS2ControllerHelper;
@@ -16,11 +17,16 @@ import us.ihmc.behaviors.tools.interfaces.LogToolsLogger;
 import us.ihmc.behaviors.tools.walkingController.ControllerStatusTracker;
 import us.ihmc.behaviors.tools.yo.YoVariableClientHelper;
 import us.ihmc.commons.FormattingTools;
+import us.ihmc.euclid.referenceFrame.FramePoint3D;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
+import us.ihmc.euclid.referenceFrame.interfaces.FramePoint3DReadOnly;
+import us.ihmc.euclid.referenceFrame.interfaces.FrameQuaternionReadOnly;
+import us.ihmc.euclid.tuple3D.interfaces.Vector3DBasics;
 import us.ihmc.footstepPlanning.LocomotionParameters;
 import us.ihmc.graphicsDescription.appearance.YoAppearance;
 import us.ihmc.humanoidRobotics.communication.packets.HumanoidMessageTools;
+import us.ihmc.log.LogTools;
 import us.ihmc.rdx.imgui.ImGuiTools;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
 import us.ihmc.rdx.imgui.RDXPanel;
@@ -257,9 +263,14 @@ public class RDXTeleoperationManager extends RDXPanel
                   {
                      if (!wholeBodyIKManager.getEnabled())
                      {
-                      RDXBaseUI.pushNotification("Commanding pelvis trajectory...");
-                      ros2Helper.publishToController(HumanoidMessageTools.createPelvisTrajectoryMessage(teleoperationParameters.getTrajectoryTime(),
-                                                                                                        interactablePelvis.getPose()));
+                        boolean flag = true;
+                        if (flag)
+                           processWBMPCCommand();
+                        else
+                           RDXBaseUI.pushNotification("Commanding pelvis  trajectory...");
+                           ros2Helper.publishToController(HumanoidMessageTools.createPelvisTrajectoryMessage(
+                                 teleoperationParameters.getTrajectoryTime(),
+                                 interactablePelvis.getPose()));
                      }
                   });
                   allInteractableRobotLinks.add(interactablePelvis);
@@ -468,6 +479,40 @@ public class RDXTeleoperationManager extends RDXPanel
 
          for (RDXInteractableRobotLink robotPartInteractable : allInteractableRobotLinks)
             robotPartInteractable.processVRInput(vrContext);
+      }
+   }
+
+   private void processWBMPCCommand()
+   {
+      // Get the current and desired poses for comparison
+      double xyTolerance = 0.01; // 1cm tolerance for x,y movement
+      Vector3DBasics currentPosition = syncedRobot.getReferenceFrames().getPelvisFrame().getTransformToWorldFrame().getTranslation();
+      FramePoint3DReadOnly desiredPosition = interactablePelvis.getPose().getPosition();
+      FrameQuaternionReadOnly desiredOrientation = interactablePelvis.getPose().getOrientation();
+
+      LogTools.info("This is the current position vector of the robot in the WF: {}", desiredPosition);
+      LogTools.info("This is the current desired position vector in the WF: {}", currentPosition );
+
+      // @TODO: preallocate these variables - Calculate position difference
+      double deltaZ = Math.abs(desiredPosition.getZ() - currentPosition.getZ());
+      // Define tolerance for considering movement as "z-only"
+
+      boolean isZOnlyMovement = (deltaZ > xyTolerance);
+      if (isZOnlyMovement)
+      {
+         // Send center of mass trajectory for z-only movement
+         RDXBaseUI.pushNotification("Commanding center of mass trajectory...");
+         ros2Helper.publishToController(HumanoidMessageTools.createCenterOfMassTrajectoryMessage(
+               teleoperationParameters.getTrajectoryTime(),
+               desiredPosition));
+      }
+      else
+      {
+         // Send orientation-only trajectory for other movements
+         RDXBaseUI.pushNotification("Commanding pelvis orientation trajectory...");
+         ros2Helper.publishToController(HumanoidMessageTools.createPelvisOrientationTrajectoryMessage(
+               teleoperationParameters.getTrajectoryTime(),
+               desiredOrientation));
       }
    }
 

--- a/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/packets/HumanoidMessageTools.java
+++ b/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/packets/HumanoidMessageTools.java
@@ -19,6 +19,7 @@ import controller_msgs.msg.dds.ArmDesiredAccelerationsMessage;
 import controller_msgs.msg.dds.ArmTrajectoryMessage;
 import controller_msgs.msg.dds.AutomaticManipulationAbortMessage;
 import controller_msgs.msg.dds.CapturabilityBasedStatus;
+import controller_msgs.msg.dds.CenterOfMassTrajectoryMessage;
 import controller_msgs.msg.dds.ChestHybridJointspaceTaskspaceTrajectoryMessage;
 import controller_msgs.msg.dds.ChestTrajectoryMessage;
 import controller_msgs.msg.dds.ClearDelayQueueMessage;
@@ -2196,6 +2197,37 @@ public class HumanoidMessageTools
          message.getWayPointTimes().add(keyFrameTimes.get(i));
          message.getDesiredWayPointPositionsInWorld().add().set(keyFramePoints.get(i));
       }
+      return message;
+   }
+
+   /**
+    * Use this constructor to execute a straight line trajectory for center of mass.
+    * Set the id of the message to {@link Packet#VALID_MESSAGE_DEFAULT_ID}.
+    *
+    * @param trajectoryTime     how long it takes to reach the desired position.
+    * @param desiredPosition    desired center of mass position expressed in world frame.
+    */
+   public static CenterOfMassTrajectoryMessage createCenterOfMassTrajectoryMessage(double trajectoryTime, Point3DReadOnly desiredPosition)
+   {
+      CenterOfMassTrajectoryMessage message = new CenterOfMassTrajectoryMessage();
+      message.getEuclideanTrajectory().set(createEuclideanTrajectoryMessage(trajectoryTime, desiredPosition, ReferenceFrame.getWorldFrame()));
+      return message;
+   }
+
+   /**
+    * Use this constructor to execute a straight line trajectory for center of mass with velocity.
+    * Set the id of the message to {@link Packet#VALID_MESSAGE_DEFAULT_ID}.
+    *
+    * @param trajectoryTime         how long it takes to reach the desired position.
+    * @param desiredPosition        desired center of mass position expressed in world frame.
+    * @param desiredLinearVelocity  desired linear velocity at the end of the trajectory.
+    */
+   public static CenterOfMassTrajectoryMessage createCenterOfMassTrajectoryMessage(double trajectoryTime,
+                                                                                   Point3DReadOnly desiredPosition,
+                                                                                   Vector3DReadOnly desiredLinearVelocity)
+   {
+      CenterOfMassTrajectoryMessage message = new CenterOfMassTrajectoryMessage();
+      message.getEuclideanTrajectory().set(createEuclideanTrajectoryMessage(trajectoryTime, desiredPosition, desiredLinearVelocity, ReferenceFrame.getWorldFrame()));
       return message;
    }
 

--- a/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/packets/HumanoidMessageTools.java
+++ b/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/packets/HumanoidMessageTools.java
@@ -2200,13 +2200,6 @@ public class HumanoidMessageTools
       return message;
    }
 
-   /**
-    * Use this constructor to execute a straight line trajectory for center of mass.
-    * Set the id of the message to {@link Packet#VALID_MESSAGE_DEFAULT_ID}.
-    *
-    * @param trajectoryTime     how long it takes to reach the desired position.
-    * @param desiredPosition    desired center of mass position expressed in world frame.
-    */
    public static CenterOfMassTrajectoryMessage createCenterOfMassTrajectoryMessage(double trajectoryTime, Point3DReadOnly desiredPosition)
    {
       CenterOfMassTrajectoryMessage message = new CenterOfMassTrajectoryMessage();


### PR DESCRIPTION
This PR adds functionality to automatically route pelvis gizmo interactions to the appropriate command type based on the movement being performed. It will be mainly used for WBMPC commands

**What Changed:**
- Added logic to detect when pelvis movements are primarily height adjustments vs orientation changes, when using the Gizmo.
- Height movements now send Center of Mass trajectory commands that preserve current x,y position
- Orientation movements continue to use standard pelvis trajectory commands
- **Feature is currently disabled by default** and can be enabled in the interface.

**Implementation Details:**
- New processWBMPCCommand() method handles the command routing logic
- Pre-allocated frame objects for better performance
- Calculates and maintains the natural CoM-to-pelvis offset during height changes
- Transforms all calculations to world frame for consistency

**Notes:**
- Tested with Nadia robot simulation