### PR TITLE
Setting 2d footstep pose in CSG prior to adjustment calls

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/wholeBodyHardwareControl/AvatarMultiThreadingFactory.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/wholeBodyHardwareControl/AvatarMultiThreadingFactory.java
@@ -430,9 +430,8 @@ public class AvatarMultiThreadingFactory
 
       LogTools.info("create step generator = " + createStepGeneratorThread);
 
-//      HumanoidSteppingPluginEnvironmentalConstraints environmentalConstraints = new HumanoidSteppingPluginEnvironmentalConstraints(robotModel.getContactPointParameters(),
-//                                                                                                                                   robotModel.getWalkingControllerParameters().getSteppingParameters());
-      HumanoidSteppingPluginEnvironmentalConstraints environmentalConstraints = null; //TODO fix the yawing issue with environmental constraints
+      HumanoidSteppingPluginEnvironmentalConstraints environmentalConstraints = new HumanoidSteppingPluginEnvironmentalConstraints(robotModel.getContactPointParameters(),
+                                                                                                                                   robotModel.getWalkingControllerParameters().getSteppingParameters());
       controllerFactory.setListenToHighLevelStatePackets(true);
 
       JoystickBasedSteppingPluginFactory pluginFactory = new JoystickBasedSteppingPluginFactory();

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/desiredFootStep/footstepGenerator/ContinuousStepGenerator.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/desiredFootStep/footstepGenerator/ContinuousStepGenerator.java
@@ -405,6 +405,9 @@ public class ContinuousStepGenerator implements Updatable, SCS2YoGraphicHolder
          nextFootstepPose3D.set(nextFootstepPose2D);
          FootstepDataMessage footstep = footsteps.add();
 
+         footstep.getLocation().set(nextFootstepPose2D.getPosition());
+         footstep.getOrientation().set(nextFootstepPose2D.getOrientation());
+
          for (int adjustorIndex = 0; adjustorIndex < footstepAdjustments.size(); adjustorIndex++)
             footstepAdjustments.get(adjustorIndex).adjustFootstep(currentSupportFootPose, nextFootstepPose2D, swingSide, footstep);
 


### PR DESCRIPTION
The CSG was using footstep adjustments to set the position and yaw. Now setting the position and yaw directly and only using the adjustment to set position Z, pitch and roll.

![CSG_Adjustment_bugfix](https://github.com/user-attachments/assets/6a032299-fcb9-4d86-bdc1-2d127a230b1b)
