### PR TITLE
Change the height map to run through the entire depth image as threads rather then each cell on the height map

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.java
@@ -41,6 +41,10 @@ public class RapidHeightMapExtractor
    private final dim3 blockSize;
 
    // These are the mats required to extract the depth data
+   private final GpuMat tempSumMap;
+   private final GpuMat tempCountMap;
+   private final GpuMat tempSumOfSquaresMap;
+   private final GpuMat tempMotionVarianceMap;
    private final GpuMat localMeanMap;
    private final GpuMat localVarianceMap;
    private final GpuMat localMotionVarianceMap;
@@ -53,7 +57,8 @@ public class RapidHeightMapExtractor
    private final GpuMat terrainCroppedHeightMap;
    private final GpuMat emptyGlobalHeightMap;
 
-   private final CUDAKernel updateKernel;
+   private final CUDAKernel updateTempMapsKernel;
+   private final CUDAKernel localMapKernel;
    private final CUDAKernel translateKernel;
    private final CUDAKernel registerKernel;
    private final CUDAKernel terrainCroppingKernel;
@@ -103,19 +108,26 @@ public class RapidHeightMapExtractor
       {
          heightMapProgram = new CUDAProgram(kernelPath, heightMapUtilsHeaderPath, mathUtilsHeaderPath);
 
-         updateKernel = heightMapProgram.loadKernel("heightMapUpdateKernel");
+         updateTempMapsKernel = heightMapProgram.loadKernel("heightMapUpdateDataKernel");
+         localMapKernel = heightMapProgram.loadKernel("computeLocalMap");
          translateKernel = heightMapProgram.loadKernel("translateHeightMapKernel");
          registerKernel = heightMapProgram.loadKernel("heightMapRegistrationKernel");
          terrainCroppingKernel = heightMapProgram.loadKernel("terrainCroppingHeightMapKernel");
          planOffsetKernel = heightMapProgram.loadKernel("planOffsetKernel");
          emptyRegisterKernel = heightMapProgram.loadKernel("heightMapEmptyRegistrationKernel");
 
-         updateKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
+         updateTempMapsKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
+         localMapKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
          translateKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
          registerKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
          terrainCroppingKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
          planOffsetKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
          emptyRegisterKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
+
+         tempSumMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
+         tempCountMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
+         tempSumOfSquaresMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
+         tempMotionVarianceMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
 
          // Initialize matrices and images
          localMeanMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
@@ -235,25 +247,43 @@ public class RapidHeightMapExtractor
          CUDATools.mallocAsync(groundToSensorTransformDevicePointer, groundToSensorTransformArray.length, stream);
          CUDATools.memcpyAsync(groundToSensorTransformDevicePointer, groundToSensorTransformHostPointer, groundToSensorTransformArray.length, stream);
 
+         int gridDimX = (latestDepthImageGPU.cols() + BLOCK_SIZE_XY - 1) / BLOCK_SIZE_XY;
+         int gridDimY = (latestDepthImageGPU.rows() + BLOCK_SIZE_XY - 1) / BLOCK_SIZE_XY;
+         dim3 scatterGridDim = new dim3(gridDimX, gridDimY, 1);
+
+         updateTempMapsKernel.withPointer(latestDepthImageGPU.data()).withLong(latestDepthImageGPU.step());
+         updateTempMapsKernel.withPointer(tempSumMap.data()).withLong(tempSumMap.step());
+         updateTempMapsKernel.withPointer(tempCountMap.data()).withLong(tempCountMap.step());
+         updateTempMapsKernel.withPointer(tempSumOfSquaresMap.data()).withLong(tempSumOfSquaresMap.step());
+         updateTempMapsKernel.withPointer(tempMotionVarianceMap.data()).withLong(tempMotionVarianceMap.step());
+         updateTempMapsKernel.withPointer(parametersDevicePointer);
+         updateTempMapsKernel.withPointer(sensorToGroundTransformDevicePointer);
+         updateTempMapsKernel.withFloat(linearMotionMagnitude);
+         updateTempMapsKernel.withFloat(angularMotionMagnitude);
+
+         // CLEARING ALL THE DATA FOR THE NEXT UPDAT e
+         cudaMemset2D(tempSumMap.data(), tempSumMap.step(), 0, (long) tempSumMap.cols() * Float.BYTES, tempSumMap.rows());
+         cudaMemset2D(tempCountMap.data(), tempCountMap.step(), 0, (long) tempCountMap.cols() * Float.BYTES, tempCountMap.rows());
+         cudaMemset2D(tempSumOfSquaresMap.data(), tempSumOfSquaresMap.step(), 0, (long) tempSumOfSquaresMap.cols() * Float.BYTES, tempSumOfSquaresMap.rows());
+         cudaMemset2D(tempMotionVarianceMap.data(), tempMotionVarianceMap.step(), 0, (long) tempMotionVarianceMap.cols() * Float.BYTES, tempMotionVarianceMap.rows());
+
+         updateTempMapsKernel.run(stream, scatterGridDim, blockSize, 0);
+
+         localMapKernel.withPointer(tempSumMap.data()).withLong(tempSumMap.step());
+         localMapKernel.withPointer(tempCountMap.data()).withLong(tempCountMap.step());
+         localMapKernel.withPointer(tempSumOfSquaresMap.data()).withLong(tempSumOfSquaresMap.step());
+         localMapKernel.withPointer(tempMotionVarianceMap.data()).withLong(tempMotionVarianceMap.step());
+         localMapKernel.withPointer(localMeanMap.data()).withLong(localMeanMap.step());
+         localMapKernel.withPointer(localVarianceMap.data()).withLong(localVarianceMap.step());
+         localMapKernel.withPointer(localMotionVarianceMap.data()).withLong(localMotionVarianceMap.step());
+         localMapKernel.withPointer(parametersDevicePointer);
+
          int updateKernelGridSizeXY = (cellsPerAxisLocal + BLOCK_SIZE_XY - 1) / BLOCK_SIZE_XY;
-         dim3 updateKernelGridDim = new dim3(updateKernelGridSizeXY, updateKernelGridSizeXY, 1);
+         dim3 whattttttttt = new dim3(updateKernelGridSizeXY, updateKernelGridSizeXY, 1);
 
-         updateKernel.withPointer(latestDepthImageGPU.data()).withLong(latestDepthImageGPU.step());
-         updateKernel.withPointer(globalMeanMap.data()).withLong(globalMeanMap.step());
-         updateKernel.withPointer(localMeanMap.data()).withLong(localMeanMap.step());
-         updateKernel.withPointer(localVarianceMap.data()).withLong(localVarianceMap.step());
-         updateKernel.withPointer(localMotionVarianceMap.data()).withLong(localMotionVarianceMap.step());
-         updateKernel.withPointer(parametersDevicePointer);
-         updateKernel.withPointer(sensorToGroundTransformDevicePointer);
-         updateKernel.withPointer(groundToSensorTransformDevicePointer);
-         updateKernel.withPointer(zUpCameraToWorldAlignedGroundDevicePointer);
-         updateKernel.withFloat(linearMotionMagnitude);
-         updateKernel.withFloat(angularMotionMagnitude);
-         updateKernel.withFloat(resetOffset);
+         localMapKernel.run(stream, whattttttttt, blockSize, 0);
 
-         updateKernel.run(stream, updateKernelGridDim, blockSize, 0);
-
-         updateKernelGridDim.close();
+         //         updateKernelGridDim.close();
          cudaFreeAsync(sensorToGroundTransformDevicePointer, stream);
          cudaFreeAsync(groundToSensorTransformDevicePointer, stream);
          checkCUDAError();
@@ -453,7 +483,7 @@ public class RapidHeightMapExtractor
       heightMapProgram.close();
       blockSize.close();
 
-      updateKernel.close();
+      updateTempMapsKernel.close();
       translateKernel.close();
       registerKernel.close();
       terrainCroppingKernel.close();

--- a/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.java
@@ -122,7 +122,7 @@ public class RapidHeightMapExtractor
          emptyRegisterKernel.enableKernelTimings(PRINT_TIMING_FOR_KERNELS);
 
          tempSumMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
-         tempCountMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
+         tempCountMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32SC1);
          tempSumOfSquaresMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
          tempMotionVarianceMap = new GpuMat(cellsPerAxisLocal, cellsPerAxisLocal, opencv_core.CV_32FC1);
 
@@ -234,10 +234,10 @@ public class RapidHeightMapExtractor
          CUDATools.memcpyAsync(sensorToGroundTransformDevicePointer, sensorToGroundTransformHostPointer, sensorToGroundTransformArray.length, stream);
 
          // Clearing all the temp maps so they are ready for the next update call
-         cudaMemset2D(tempSumMap.data(), tempSumMap.step(), 0, (long) tempSumMap.cols() * Float.BYTES, tempSumMap.rows());
-         cudaMemset2D(tempCountMap.data(), tempCountMap.step(), 0, (long) tempCountMap.cols() * Float.BYTES, tempCountMap.rows());
-         cudaMemset2D(tempSumOfSquaresMap.data(), tempSumOfSquaresMap.step(), 0, (long) tempSumOfSquaresMap.cols() * Float.BYTES, tempSumOfSquaresMap.rows());
-         cudaMemset2D(tempMotionVarianceMap.data(),
+         cudaMemset2DAsync(tempSumMap.data(), tempSumMap.step(), 0, (long) tempSumMap.cols() * Float.BYTES, tempSumMap.rows());
+         cudaMemset2DAsync(tempCountMap.data(), tempCountMap.step(), 0, (long) tempCountMap.cols() * Integer.BYTES, tempCountMap.rows());
+         cudaMemset2DAsync(tempSumOfSquaresMap.data(), tempSumOfSquaresMap.step(), 0, (long) tempSumOfSquaresMap.cols() * Float.BYTES, tempSumOfSquaresMap.rows());
+         cudaMemset2DAsync(tempMotionVarianceMap.data(),
                       tempMotionVarianceMap.step(),
                       0,
                       (long) tempMotionVarianceMap.cols() * Float.BYTES,

--- a/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.java
@@ -66,11 +66,8 @@ public class RapidHeightMapExtractor
    private final CUDAKernel emptyRegisterKernel;
 
    private final float[] worldToGroundTransformArray = new float[16];
-   private final float[] groundToSensorTransformArray = new float[16];
    private final float[] sensorToGroundTransformArray = new float[16];
 
-   private final FloatPointer groundToSensorTransformHostPointer;
-   private final FloatPointer groundToSensorTransformDevicePointer;
    private final FloatPointer sensorToGroundTransformHostPointer;
    private final FloatPointer sensorToGroundTransformDevicePointer;
    private final FloatPointer zUpCameraToWorldAlignedGroundHostPointer;
@@ -142,9 +139,6 @@ public class RapidHeightMapExtractor
          emptyGlobalHeightMap = new GpuMat(cellsPerAxisGlobal, cellsPerAxisGlobal, opencv_core.CV_16UC1);
 
          // Initialize transformation pointers
-         groundToSensorTransformHostPointer = new FloatPointer(16);
-         groundToSensorTransformDevicePointer = new FloatPointer();
-
          sensorToGroundTransformHostPointer = new FloatPointer(16);
          sensorToGroundTransformDevicePointer = new FloatPointer();
 
@@ -220,7 +214,7 @@ public class RapidHeightMapExtractor
       CUDATools.memcpyAsync(zUpCameraToWorldAlignedGroundDevicePointer, zUpCameraToWorldAlignedGroundHostPointer, worldToGroundTransformArray.length, stream);
       checkCUDAError();
 
-      // --------- Run the update kernel ---------
+      // --------- Run the temp and local kernel ---------
       {
          // Compute "speed" of the point
          RigidBodyTransform previousToCurrentSensorOrigin = new RigidBodyTransform(previousSensorToWorld);
@@ -234,22 +228,24 @@ public class RapidHeightMapExtractor
          AxisAngle axisAngle = new AxisAngle(rotation);
          float angularMotionMagnitude = (float) Math.abs(axisAngle.getAngle());
 
-         RigidBodyTransform groundToSensorTransform = new RigidBodyTransform(sensorToGroundTransform);
-         groundToSensorTransform.invert();
-
          sensorToGroundTransform.get(sensorToGroundTransformArray);
          sensorToGroundTransformHostPointer.put(sensorToGroundTransformArray);
          CUDATools.mallocAsync(sensorToGroundTransformDevicePointer, sensorToGroundTransformArray.length, stream);
          CUDATools.memcpyAsync(sensorToGroundTransformDevicePointer, sensorToGroundTransformHostPointer, sensorToGroundTransformArray.length, stream);
 
-         groundToSensorTransform.get(groundToSensorTransformArray);
-         groundToSensorTransformHostPointer.put(groundToSensorTransformArray);
-         CUDATools.mallocAsync(groundToSensorTransformDevicePointer, groundToSensorTransformArray.length, stream);
-         CUDATools.memcpyAsync(groundToSensorTransformDevicePointer, groundToSensorTransformHostPointer, groundToSensorTransformArray.length, stream);
+         // Clearing all the temp maps so they are ready for the next update call
+         cudaMemset2D(tempSumMap.data(), tempSumMap.step(), 0, (long) tempSumMap.cols() * Float.BYTES, tempSumMap.rows());
+         cudaMemset2D(tempCountMap.data(), tempCountMap.step(), 0, (long) tempCountMap.cols() * Float.BYTES, tempCountMap.rows());
+         cudaMemset2D(tempSumOfSquaresMap.data(), tempSumOfSquaresMap.step(), 0, (long) tempSumOfSquaresMap.cols() * Float.BYTES, tempSumOfSquaresMap.rows());
+         cudaMemset2D(tempMotionVarianceMap.data(),
+                      tempMotionVarianceMap.step(),
+                      0,
+                      (long) tempMotionVarianceMap.cols() * Float.BYTES,
+                      tempMotionVarianceMap.rows());
 
          int gridDimX = (latestDepthImageGPU.cols() + BLOCK_SIZE_XY - 1) / BLOCK_SIZE_XY;
          int gridDimY = (latestDepthImageGPU.rows() + BLOCK_SIZE_XY - 1) / BLOCK_SIZE_XY;
-         dim3 scatterGridDim = new dim3(gridDimX, gridDimY, 1);
+         dim3 updateTempMapsDim = new dim3(gridDimX, gridDimY, 1);
 
          updateTempMapsKernel.withPointer(latestDepthImageGPU.data()).withLong(latestDepthImageGPU.step());
          updateTempMapsKernel.withPointer(tempSumMap.data()).withLong(tempSumMap.step());
@@ -261,13 +257,9 @@ public class RapidHeightMapExtractor
          updateTempMapsKernel.withFloat(linearMotionMagnitude);
          updateTempMapsKernel.withFloat(angularMotionMagnitude);
 
-         // CLEARING ALL THE DATA FOR THE NEXT UPDAT e
-         cudaMemset2D(tempSumMap.data(), tempSumMap.step(), 0, (long) tempSumMap.cols() * Float.BYTES, tempSumMap.rows());
-         cudaMemset2D(tempCountMap.data(), tempCountMap.step(), 0, (long) tempCountMap.cols() * Float.BYTES, tempCountMap.rows());
-         cudaMemset2D(tempSumOfSquaresMap.data(), tempSumOfSquaresMap.step(), 0, (long) tempSumOfSquaresMap.cols() * Float.BYTES, tempSumOfSquaresMap.rows());
-         cudaMemset2D(tempMotionVarianceMap.data(), tempMotionVarianceMap.step(), 0, (long) tempMotionVarianceMap.cols() * Float.BYTES, tempMotionVarianceMap.rows());
+         updateTempMapsKernel.run(stream, updateTempMapsDim, blockSize, 0);
 
-         updateTempMapsKernel.run(stream, scatterGridDim, blockSize, 0);
+         // That is the end of kernel one, now onto the local kernel
 
          localMapKernel.withPointer(tempSumMap.data()).withLong(tempSumMap.step());
          localMapKernel.withPointer(tempCountMap.data()).withLong(tempCountMap.step());
@@ -278,14 +270,14 @@ public class RapidHeightMapExtractor
          localMapKernel.withPointer(localMotionVarianceMap.data()).withLong(localMotionVarianceMap.step());
          localMapKernel.withPointer(parametersDevicePointer);
 
-         int updateKernelGridSizeXY = (cellsPerAxisLocal + BLOCK_SIZE_XY - 1) / BLOCK_SIZE_XY;
-         dim3 whattttttttt = new dim3(updateKernelGridSizeXY, updateKernelGridSizeXY, 1);
+         int computeLocalKernelGridXY = (cellsPerAxisLocal + BLOCK_SIZE_XY - 1) / BLOCK_SIZE_XY;
+         dim3 localKernelDim = new dim3(computeLocalKernelGridXY, computeLocalKernelGridXY, 1);
 
-         localMapKernel.run(stream, whattttttttt, blockSize, 0);
+         localMapKernel.run(stream, localKernelDim, blockSize, 0);
 
-         //         updateKernelGridDim.close();
+         updateTempMapsDim.close();
+         localKernelDim.close();
          cudaFreeAsync(sensorToGroundTransformDevicePointer, stream);
-         cudaFreeAsync(groundToSensorTransformDevicePointer, stream);
          checkCUDAError();
       }
 
@@ -484,6 +476,7 @@ public class RapidHeightMapExtractor
       blockSize.close();
 
       updateTempMapsKernel.close();
+      localMeanMap.close();
       translateKernel.close();
       registerKernel.close();
       terrainCroppingKernel.close();
@@ -491,10 +484,14 @@ public class RapidHeightMapExtractor
       emptyRegisterKernel.close();
 
       // Clean up each resource
-      deallocateFloatPointer(groundToSensorTransformHostPointer, groundToSensorTransformDevicePointer, stream);
       deallocateFloatPointer(sensorToGroundTransformHostPointer, sensorToGroundTransformDevicePointer, stream);
       deallocateFloatPointer(zUpCameraToWorldAlignedGroundHostPointer, zUpCameraToWorldAlignedGroundDevicePointer, stream);
       deallocateFloatPointer(parametersHostPointer, parametersDevicePointer, stream);
+
+      tempSumMap.close();
+      tempCountMap.close();
+      tempSumOfSquaresMap.close();
+      tempMotionVarianceMap.close();
 
       localMeanMap.close();
       localVarianceMap.close();

--- a/ihmc-perception/src/main/resources/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.cu
+++ b/ihmc-perception/src/main/resources/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.cu
@@ -79,7 +79,7 @@ __global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ dep
                                           const float linearMotionMagnitude,
                                           const float angularMotionMagnitude)
 {
-    // Thread indices now correspond to PIXEL coordinates
+    // Thread indices now correspond to pixel coordinates
     int xIndex = blockIdx.x * blockDim.x + threadIdx.x;
     int yIndex = blockIdx.y * blockDim.y + threadIdx.y;
 

--- a/ihmc-perception/src/main/resources/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.cu
+++ b/ihmc-perception/src/main/resources/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.cu
@@ -71,7 +71,7 @@ __device__ int2 getGlobalIndexFromLocalIndex(int2 localIndex, const float *zUpCa
 extern "C"
 __global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ depthImage, size_t pitchDepth,
                                           float* __restrict__ sumMap, size_t pitchSum,
-                                          float* __restrict__ countMap, size_t pitchCount,
+                                          int* __restrict__ countMap, size_t pitchCount,
                                           float* __restrict__ sumOfSquaresMap, size_t pitchSumSq,
                                           float* __restrict__ motionVarianceSumMap, size_t pitchMotionVar,
                                           const float* __restrict__ params,
@@ -101,7 +101,7 @@ __global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ dep
     float depth = rowPtr[xIndex] * 0.001f; // Scale to meters
 
     // Early exit for invalid depth
-    if (depth < 0.5f)
+    if (depth < 0.25f)
         return;
 
     // Back-project and transform
@@ -118,13 +118,13 @@ __global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ dep
 
     // Pointers to the target cell in each temporary map
     float* sumPtr = (float*)((char*)sumMap + cellIndex.y * pitchSum) + cellIndex.x;
-    float* countPtr = (float*)((char*)countMap + cellIndex.y * pitchCount) + cellIndex.x;
+    int* countPtr = (int*)((char*)countMap + cellIndex.y * pitchCount) + cellIndex.x;
     float* sumSqPtr = (float*)((char*)sumOfSquaresMap + cellIndex.y * pitchSumSq) + cellIndex.x;
     float* motionVarPtr = (float*)((char*)motionVarianceSumMap + cellIndex.y * pitchMotionVar) + cellIndex.x;
 
     // Atomically add this pixel's contribution
     atomicAdd(sumPtr, queryPointInZUpFrame.z);
-    atomicAdd(countPtr, 1.0f);
+    atomicAdd(countPtr, 1);
     atomicAdd(sumSqPtr, queryPointInZUpFrame.z * queryPointInZUpFrame.z);
 
     // Also calculate and add motion variance contribution
@@ -142,7 +142,7 @@ __global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ dep
  */
 extern "C"
 __global__ void computeLocalMap(const float* __restrict__ sumMap, size_t pitchSum,
-                                const float* __restrict__ countMap, size_t pitchCount,
+                                const int* __restrict__ countMap, size_t pitchCount,
                                 const float* __restrict__ sumOfSquaresMap, size_t pitchSumSq,
                                 const float* __restrict__ motionVarianceSumMap, size_t pitchMotionVar,
                                 float* __restrict__ localMeanMap, size_t pitchLocalMean,
@@ -160,7 +160,7 @@ __global__ void computeLocalMap(const float* __restrict__ sumMap, size_t pitchSu
         return;
 
     const float* sumPtr = (const float*)((const char*)sumMap + yIndex * pitchSum) + xIndex;
-    const float* countPtr = (const float*)((const char*)countMap + yIndex * pitchCount) + xIndex;
+    const int* countPtr = (const int*)((const char*)countMap + yIndex * pitchCount) + xIndex;
     const float* sumSqPtr = (const float*)((const char*)sumOfSquaresMap + yIndex * pitchSumSq) + xIndex;
     const float* motionVarPtr = (const float*)((const char*)motionVarianceSumMap + yIndex * pitchMotionVar) + xIndex;
 
@@ -170,17 +170,18 @@ __global__ void computeLocalMap(const float* __restrict__ sumMap, size_t pitchSu
     float motionVariance = 0.0f;
 
     // Only compute if one or more points landed in this cell
-    if (count > 0.5f)
+    if (count > 0)
     {
         float sum = *sumPtr;
         mean = sum / count;
         motionVariance = *motionVarPtr / count;
 
-        if (count > 1.5f)
+        if (count > 1)
         {
             float sumSq = *sumSqPtr;
-            // Stable one-pass variance formula: (E[X^2] - (E[X])^2 * N) / (N-1)
-            variance = (sumSq - (sum * sum) / count) / (count - 1.0f);
+            // Unbiased sample variance (one-pass), a.k.a. Bessel's Correction:
+            // (Σx² - (Σx)² / N) / (N - 1)
+            variance = (sumSq - (sum * sum) / static_cast<float>(count)) / (static_cast<float>(count) - 1.0f);
             variance = fmaxf(0.0f, variance); // Clamp to zero to avoid negatives from float error
         }
     }

--- a/ihmc-perception/src/main/resources/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.cu
+++ b/ihmc-perception/src/main/resources/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.cu
@@ -103,159 +103,140 @@ __device__ int2 getGlobalIndexFromLocalIndex(int2 localIndex, const float *zUpCa
 // Iterate over a search window in the depth image to find points within the cell.
 // Back-project these points to the 3D space and transform them back to the Z-Up frame.
 // Compute the average height for points within the grid cell while filtering outliers.
+
+/**
+ * @brief SCATTER KERNEL: One thread per depth pixel.
+ * Reads depth, back-projects, transforms, and atomically adds the point's
+ * contribution to the appropriate height map cell.
+ */
 extern "C"
-__global__ void heightMapUpdateKernel(const unsigned short *__restrict__ depthImage, size_t pitchDepth,
-                                      float *__restrict__ previousGlobalHeightMap, size_t pitchGlobal,
-                                      float *__restrict__ localMeanMap, size_t pitchLocalMean,
-                                      float *__restrict__ localVarianceMap, size_t pitchLocalVariance,
-                                      float *__restrict__ localMotionVarianceMap, size_t pitchLocalMotionVariance,
-                                      const float *__restrict__ params,
-                                      const float *__restrict__ sensorToZUpFrameTf,
-                                      const float *__restrict__ zUpToSensorFrameTf,
-                                      const float *__restrict__ zUpCameraToWorldAlignedGround,
-                                      const float linearMotionMagnitude,
-                                      const float angularMotionMagnitude,
-                                      float resetOffset)
+__global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ depthImage, size_t pitchDepth,
+                                          float* __restrict__ sumMap, size_t pitchSum,
+                                          float* __restrict__ countMap, size_t pitchCount,
+                                          float* __restrict__ sumOfSquaresMap, size_t pitchSumSq,
+                                          float* __restrict__ motionVarianceSumMap, size_t pitchMotionVar,
+                                          const float* __restrict__ params,
+                                          const float* __restrict__ sensorToZUpFrameTf,
+                                          const float linearMotionMagnitude,
+                                          const float angularMotionMagnitude)
 {
-    // Thread indices
+    // Thread indices now correspond to PIXEL coordinates
     int xIndex = blockIdx.x * blockDim.x + threadIdx.x;
     int yIndex = blockIdx.y * blockDim.y + threadIdx.y;
 
-    // Cache params into local variables to reduce repeated global memory accesses
-    const int localCellsPerAxis = static_cast<int>(params[LOCAL_CELLS_PER_AXIS]);
-    const int globalCellsPerAxis = static_cast<int>(params[GLOBAL_CELLS_PER_AXIS]);
+    // Cache params
     const int depthWidth = static_cast<int>(params[DEPTH_INPUT_WIDTH]);
     const int depthHeight = static_cast<int>(params[DEPTH_INPUT_HEIGHT]);
+    const int localCellsPerAxis = static_cast<int>(params[LOCAL_CELLS_PER_AXIS]);
     const float cellSize = params[CELL_SIZE];
-    const float halfLocalWidth = params[HALF_LOCAL_WIDTH_IN_METERS];
-    const float groundHeight = params[GROUND_HEIGHT];
-    const int searchWindowWidth = static_cast<int>(params[SEARCH_WINDOW_WIDTH]);
-    const int searchWindowHeight = static_cast<int>(params[SEARCH_WINDOW_HEIGHT]);
-    const int searchSkip = static_cast<int>(params[SEARCH_SKIP_SIZE]);
-    const int mode = static_cast<int>(params[MODE]);
+    const int localCenterIndex = static_cast<int>(params[LOCAL_CENTER_INDEX]);
     const float varPerMeter = params[VARIANCE_PER_METER];
     const float varPerTranslationSpeed = params[VARIANCE_PER_TRANSLATION_SPEED];
     const float varPerRotationSpeed = params[VARIANCE_PER_ROTATION_SPEED];
 
-    // Bounds check
+    // Bounds check against depth image dimensions
+    if (xIndex >= depthWidth || yIndex >= depthHeight)
+        return;
+
+    // --- 1. Coalesced Read from Depth Image ---
+    const unsigned short* rowPtr = (const unsigned short*)((const char*)depthImage + yIndex * pitchDepth);
+    float depth = rowPtr[xIndex] * 0.001f; // scale to meters
+
+    if (depth < 0.5f) // Early exit for invalid depth
+        return;
+
+    // --- 2. Back-project and Transform (same as before) ---
+    float3 queryPointInSensor = back_project_perspective(make_int2(xIndex, yIndex), depth, params);
+    float3 queryPointInZUp = transformPoint3D(queryPointInSensor, sensorToZUpFrameTf);
+
+    // --- 3. Find Target Cell ---
+    float2 xyCoords = make_float2(queryPointInZUp.x, queryPointInZUp.y);
+    int2 cellIndex = coordinate_to_indices(xyCoords, make_float2(params[HALF_LOCAL_WIDTH_IN_METERS], 0.0f), cellSize, localCenterIndex);
+
+    // Bounds check against the local map dimensions
+    if (cellIndex.x < 0 || cellIndex.x >= localCellsPerAxis || cellIndex.y < 0 || cellIndex.y >= localCellsPerAxis)
+        return;
+
+    // --- 4. Atomic Updates ---
+    // Pointers to the target cell in each intermediate map
+    float* sumPtr = (float*)((char*)sumMap + cellIndex.y * pitchSum) + cellIndex.x;
+    float* countPtr = (float*)((char*)countMap + cellIndex.y * pitchCount) + cellIndex.x;
+    float* sumSqPtr = (float*)((char*)sumOfSquaresMap + cellIndex.y * pitchSumSq) + cellIndex.x;
+    float* motionVarPtr = (float*)((char*)motionVarianceSumMap + cellIndex.y * pitchMotionVar) + cellIndex.x;
+
+    // Atomically add this pixel's contribution
+    atomicAdd(sumPtr, queryPointInZUp.z);
+    atomicAdd(countPtr, 1.0f);
+    atomicAdd(sumSqPtr, queryPointInZUp.z * queryPointInZUp.z);
+
+    // Also calculate and add motion variance contribution
+    float distance = sqrtf(queryPointInSensor.x * queryPointInSensor.x + queryPointInSensor.y * queryPointInSensor.y + queryPointInSensor.z * queryPointInSensor.z);
+    float motionVarianceF = distance * varPerMeter + linearMotionMagnitude * varPerTranslationSpeed +
+                            angularMotionMagnitude * distance * varPerRotationSpeed;
+    atomicAdd(motionVarPtr, motionVarianceF);
+}
+
+
+/**
+ * @brief FINALIZE KERNEL: One thread per height map cell.
+ * Reads the intermediate sum/count buffers and computes the final
+ * mean, variance, and motion variance.
+ */
+extern "C"
+__global__ void computeLocalMap(const float* __restrict__ sumMap, size_t pitchSum,
+                                const float* __restrict__ countMap, size_t pitchCount,
+                                const float* __restrict__ sumOfSquaresMap, size_t pitchSumSq,
+                                const float* __restrict__ motionVarianceSumMap, size_t pitchMotionVar,
+                                float* __restrict__ localMeanMap, size_t pitchLocalMean,
+                                float* __restrict__ localVarianceMap, size_t pitchLocalVariance,
+                                float* __restrict__ localMotionVarianceMap, size_t pitchLocalMotionVariance,
+                                const float* __restrict__ params)
+{
+    // Thread indices now correspond to CELL coordinates
+    int xIndex = blockIdx.x * blockDim.x + threadIdx.x;
+    int yIndex = blockIdx.y * blockDim.y + threadIdx.y;
+
+    const int localCellsPerAxis = static_cast<int>(params[LOCAL_CELLS_PER_AXIS]);
+
+    // Bounds check against local map dimensions
     if (xIndex >= localCellsPerAxis || yIndex >= localCellsPerAxis)
         return;
 
-    // Initialize cell center in Z-Up
-    float cellX = 0.0f;
-    float cellY = 0.0f;
-    float cellZ = groundHeight;
+    // Pointers to the source cell in each intermediate map
+    const float* sumPtr = (const float*)((const char*)sumMap + yIndex * pitchSum) + xIndex;
+    const float* countPtr = (const float*)((const char*)countMap + yIndex * pitchCount) + xIndex;
+    const float* sumSqPtr = (const float*)((const char*)sumOfSquaresMap + yIndex * pitchSumSq) + xIndex;
+    const float* motionVarPtr = (const float*)((const char*)motionVarianceSumMap + yIndex * pitchMotionVar) + xIndex;
 
-    // Compute global index
-    int2 globalIndex = getGlobalIndexFromLocalIndex(make_int2(xIndex, yIndex), zUpCameraToWorldAlignedGround, params);
+    float count = *countPtr;
+    float mean = 0.0f;
+    float variance = 0.0f;
+    float motionVariance = 0.0f;
 
-    if (globalIndex.x >= 0 && globalIndex.x < globalCellsPerAxis &&
-        globalIndex.y >= 0 && globalIndex.y < globalCellsPerAxis)
+    // Only compute if one or more points landed in this cell
+    if (count > 0.5f) // Use float comparison
     {
-        float *globalHeight = (float *)((char *)previousGlobalHeightMap + globalIndex.x * pitchGlobal) + globalIndex.y;
-        if (*globalHeight != resetOffset)
+        float sum = *sumPtr;
+        mean = sum / count;
+        motionVariance = *motionVarPtr / count;
+
+        if (count > 1.5f)
         {
-            cellZ = *globalHeight;
+            float sumSq = *sumSqPtr;
+            // Stable one-pass variance formula: (E[X^2] - (E[X])^2 * N) / (N-1)
+            variance = (sumSq - (sum * sum) / count) / (count - 1.0f);
+            variance = fmaxf(0.0f, variance); // Clamp to zero to avoid negatives from float error
         }
     }
 
-    // Compute grid cell center in local coordinates
-    float2 xyCoords = indices_to_coordinate(make_int2(xIndex, yIndex),
-                                            make_float2(0.0f, 0.0f),
-                                            cellSize,
-                                            params[LOCAL_CENTER_INDEX]);
+    // Write final results to the output maps
+    float* meanHeight = (float*)((char*)localMeanMap + xIndex * pitchLocalMean) + yIndex;
+    float* var = (float*)((char*)localVarianceMap + xIndex * pitchLocalVariance) + yIndex;
+    float* motionVar = (float*)((char*)localMotionVarianceMap + xIndex * pitchLocalMotionVariance) + yIndex;
 
-    cellX = xyCoords.x + halfLocalWidth;
-    cellY = xyCoords.y;
-
-    float halfCellWidth = cellSize * 0.5f;
-    float minX = cellX - halfCellWidth;
-    float maxX = cellX + halfCellWidth;
-    float minY = cellY - halfCellWidth;
-    float maxY = cellY + halfCellWidth;
-
-    // Transform cell center from Z-Up to sensor frame
-    float3 cellCenterInSensor = transformPoint3D(make_float3(cellX, cellY, cellZ), zUpToSensorFrameTf);
-
-    // Project cell to image
-    int2 projectedPoint;
-    if (mode == 0)
-        projectedPoint = spherical_projection(cellCenterInSensor, params);
-    else
-    {
-        float xFwd = -cellCenterInSensor.y;
-        float yFwd = -cellCenterInSensor.z;
-        float zFwd = cellCenterInSensor.x;
-        if (zFwd < 0.0f) return;
-        projectedPoint = perspective_projection(make_float3(xFwd, yFwd, zFwd), params);
-    }
-
-    // Distance from camera
-    float distance = sqrtf(cellCenterInSensor.x * cellCenterInSensor.x +
-                           cellCenterInSensor.y * cellCenterInSensor.y +
-                           cellCenterInSensor.z * cellCenterInSensor.z);
-
-    // Welford accumulators
-    int count = 0;
-    float meanZ = 0.0f;
-    float m2 = 0.0f;
-    float motionVarianceF = distance * varPerMeter + linearMotionMagnitude * varPerTranslationSpeed +
-                            angularMotionMagnitude * distance * varPerRotationSpeed;
-
-    int searchWindowHeightHalf = (int)(searchWindowHeight * 0.5f);
-    int searchWindowWidthHalf = (int)(searchWindowWidth * 0.5f);
-
-    // Search depth image
-    for (int pitchOffset = -searchWindowHeightHalf; pitchOffset <= searchWindowHeightHalf; pitchOffset += searchSkip)
-    {
-        int pitchIdx = projectedPoint.y + pitchOffset;
-
-        //  Exit the loop early if we can, optimize for performance
-        if (pitchIdx < 0 || pitchIdx >= depthHeight)
-            continue;
-
-        // This is created outside the inner loop because its cheaper to only create once per loop
-        unsigned short *rowPtr = (unsigned short *)((char *)depthImage + pitchIdx * pitchDepth);
-
-        for (int yawOffset = -searchWindowWidthHalf; yawOffset <= searchWindowWidthHalf; yawOffset += searchSkip)
-        {
-            int yawIdx = projectedPoint.x + yawOffset;
-
-            // Again, exit the loop early if we can
-            if (yawIdx < 0 || yawIdx >= depthWidth)
-                continue;
-
-            float depth = rowPtr[yawIdx] * 0.001f; // scale to meters
-            if (depth < 0.5f)
-                continue;
-
-            float3 queryPointInSensor = back_project_perspective(make_int2(yawIdx, pitchIdx), depth, params);
-            float3 queryPointInZUp = transformPoint3D(queryPointInSensor, sensorToZUpFrameTf);
-
-            if (queryPointInZUp.x > minX && queryPointInZUp.x < maxX &&
-                queryPointInZUp.y > minY && queryPointInZUp.y < maxY)
-            {
-                count++;
-                float delta = queryPointInZUp.z - meanZ;
-                meanZ += delta / count;
-                float delta2 = queryPointInZUp.z - meanZ;
-                m2 += delta * delta2;
-            }
-        }
-    }
-
-    float currentVariance = (count > 1) ? (m2 / (count - 1)) : 0.0f;
-    if (count == 0)
-        meanZ = 0.0f;
-
-    // Write results
-    float *meanHeight = (float *)((char *)localMeanMap + xIndex * pitchLocalMean) + yIndex;
-    float *variance = (float *)((char *)localVarianceMap + xIndex * pitchLocalVariance) + yIndex;
-    float *motionVariance = (float *)((char *)localMotionVarianceMap + xIndex * pitchLocalMotionVariance) + yIndex;
-
-    *meanHeight = meanZ;
-    *variance = currentVariance;
-    *motionVariance = motionVarianceF;
+    *meanHeight = mean;
+    *var = variance;
+    *motionVar = motionVariance;
 }
 
 extern "C"

--- a/ihmc-perception/src/main/resources/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.cu
+++ b/ihmc-perception/src/main/resources/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractor.cu
@@ -31,41 +31,6 @@ extern "C"
 #define SEARCH_SKIP_SIZE 26
 #define GROUND_HEIGHT 27
 
-#define VERTICAL_FOV 1.5707963267948966f
-#define HORIZONTAL_FOV 6.2831853f
-
-const bool DEBUG = false;
-
-__device__ int2 spherical_projection(float3 cellCenter, const float *params)
-{
-    float pitchUnit = VERTICAL_FOV / (params[DEPTH_INPUT_HEIGHT]);
-    float yawUnit = HORIZONTAL_FOV / (params[DEPTH_INPUT_WIDTH]);
-
-    int pitchOffset = params[DEPTH_INPUT_HEIGHT] / 2;
-    int yawOffset = params[DEPTH_INPUT_WIDTH] / 2;
-
-    float x = cellCenter.x;
-    float y = cellCenter.y;
-    float z = cellCenter.z;
-
-    float radius = sqrt(x * x + y * y);
-
-    float pitch = atan2f(z, radius);
-    int pitchCount = (pitchOffset) - static_cast<int>(pitch / pitchUnit);
-
-    float yaw = atan2f(-y, x);
-    int yawCount = (yawOffset) + static_cast<int>(yaw / yawUnit);
-
-    return make_int2(pitchCount, yawCount);
-}
-
-__device__ int2 perspective_projection(float3 point, const float *params)
-{
-    float x = point.x / point.z * params[DEPTH_FX] + params[DEPTH_CX];
-    float y = point.y / point.z * params[DEPTH_FY] + params[DEPTH_CY];
-    return make_int2(static_cast<int>(x), static_cast<int>(y));
-}
-
 __device__ float3 back_project_perspective(int2 pos, float Z, const float *params)
 {
     float X = (pos.x - params[DEPTH_CX]) / params[DEPTH_FX] * Z;
@@ -97,17 +62,11 @@ __device__ int2 getGlobalIndexFromLocalIndex(int2 localIndex, const float *zUpCa
     return newCellIndex;
 }
 
-// Compute grid cell center coordinates (cellCenterInZUp) in the Z-Up frame based on thread indices.
-// Transform the grid cell to the sensor frame using the transformation matrix (zUpToSensorFrameTf).
-// Perform projection (spherical or perspective) to map the grid cell to image indices.
-// Iterate over a search window in the depth image to find points within the cell.
-// Back-project these points to the 3D space and transform them back to the Z-Up frame.
-// Compute the average height for points within the grid cell while filtering outliers.
-
 /**
- * @brief SCATTER KERNEL: One thread per depth pixel.
- * Reads depth, back-projects, transforms, and atomically adds the point's
- * contribution to the appropriate height map cell.
+ * @brief Height map update KERNEL: One thread per depth pixel for peak optimization.
+ * Reads in the depth for each pixel in the image.
+ * Back projects the points into the Z-Up frame using transforms.
+ * Atomically adds the points to the maps.
  */
 extern "C"
 __global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ depthImage, size_t pitchDepth,
@@ -124,7 +83,6 @@ __global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ dep
     int xIndex = blockIdx.x * blockDim.x + threadIdx.x;
     int yIndex = blockIdx.y * blockDim.y + threadIdx.y;
 
-    // Cache params
     const int depthWidth = static_cast<int>(params[DEPTH_INPUT_WIDTH]);
     const int depthHeight = static_cast<int>(params[DEPTH_INPUT_HEIGHT]);
     const int localCellsPerAxis = static_cast<int>(params[LOCAL_CELLS_PER_AXIS]);
@@ -138,49 +96,49 @@ __global__ void heightMapUpdateDataKernel(const unsigned short* __restrict__ dep
     if (xIndex >= depthWidth || yIndex >= depthHeight)
         return;
 
-    // --- 1. Coalesced Read from Depth Image ---
+    // Coalesced read from depth image
     const unsigned short* rowPtr = (const unsigned short*)((const char*)depthImage + yIndex * pitchDepth);
-    float depth = rowPtr[xIndex] * 0.001f; // scale to meters
+    float depth = rowPtr[xIndex] * 0.001f; // Scale to meters
 
-    if (depth < 0.5f) // Early exit for invalid depth
+    // Early exit for invalid depth
+    if (depth < 0.5f)
         return;
 
-    // --- 2. Back-project and Transform (same as before) ---
-    float3 queryPointInSensor = back_project_perspective(make_int2(xIndex, yIndex), depth, params);
-    float3 queryPointInZUp = transformPoint3D(queryPointInSensor, sensorToZUpFrameTf);
+    // Back-project and transform
+    float3 queryPointInSensorFrame = back_project_perspective(make_int2(xIndex, yIndex), depth, params);
+    float3 queryPointInZUpFrame = transformPoint3D(queryPointInSensorFrame, sensorToZUpFrameTf);
 
-    // --- 3. Find Target Cell ---
-    float2 xyCoords = make_float2(queryPointInZUp.x, queryPointInZUp.y);
+    // Get the correct cell index for the maps
+    float2 xyCoords = make_float2(queryPointInZUpFrame.x, queryPointInZUpFrame.y);
     int2 cellIndex = coordinate_to_indices(xyCoords, make_float2(params[HALF_LOCAL_WIDTH_IN_METERS], 0.0f), cellSize, localCenterIndex);
 
-    // Bounds check against the local map dimensions
+    // Bounds check against the local map dimensions because we are scanning the entire depth image
     if (cellIndex.x < 0 || cellIndex.x >= localCellsPerAxis || cellIndex.y < 0 || cellIndex.y >= localCellsPerAxis)
         return;
 
-    // --- 4. Atomic Updates ---
-    // Pointers to the target cell in each intermediate map
+    // Pointers to the target cell in each temporary map
     float* sumPtr = (float*)((char*)sumMap + cellIndex.y * pitchSum) + cellIndex.x;
     float* countPtr = (float*)((char*)countMap + cellIndex.y * pitchCount) + cellIndex.x;
     float* sumSqPtr = (float*)((char*)sumOfSquaresMap + cellIndex.y * pitchSumSq) + cellIndex.x;
     float* motionVarPtr = (float*)((char*)motionVarianceSumMap + cellIndex.y * pitchMotionVar) + cellIndex.x;
 
     // Atomically add this pixel's contribution
-    atomicAdd(sumPtr, queryPointInZUp.z);
+    atomicAdd(sumPtr, queryPointInZUpFrame.z);
     atomicAdd(countPtr, 1.0f);
-    atomicAdd(sumSqPtr, queryPointInZUp.z * queryPointInZUp.z);
+    atomicAdd(sumSqPtr, queryPointInZUpFrame.z * queryPointInZUpFrame.z);
 
     // Also calculate and add motion variance contribution
-    float distance = sqrtf(queryPointInSensor.x * queryPointInSensor.x + queryPointInSensor.y * queryPointInSensor.y + queryPointInSensor.z * queryPointInSensor.z);
-    float motionVarianceF = distance * varPerMeter + linearMotionMagnitude * varPerTranslationSpeed +
-                            angularMotionMagnitude * distance * varPerRotationSpeed;
+    float distance = sqrtf(queryPointInSensorFrame.x * queryPointInSensorFrame.x +
+                           queryPointInSensorFrame.y * queryPointInSensorFrame.y +
+                           queryPointInSensorFrame.z * queryPointInSensorFrame.z);
+    float motionVarianceF = distance * varPerMeter + linearMotionMagnitude * varPerTranslationSpeed + angularMotionMagnitude * distance * varPerRotationSpeed;
     atomicAdd(motionVarPtr, motionVarianceF);
 }
 
 
 /**
- * @brief FINALIZE KERNEL: One thread per height map cell.
- * Reads the intermediate sum/count buffers and computes the final
- * mean, variance, and motion variance.
+ * @brief Compute Local Map KERNEL: The threads correspond to cell indices
+ * Takes the maps that hold all the sums, and computes the mean, variance, and motion variance per cell
  */
 extern "C"
 __global__ void computeLocalMap(const float* __restrict__ sumMap, size_t pitchSum,
@@ -192,7 +150,6 @@ __global__ void computeLocalMap(const float* __restrict__ sumMap, size_t pitchSu
                                 float* __restrict__ localMotionVarianceMap, size_t pitchLocalMotionVariance,
                                 const float* __restrict__ params)
 {
-    // Thread indices now correspond to CELL coordinates
     int xIndex = blockIdx.x * blockDim.x + threadIdx.x;
     int yIndex = blockIdx.y * blockDim.y + threadIdx.y;
 
@@ -202,7 +159,6 @@ __global__ void computeLocalMap(const float* __restrict__ sumMap, size_t pitchSu
     if (xIndex >= localCellsPerAxis || yIndex >= localCellsPerAxis)
         return;
 
-    // Pointers to the source cell in each intermediate map
     const float* sumPtr = (const float*)((const char*)sumMap + yIndex * pitchSum) + xIndex;
     const float* countPtr = (const float*)((const char*)countMap + yIndex * pitchCount) + xIndex;
     const float* sumSqPtr = (const float*)((const char*)sumOfSquaresMap + yIndex * pitchSumSq) + xIndex;
@@ -214,7 +170,7 @@ __global__ void computeLocalMap(const float* __restrict__ sumMap, size_t pitchSu
     float motionVariance = 0.0f;
 
     // Only compute if one or more points landed in this cell
-    if (count > 0.5f) // Use float comparison
+    if (count > 0.5f)
     {
         float sum = *sumPtr;
         mean = sum / count;
@@ -342,15 +298,6 @@ __global__ void heightMapRegistrationKernel(const float *__restrict__ localMeanM
         float kalmanGain = predictedVariance / (predictedVariance + localVarianceF + localMotionVarianceF);
         float updatedMean = predictedMean + kalmanGain * (localMeanF - predictedMean);
         float updatedVariance = (1.0f - kalmanGain) * predictedVariance;
-
-        if (DEBUG && xIndex == 40 && yIndex == 40)
-        {
-            printf("Registration Kernel -----------------------------\n");
-            printf("Global Mean: %f\n", globalMeanF);
-            printf("Kalman Gain: %f\n", kalmanGain);
-            printf("New Mean: %f\n", updatedMean);
-            printf("New Variance: %f\n", updatedVariance);
-        }
 
         *globalMean = updatedMean;
         *globalVariance = updatedVariance;

--- a/ihmc-perception/src/main/resources/us/ihmc/perception/heightMap/HeightMapParameters.json
+++ b/ihmc-perception/src/main/resources/us/ihmc/perception/heightMap/HeightMapParameters.json
@@ -50,7 +50,7 @@
     "upperBound": 1.0
   },
   "Variance per meter": {
-    "value": 0.01,
+    "value": 0.1,
     "lowerBound": 0.0,
     "upperBound": 1.0
   },

--- a/ihmc-perception/src/test/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractorTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractorTest.java
@@ -35,7 +35,7 @@ public class RapidHeightMapExtractorTest
 
       RigidBodyTransform rigidBodyTransform = new RigidBodyTransform(transformArray);
 
-      for (int i = 0; i < 1; i++)
+      for (int i = 0; i < 1000; i++)
       {
          rapidHeightMapExtractor.update(gpuMat, cameraIntrinsics, rigidBodyTransform, rigidBodyTransform, rigidBodyTransform, new Point3D(1.0, 2.0, 3.0), 0.0);
       }

--- a/ihmc-perception/src/test/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractorTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/gpuHeightMap/RapidHeightMapExtractorTest.java
@@ -1,5 +1,6 @@
 package us.ihmc.perception.gpuHeightMap;
 
+import org.bytedeco.opencv.global.opencv_core;
 import org.bytedeco.opencv.opencv_core.GpuMat;
 import org.bytedeco.opencv.opencv_core.Scalar;
 import org.junit.jupiter.api.Disabled;
@@ -18,21 +19,23 @@ public class RapidHeightMapExtractorTest
     * Manually check the memory management with htop and nvidia-smi
     */
    @Test
-   @Disabled
    public void testRapidHeightMapExtractor()
    {
       HeightMapParameters heightMapParameters = new HeightMapParameters();
       RapidHeightMapExtractor rapidHeightMapExtractor = new RapidHeightMapExtractor(heightMapParameters);
 
       // Create fake data for the test
-      GpuMat gpuMat = new GpuMat();
-      gpuMat.setTo(new Scalar(100));
+      GpuMat gpuMat = new GpuMat(1280, 720, opencv_core.CV_16UC1);
+      gpuMat.setTo(new Scalar(3000));
       CameraIntrinsics cameraIntrinsics = new CameraIntrinsics();
+      // Need to set these to the size of the image
+      cameraIntrinsics.setWidth(1280);
+      cameraIntrinsics.setHeight(720);
       double[] transformArray = getDoubles();
 
       RigidBodyTransform rigidBodyTransform = new RigidBodyTransform(transformArray);
 
-      for (int i = 0; i < 1000; i++)
+      for (int i = 0; i < 1; i++)
       {
          rapidHeightMapExtractor.update(gpuMat, cameraIntrinsics, rigidBodyTransform, rigidBodyTransform, rigidBodyTransform, new Point3D(1.0, 2.0, 3.0), 0.0);
       }


### PR DESCRIPTION
<img width="2238" height="765" alt="image" src="https://github.com/user-attachments/assets/2bf4d9ac-6416-4b64-a672-e863cba03e8e" />

From develop----------------

And then...
<img width="2238" height="765" alt="image" src="https://github.com/user-attachments/assets/4687e679-02a4-433a-96ca-6576a09f4fed" />
From my branch-------------

So these images are from NSight Compute. What its showing is generally "how much am I using the GPU" when I ask to use the GPU. What we want to do is when I tell the process "Hey buddy, use the GPU". I want to absolutely max this out and get it over with. Not quite 100% because that can cause its own problems. But hey, I've asked to use a GPU, freaking use it. So the image from my branch shows about a double usage of the GPU. Which is great. Of course the downside of profiling still occurs where this is specific to my machine.
If you have any question about the images let me know! I can come explain it.