### PR TITLE
Improve VR performance

### DIFF
--- a/ihmc-graphics/src/libgdx/java/us/ihmc/rdx/vr/RDXVRManager.java
+++ b/ihmc-graphics/src/libgdx/java/us/ihmc/rdx/vr/RDXVRManager.java
@@ -36,8 +36,6 @@ public class RDXVRManager
    private final ImBoolean showScenePoseGizmo = new ImBoolean(false);
    private RDXPose3DGizmo scenePoseGizmo;
    private final ImBoolean vrEnabled = new ImBoolean(false);
-   private final Notification posesReady = new Notification();
-   private volatile boolean waitingOnPoses = false;
    private final ImGuiPlot vrFPSPlot = new ImGuiPlot(labels.get("VR FPS Hz"), 1000, 180, 50);
    private final FrequencyCalculator vrFPSCalculator = new FrequencyCalculator();
    private final ImGuiPlot waitGetPosesPlot = new ImGuiPlot(labels.get("Wait Get Poses Hz"), 1000, 180, 50);
@@ -82,6 +80,7 @@ public class RDXVRManager
             initializing = true;
             contextCreatedNotification = new Notification();
             context.initSystem(); // May block for a bit
+            contextCreatedNotification.set();
          }
          if (contextCreatedNotification != null && contextCreatedNotification.poll())
          {
@@ -96,7 +95,9 @@ public class RDXVRManager
 
          if (contextInitialized)
          {
-            waitOnPoses();
+            waitGetPosesFrequencyCalculator.ping();
+            context.waitGetPoses();
+            waitGetToRenderStopwatch.reset();
 
             // pollEventsFrequencyCalculator.ping();
             context.pollEvents();
@@ -165,13 +166,6 @@ public class RDXVRManager
       }
 
       return posesReadyThisFrame;
-   }
-
-   private void waitOnPoses()
-   {
-      waitGetPosesFrequencyCalculator.ping();
-      context.waitGetPoses();
-      waitGetToRenderStopwatch.reset();
    }
 
    public void renderMenuBar()

--- a/ihmc-graphics/src/libgdx/java/us/ihmc/rdx/vr/RDXVRManager.java
+++ b/ihmc-graphics/src/libgdx/java/us/ihmc/rdx/vr/RDXVRManager.java
@@ -6,7 +6,6 @@ import com.badlogic.gdx.utils.Pool;
 import imgui.internal.ImGui;
 import imgui.type.ImBoolean;
 import org.apache.commons.lang3.StringUtils;
-import us.ihmc.commons.thread.Notification;
 import us.ihmc.commons.thread.ThreadTools;
 import us.ihmc.commons.time.FrequencyCalculator;
 import us.ihmc.commons.time.Stopwatch;
@@ -21,6 +20,7 @@ import us.ihmc.rdx.ui.gizmo.RDXPose3DGizmo;
 import us.ihmc.robotics.robotSide.RobotSide;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,20 +29,16 @@ public class RDXVRManager
    private final ImGuiUniqueLabelMap labels = new ImGuiUniqueLabelMap(getClass());
 
    private final RDXVRContext context = new RDXVRContext();
-   private Notification contextCreatedNotification;
    private boolean contextInitialized = false;
-   private boolean initializing = false;
    private boolean skipHeadset = false;
    private final ImBoolean showScenePoseGizmo = new ImBoolean(false);
    private RDXPose3DGizmo scenePoseGizmo;
    private final ImBoolean vrEnabled = new ImBoolean(false);
    private final ImGuiPlot vrFPSPlot = new ImGuiPlot(labels.get("VR FPS Hz"), 1000, 180, 50);
    private final FrequencyCalculator vrFPSCalculator = new FrequencyCalculator();
-   private final ImGuiPlot waitGetPosesPlot = new ImGuiPlot(labels.get("Wait Get Poses Hz"), 1000, 180, 50);
    private final ImGuiPlot waitGetToRenderDelayPlot = new ImGuiPlot(labels.get("WaitGetToRender Delay"), 1000, 180, 50);
    private final Stopwatch waitGetToRenderStopwatch = new Stopwatch();
    private volatile double waitGetToRenderDuration = Double.NaN;
-   private final FrequencyCalculator waitGetPosesFrequencyCalculator = new FrequencyCalculator();
    private final ImGuiPlot pollEventsPlot = new ImGuiPlot(labels.get("Poll Events Hz"), 1000, 180, 50);
    private final FrequencyCalculator pollEventsFrequencyCalculator = new FrequencyCalculator();
    private final ImGuiPlot contextInitializedPlot = new ImGuiPlot(labels.get("contextInitialized"), 1000, 180, 50);
@@ -59,8 +55,8 @@ public class RDXVRManager
 
    public void pollEventsAndRender(RDXBaseUI baseUI, RDX3DScene scene)
    {
-      boolean posesReady = pollEvents(baseUI);
-      if (posesReady && isVRReady())
+      pollEvents(baseUI);
+      if (isVRReady())
       {
          skipHeadset = true;
          vrFPSCalculator.ping();
@@ -70,22 +66,18 @@ public class RDXVRManager
       }
    }
 
-   private boolean pollEvents(RDXBaseUI baseUI)
+   private void pollEvents(RDXBaseUI baseUI)
    {
-      boolean posesReadyThisFrame = false;
-      if (vrEnabled.get())
+      // Close VR if it was previously initialized and now was disabled
+      if (!vrEnabled.get() && contextInitialized)
       {
-         if (!initializing && contextCreatedNotification == null) // should completely dispose and recreate?
+         dispose();
+      }
+      else if (vrEnabled.get())
+      {
+         if (!contextInitialized)
          {
-            initializing = true;
-            contextCreatedNotification = new Notification();
             context.initSystem(); // May block for a bit
-            contextCreatedNotification.set();
-         }
-         if (contextCreatedNotification != null && contextCreatedNotification.poll())
-         {
-            initializing = false;
-
             context.setupEyes();
 
             scenePoseGizmo = new RDXPose3DGizmo(context.getTeleportFrameIHMCZUp(), context.getTeleportIHMCZUpToIHMCZUpWorld());
@@ -93,79 +85,61 @@ public class RDXVRManager
             contextInitialized = true;
          }
 
-         if (contextInitialized)
+         context.waitGetPoses();
+         waitGetToRenderStopwatch.reset();
+
+         // pollEventsFrequencyCalculator.ping();
+         context.pollEvents();
+
+         // A tracker has disconnected
+         List<String> removedTrackersSerialNumbers = context.getRemovedTrackersSerialNumbers();
+         Iterator<RDXVRTrackerRoleManager> trackerIterator = trackerRoleManagers.iterator();
+         while (trackerIterator.hasNext())
          {
-            waitGetPosesFrequencyCalculator.ping();
-            context.waitGetPoses();
-            waitGetToRenderStopwatch.reset();
+            RDXVRTrackerRoleManager tracker = trackerIterator.next();
 
-            // pollEventsFrequencyCalculator.ping();
-            context.pollEvents();
-
-            // A tracker has disconnected
-            List<String> removedTrackersSerialNumbers = context.getRemovedTrackersSerialNumbers();
-            for (String removedSerialNumber : removedTrackersSerialNumbers)
+            if (removedTrackersSerialNumbers.contains(tracker.getTrackerSerialNumber()))
             {
-               for (int i = 0; i < trackerRoleManagers.size(); i++)
-               {
-                  if (trackerRoleManagers.get(i).getTrackerSerialNumber().equals(removedSerialNumber))
-                  {
-                     String assignedRole = trackerRoleManagers.get(i).getAssignedRole();
-                     if (assignedRole != null)
-                     {
-                        context.setTrackerRoleAsAvailable(assignedRole);
-                     }
-                     trackerRoleManagers.remove(i);
-                  }
-               }
-               context.getTrackers().remove(removedSerialNumber);
-               LogTools.warn("Tracker {} removed", removedSerialNumber);
-            }
+               trackerIterator.remove();
 
-            // A new tracker has been detected
-            List<String> newTrackersSerialNumbers = context.getNewTrackersSerialNumbers();
-            for (String newSerialNumber : newTrackersSerialNumbers)
+               LogTools.warn("Tracker {} removed", tracker.getTrackerSerialNumber());
+            }
+         }
+
+         // A new tracker has been detected
+         List<String> newTrackersSerialNumbers = context.getNewTrackersSerialNumbers();
+         for (String newSerialNumber : newTrackersSerialNumbers)
+         {
+            trackerRoleManagers.add(new RDXVRTrackerRoleManager(context, context.getTrackers().get(newSerialNumber)));
+         }
+
+         // A reset of roles has been triggered from the UI
+         if (context.getRolesResetNotification().poll())
+         {
+            for (var trackerRoleManager : trackerRoleManagers)
             {
-               trackerRoleManagers.add(new RDXVRTrackerRoleManager(context, context.getTrackers().get(newSerialNumber)));
+               trackerRoleManager.reset();
             }
+         }
 
-            // A reset of roles has been triggered from the UI
-            if (context.getRolesResetNotification().poll())
+         // A loading of preset roles has been triggered from the UI
+         if (context.getLoadingRolesNotification().poll())
+         {
+            var trackerRoleMap = context.getTrackersRoleMap();
+            for (var trackerRole : trackerRoleMap.entrySet())
             {
                for (var trackerRoleManager : trackerRoleManagers)
                {
-                  trackerRoleManager.reset();
-               }
-            }
-
-            // A loading of preset roles has been triggered from the UI
-            if (context.getLoadingRolesNotification().poll())
-            {
-               var trackerRoleMap = context.getTrackersRoleMap();
-               for (var trackerRole : trackerRoleMap.entrySet())
-               {
-                  for (var trackerRoleManager : trackerRoleManagers)
+                  // if serial numbers match
+                  if (trackerRole.getValue().equals(trackerRoleManager.getTrackerSerialNumber()))
                   {
-                     // if serial numbers match
-                     if (trackerRole.getValue().equals(trackerRoleManager.getTrackerSerialNumber()))
-                     {
-                        trackerRoleManager.setActive(trackerRole.getKey());
-                     }
+                     trackerRoleManager.setActive(trackerRole.getKey());
                   }
                }
-               LogTools.info("Loaded roles");
             }
+            LogTools.info("Loaded roles");
          }
       }
-      else
-      {
-         if (contextCreatedNotification != null && contextInitialized)
-         {
-            dispose();
-         }
-      }
-
-      return posesReadyThisFrame;
    }
 
    public void renderMenuBar()
@@ -226,7 +200,6 @@ public class RDXVRManager
    {
       ImGui.checkbox(labels.get("Show scene pose gizmo"), showScenePoseGizmo);
       contextInitializedPlot.render(contextInitialized ? 1.0 : 0.0);
-      waitGetPosesPlot.render(waitGetPosesFrequencyCalculator.getFrequency());
       pollEventsPlot.render(pollEventsFrequencyCalculator.getFrequency());
       vrFPSPlot.render(vrFPSCalculator.getFrequency());
       waitGetToRenderDelayPlot.render(waitGetToRenderDuration);
@@ -244,9 +217,8 @@ public class RDXVRManager
 
    public void dispose()
    {
-      if (contextCreatedNotification != null && contextInitialized)
+      if (contextInitialized)
       {
-         contextCreatedNotification = null;
          contextInitialized = false;
          context.dispose();
       }

--- a/ihmc-graphics/src/libgdx/java/us/ihmc/rdx/vr/RDXVRManager.java
+++ b/ihmc-graphics/src/libgdx/java/us/ihmc/rdx/vr/RDXVRManager.java
@@ -6,7 +6,6 @@ import com.badlogic.gdx.utils.Pool;
 import imgui.internal.ImGui;
 import imgui.type.ImBoolean;
 import org.apache.commons.lang3.StringUtils;
-import us.ihmc.commons.exception.DefaultExceptionHandler;
 import us.ihmc.commons.thread.Notification;
 import us.ihmc.commons.thread.ThreadTools;
 import us.ihmc.commons.time.FrequencyCalculator;
@@ -34,7 +33,6 @@ public class RDXVRManager
    private boolean contextInitialized = false;
    private boolean initializing = false;
    private boolean skipHeadset = false;
-   private final Object syncObject = new Object();
    private final ImBoolean showScenePoseGizmo = new ImBoolean(false);
    private RDXPose3DGizmo scenePoseGizmo;
    private final ImBoolean vrEnabled = new ImBoolean(false);
@@ -50,12 +48,6 @@ public class RDXVRManager
    private final ImGuiPlot pollEventsPlot = new ImGuiPlot(labels.get("Poll Events Hz"), 1000, 180, 50);
    private final FrequencyCalculator pollEventsFrequencyCalculator = new FrequencyCalculator();
    private final ImGuiPlot contextInitializedPlot = new ImGuiPlot(labels.get("contextInitialized"), 1000, 180, 50);
-   private final ImGuiPlot initSystemCountPlot = new ImGuiPlot(labels.get("initSystemCount"), 1000, 180, 50);
-   private volatile int initSystemCount = 0;
-   private final ImGuiPlot setupEyesCountPlot = new ImGuiPlot(labels.get("setupEyesCount"), 1000, 180, 50);
-   private volatile int setupEyesCount = 0;
-   private final Notification waitOnPosesNotification = new Notification();
-   private volatile boolean waitGetPosesThreadRunning = false;
    private final RDXVRTeleporter teleporter = new RDXVRTeleporter();
    private final List<RDXVRTrackerRoleManager> trackerRoleManagers = new ArrayList<>();
 
@@ -67,13 +59,6 @@ public class RDXVRManager
          trackerRoleManagers.add(new RDXVRTrackerRoleManager(context, tracker));
    }
 
-   /**
-    * Doing poll and render close together makes VR performance the best it can be
-    * and reduce dizziness.
-    *
-    * TODO: This thread has to be a multiple of the parent (240?)
-    * TODO: If the rest of the app is too slow, can we run this one faster?
-    */
    public void pollEventsAndRender(RDXBaseUI baseUI, RDX3DScene scene)
    {
       boolean posesReady = pollEvents(baseUI);
@@ -82,10 +67,7 @@ public class RDXVRManager
          skipHeadset = true;
          vrFPSCalculator.ping();
          waitGetToRenderDuration = waitGetToRenderStopwatch.totalElapsed();
-         synchronized (syncObject)
-         {
-            context.renderEyes(scene);
-         }
+         context.renderEyes(scene);
          skipHeadset = false;
       }
    }
@@ -99,110 +81,78 @@ public class RDXVRManager
          {
             initializing = true;
             contextCreatedNotification = new Notification();
-            ThreadTools.startAsDaemon(() ->
-            {
-               synchronized (syncObject)
-               {
-                  initSystemCount++;
-                  context.initSystem();
-               }
-               contextCreatedNotification.set();
-            }, DefaultExceptionHandler.MESSAGE_AND_STACKTRACE, getClass().getSimpleName() + "-initSystem");
+            context.initSystem(); // May block for a bit
          }
          if (contextCreatedNotification != null && contextCreatedNotification.poll())
          {
             initializing = false;
 
-            synchronized (syncObject)
-            {
-               setupEyesCount++;
-               context.setupEyes();
-            }
+            context.setupEyes();
 
             scenePoseGizmo = new RDXPose3DGizmo(context.getTeleportFrameIHMCZUp(), context.getTeleportIHMCZUpToIHMCZUpWorld());
             scenePoseGizmo.create(baseUI.getPrimary3DPanel());
             contextInitialized = true;
-            waitGetPosesThreadRunning = true;
-            ThreadTools.startAsDaemon(this::waitOnPoses, getClass().getSimpleName() + "WaitOnPosesThread");
          }
 
          if (contextInitialized)
          {
-            // Waiting for the poses on a thread allows for the rest of the application to keep
-            // cranking faster than VR can do stuff. This also makes the performance graph in Steam
-            // show the correct value and the OpenVR stack work much better.
-            // TODO: This whole thing might have major issues because
-            // there's a delay waiting for the next time this method is called
-            posesReadyThisFrame = posesReady.poll();
+            waitOnPoses();
 
-            if (!posesReadyThisFrame && !waitingOnPoses)
-            {
-               waitingOnPoses = true;
-               waitOnPosesNotification.set();
-            }
-            else
-            {
-               waitingOnPoses = false;
-            }
+            // pollEventsFrequencyCalculator.ping();
+            context.pollEvents();
 
-            if (posesReadyThisFrame)
+            // A tracker has disconnected
+            List<String> removedTrackersSerialNumbers = context.getRemovedTrackersSerialNumbers();
+            for (String removedSerialNumber : removedTrackersSerialNumbers)
             {
-               // pollEventsFrequencyCalculator.ping();
-               context.pollEvents(); // FIXME: Potential bug is that the poses get updated in the above thread while they're being used in here
-
-               // A tracker has disconnected
-               List<String> removedTrackersSerialNumbers = context.getRemovedTrackersSerialNumbers();
-               for (String removedSerialNumber : removedTrackersSerialNumbers)
+               for (int i = 0; i < trackerRoleManagers.size(); i++)
                {
-                  for (int i = 0; i < trackerRoleManagers.size(); i++)
+                  if (trackerRoleManagers.get(i).getTrackerSerialNumber().equals(removedSerialNumber))
                   {
-                     if (trackerRoleManagers.get(i).getTrackerSerialNumber().equals(removedSerialNumber))
+                     String assignedRole = trackerRoleManagers.get(i).getAssignedRole();
+                     if (assignedRole != null)
                      {
-                        String assignedRole = trackerRoleManagers.get(i).getAssignedRole();
-                        if (assignedRole != null)
-                        {
-                           context.setTrackerRoleAsAvailable(assignedRole);
-                        }
-                        trackerRoleManagers.remove(i);
+                        context.setTrackerRoleAsAvailable(assignedRole);
                      }
+                     trackerRoleManagers.remove(i);
                   }
-                  context.getTrackers().remove(removedSerialNumber);
-                  LogTools.warn("Tracker {} removed", removedSerialNumber);
                }
+               context.getTrackers().remove(removedSerialNumber);
+               LogTools.warn("Tracker {} removed", removedSerialNumber);
+            }
 
-               // A new tracker has been detected
-               List<String> newTrackersSerialNumbers = context.getNewTrackersSerialNumbers();
-               for (String newSerialNumber : newTrackersSerialNumbers)
+            // A new tracker has been detected
+            List<String> newTrackersSerialNumbers = context.getNewTrackersSerialNumbers();
+            for (String newSerialNumber : newTrackersSerialNumbers)
+            {
+               trackerRoleManagers.add(new RDXVRTrackerRoleManager(context, context.getTrackers().get(newSerialNumber)));
+            }
+
+            // A reset of roles has been triggered from the UI
+            if (context.getRolesResetNotification().poll())
+            {
+               for (var trackerRoleManager : trackerRoleManagers)
                {
-                  trackerRoleManagers.add(new RDXVRTrackerRoleManager(context, context.getTrackers().get(newSerialNumber)));
+                  trackerRoleManager.reset();
                }
+            }
 
-               // A reset of roles has been triggered from the UI
-               if (context.getRolesResetNotification().poll())
+            // A loading of preset roles has been triggered from the UI
+            if (context.getLoadingRolesNotification().poll())
+            {
+               var trackerRoleMap = context.getTrackersRoleMap();
+               for (var trackerRole : trackerRoleMap.entrySet())
                {
                   for (var trackerRoleManager : trackerRoleManagers)
                   {
-                     trackerRoleManager.reset();
-                  }
-               }
-
-               // A loading of preset roles has been triggered from the UI
-               if (context.getLoadingRolesNotification().poll())
-               {
-                  var trackerRoleMap = context.getTrackersRoleMap();
-                  for (var trackerRole : trackerRoleMap.entrySet())
-                  {
-                     for (var trackerRoleManager : trackerRoleManagers)
+                     // if serial numbers match
+                     if (trackerRole.getValue().equals(trackerRoleManager.getTrackerSerialNumber()))
                      {
-                        // if serial numbers match
-                        if (trackerRole.getValue().equals(trackerRoleManager.getTrackerSerialNumber()))
-                        {
-                           trackerRoleManager.setActive(trackerRole.getKey());
-                        }
+                        trackerRoleManager.setActive(trackerRole.getKey());
                      }
                   }
-                  LogTools.info("Loaded roles");
                }
+               LogTools.info("Loaded roles");
             }
          }
       }
@@ -219,21 +169,9 @@ public class RDXVRManager
 
    private void waitOnPoses()
    {
-      while (waitGetPosesThreadRunning)
-      {
-         waitOnPosesNotification.blockingPoll();
-
-         if (waitGetPosesThreadRunning)
-         {
-            waitGetPosesFrequencyCalculator.ping();
-            synchronized (syncObject)
-            {
-               context.waitGetPoses();
-            }
-            waitGetToRenderStopwatch.reset();
-            posesReady.set();
-         }
-      }
+      waitGetPosesFrequencyCalculator.ping();
+      context.waitGetPoses();
+      waitGetToRenderStopwatch.reset();
    }
 
    public void renderMenuBar()
@@ -294,8 +232,6 @@ public class RDXVRManager
    {
       ImGui.checkbox(labels.get("Show scene pose gizmo"), showScenePoseGizmo);
       contextInitializedPlot.render(contextInitialized ? 1.0 : 0.0);
-      initSystemCountPlot.render(initSystemCount);
-      setupEyesCountPlot.render(setupEyesCount);
       waitGetPosesPlot.render(waitGetPosesFrequencyCalculator.getFrequency());
       pollEventsPlot.render(pollEventsFrequencyCalculator.getFrequency());
       vrFPSPlot.render(vrFPSCalculator.getFrequency());
@@ -314,8 +250,6 @@ public class RDXVRManager
 
    public void dispose()
    {
-      waitGetPosesThreadRunning = false;
-      waitOnPosesNotification.set();
       if (contextCreatedNotification != null && contextInitialized)
       {
          contextCreatedNotification = null;


### PR DESCRIPTION
Removes the init thread and the poses update thread in the VR manager, drastically improving overall performance because we aren't having to synchronize the render loop with other things.

**Limits UI FPS to the headset display FPS when VR is enabled**