### PR TITLE
bugfix/auto-transition-to-walking

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/wholeBodyHardwareControl/AvatarMultiThreadingFactory.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/wholeBodyHardwareControl/AvatarMultiThreadingFactory.java
@@ -349,7 +349,7 @@ public class AvatarMultiThreadingFactory
          controllerFactory.addFinishedTransition(STAND_TRANSITION_STATE, WALKING, false);
          controllerFactory.addFinishedTransition(EXIT_WALKING, FREEZE_STATE);
 
-         controllerFactory.addCustomStateTransition(createStandTransitionState(STAND_TRANSITION_STATE, controllerFactory, feetForceSensorNames));
+         controllerFactory.addCustomStateTransition(createStandTransitionState(STAND_TRANSITION_STATE, controllerFactory, feetForceSensorNames, !highLevelControllerParameters.automaticallyTransitionToWalkingWhenReady()));
 
          // Transition to DO_NOTHING in the event of a fault
          HighLevelControllerStateCommand transitionToDoNothingCommand = new HighLevelControllerStateCommand();
@@ -447,7 +447,8 @@ public class AvatarMultiThreadingFactory
     */
    private static ControllerStateTransitionFactory<HighLevelControllerName> createStandTransitionState(HighLevelControllerName transitionStateName,
                                                                                                        HighLevelHumanoidControllerFactory controllerFactory,
-                                                                                                       SideDependentList<String> feetForceSensorNames)
+                                                                                                       SideDependentList<String> feetForceSensorNames,
+                                                                                                       boolean waitForRequestToTransition)
    {
       return new ControllerStateTransitionFactory<>()
       {
@@ -472,6 +473,7 @@ public class AvatarMultiThreadingFactory
 
             StateTransitionCondition feetLoadedTransition = new FeetLoadedToWalkingStandTransition(transitionStateName,
                                                                                                    requestedState,
+                                                                                                   waitForRequestToTransition,
                                                                                                    forceSensorDataHolder,
                                                                                                    feetForceSensorNames,
                                                                                                    controlDT,
@@ -522,7 +524,7 @@ public class AvatarMultiThreadingFactory
 
    public void addStandPrepStateTransition(HighLevelControllerName nextControlStateEnum)
    {
-      controllerFactory.addCustomStateTransition(createStandTransitionState(nextControlStateEnum, controllerFactory, robotModel.getSensorInformation().getFeetForceSensorNames()));
+      controllerFactory.addCustomStateTransition(createStandTransitionState(nextControlStateEnum, controllerFactory, robotModel.getSensorInformation().getFeetForceSensorNames(), true));
    }
 
    public void addFinishedTransition(HighLevelControllerName currentControlStateEnum, HighLevelControllerName nextControlStateEnum, boolean performNextStateOnEntry)

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/factories/FeetLoadedToWalkingStandTransitionFactory.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/factories/FeetLoadedToWalkingStandTransitionFactory.java
@@ -24,12 +24,15 @@ public class FeetLoadedToWalkingStandTransitionFactory implements ControllerStat
    private final YoEnum<HighLevelControllerName> requestedState;
    private final SideDependentList<String> feetForceSensors;
 
+   private final boolean waitForRequestToTransition;
+
    public FeetLoadedToWalkingStandTransitionFactory(HighLevelControllerName stateToAttachEnum, HighLevelControllerName nextStateEnum,
-                                                    YoEnum<HighLevelControllerName> requestedState, SideDependentList<String> feetForceSensors)
+                                                    YoEnum<HighLevelControllerName> requestedState, boolean waitForRequestToTransition, SideDependentList<String> feetForceSensors)
    {
       this.stateToAttachEnum = stateToAttachEnum;
       this.nextStateEnum = nextStateEnum;
       this.requestedState = requestedState;
+      this.waitForRequestToTransition = waitForRequestToTransition;
       this.feetForceSensors = feetForceSensors;
    }
 
@@ -47,9 +50,16 @@ public class FeetLoadedToWalkingStandTransitionFactory implements ControllerStat
       ForceSensorDataHolderReadOnly forceSensorDataHolder = controllerFactoryHelper.getForceSensorDataHolder();
       HighLevelControllerParameters highLevelControllerParameters = controllerFactoryHelper.getHighLevelControllerParameters();
 
-      StateTransitionCondition stateTransitionCondition = new FeetLoadedToWalkingStandTransition(nextStateEnum, requestedState, forceSensorDataHolder,
-                                                                                                 feetForceSensors, controlDT, totalMass, gravityZ,
-                                                                                                 highLevelControllerParameters, parentRegistry);
+      StateTransitionCondition stateTransitionCondition = new FeetLoadedToWalkingStandTransition(nextStateEnum,
+                                                                                                 requestedState,
+                                                                                                 waitForRequestToTransition,
+                                                                                                 forceSensorDataHolder,
+                                                                                                 feetForceSensors,
+                                                                                                 controlDT,
+                                                                                                 totalMass,
+                                                                                                 gravityZ,
+                                                                                                 highLevelControllerParameters,
+                                                                                                 parentRegistry);
       stateTransition = new StateTransition<>(nextStateEnum, stateTransitionCondition);
 
       return stateTransition;

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/stateTransitions/FeetLoadedToWalkingStandTransition.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/stateTransitions/FeetLoadedToWalkingStandTransition.java
@@ -19,7 +19,7 @@ public class FeetLoadedToWalkingStandTransition extends FeetLoadedTransition
 
    private final YoDouble minimumTimeInState;
 
-   public FeetLoadedToWalkingStandTransition(HighLevelControllerName nextStateEnum, YoEnum<HighLevelControllerName> requestedState,
+   public FeetLoadedToWalkingStandTransition(HighLevelControllerName nextStateEnum, YoEnum<HighLevelControllerName> requestedState, boolean waitForRequestToTransition,
                                              ForceSensorDataHolderReadOnly forceSensorDataHolder, SideDependentList<String> feetForceSensors, double controlDT,
                                              double totalMass, double gravityZ, HighLevelControllerParameters highLevelControllerParameters,
                                              YoRegistry parentRegistry)
@@ -34,7 +34,7 @@ public class FeetLoadedToWalkingStandTransition extends FeetLoadedTransition
       minimumTimeInState.set(highLevelControllerParameters.getMinimumTimeInStandReady());
 
       this.waitForRequest = new YoBoolean("waitForRequestToTransitionToWalking", registry);
-      this.waitForRequest.set(!highLevelControllerParameters.automaticallyTransitionToWalkingWhenReady());
+      this.waitForRequest.set(waitForRequestToTransition);
    }
 
    @Override


### PR DESCRIPTION
made externally added transitions out of stand prep happen manually, not automatically

This issue popped up when we attached the RL_TRANSITION state to STAND_PREP the same way we do for STAND_TRANSITION. The reason why it is setup this way and not as a normal requestable transition is because this one accounts for stand prep being done, and for the feet being loaded. The problem is if we have two states (RL_TRANSITION and STAND_TRANSITION) set up like this, we cannot have both transitions happen automatically because then the state machine wouldn't know which one to go to. Originally we turned off the auto transition upon feet loading for both states, but this messes with our normal workflow for the normal walking controller of putting the robot into STAND_PREP and then having it do the rest automatically. 

With this PR, the original transition defaults to automatic, and any externally added one (like RL_TRANSITION) requires a manual state transition request