### PR TITLE
Intraprocess logger safety

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/logging/IntraprocessYoVariableLogger.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/logging/IntraprocessYoVariableLogger.java
@@ -34,7 +34,6 @@ import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 public class IntraprocessYoVariableLogger
 {
@@ -68,7 +67,7 @@ public class IntraprocessYoVariableLogger
    private ByteBuffer compressedBuffer;
    private ByteBuffer indexBuffer;
    private ConcurrentRingBuffer<ByteBuffer> compressionBufferRing;
-   private CountDownLatch compressionThreadLatch;
+   private final Object compressionThreadLock = new Object();
    private RepeatingTaskThread compressionThread;
    private FileChannel dataChannel;
    private FileChannel indexChannel;
@@ -196,10 +195,12 @@ public class IntraprocessYoVariableLogger
           */
          indexBuffer = ByteBuffer.allocate(2 * Long.BYTES);
          compressionBufferRing = new ConcurrentRingBuffer<>(() -> ByteBuffer.allocate(singleTickBufferSize), 2);
-         compressionThreadLatch = new CountDownLatch(1);
          compressionThread = new RepeatingTaskThread("IntraprocessLoggerCompressionThread", () ->
          {
-            compressionThreadLatch.await();
+            synchronized (compressionThreadLock)
+            {
+               compressionThreadLock.wait();
+            }
 
             if (compressionBufferRing.poll())
             {
@@ -323,7 +324,10 @@ public class IntraprocessYoVariableLogger
          compressionBufferRing.commit();
       }
 
-      compressionThreadLatch.countDown();
+      synchronized (compressionThreadLock)
+      {
+         compressionThreadLock.notify();
+      }
    }
 
    private File createFileInLogFolder(String filename)

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/logging/IntraprocessYoVariableLogger.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/logging/IntraprocessYoVariableLogger.java
@@ -46,6 +46,7 @@ public class IntraprocessYoVariableLogger
    public static final String MODEL_RESOURCE_BUNDLE = "resources.zip";
    public static final String INDEX_FILENAME = "robotData.dat";
    public static final Path DEFAULT_INCOMING_LOGS_DIRECTORY = Paths.get(System.getProperty("user.home")).resolve(".ihmc").resolve("logs");
+   public static final Path BACKUP_INCOMING_LOGS_DIRECTORY = Paths.get(System.getProperty("user.home")).resolve(".ihmc").resolve("logs2");
 
    private final List<RegistrySendBufferBuilder> registrySendBufferBuilders;
    private final double dt;
@@ -97,6 +98,26 @@ public class IntraprocessYoVariableLogger
          DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmssSSS");
          String fileTimestamp = dateFormat.format(Calendar.getInstance().getTime());
          logFolder = DEFAULT_INCOMING_LOGS_DIRECTORY.resolve(fileTimestamp + logName + INTRAPROCESS_LOG_POSTFIX);
+         logFolder.toFile().mkdirs();
+
+         // Make sure we can create a file in logFolder
+         FileTools.ensureDirectoryExists(logFolder);
+
+         Path tempFile = logFolder.resolve(".temp");
+         FileTools.deleteQuietly(tempFile);
+         if (!tempFile.toFile().createNewFile())
+         {
+            // If we failed to create a temp file, try the backup logs dir
+            logFolder = BACKUP_INCOMING_LOGS_DIRECTORY;
+            logFolder.toFile().mkdirs();
+
+            if (!tempFile.toFile().createNewFile())
+            {
+               // We failed to use both the default and backup logs dir
+               return false;
+            }
+         }
+         FileTools.deleteQuietly(tempFile);
 
          YoVariableHandShakeBuilder handshakeBuilder = new YoVariableHandShakeBuilder("main", dt);
          handshakeBuilder.setFrames(ReferenceFrame.getWorldFrame());
@@ -201,8 +222,20 @@ public class IntraprocessYoVariableLogger
                   indexBuffer.putLong(dataChannel.position());
                   indexBuffer.flip();
 
-                  indexChannel.write(indexBuffer);
-                  dataChannel.write(compressedBuffer);
+                  try
+                  {
+                     long ignored0 = indexChannel.write(indexBuffer);
+                     long ignored1 = dataChannel.write(compressedBuffer);
+                  }
+                  catch (IOException e)
+                  {
+                     LogTools.error("Could not log to: " + logFolder.toAbsolutePath());
+                     LogTools.error("Stopping Intraprocess logger...");
+
+                     destroy();
+
+                     compressionThread.blockingKill();
+                  }
                }
 
                compressionBufferRing.flush();
@@ -252,7 +285,6 @@ public class IntraprocessYoVariableLogger
    {
       if (destroyed)
       {
-         LogTools.error("Logger has already been destroyed.");
          return;
       }
 

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/logging/IntraprocessYoVariableLogger.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/logging/IntraprocessYoVariableLogger.java
@@ -98,8 +98,6 @@ public class IntraprocessYoVariableLogger
          DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmssSSS");
          String fileTimestamp = dateFormat.format(Calendar.getInstance().getTime());
          logFolder = DEFAULT_INCOMING_LOGS_DIRECTORY.resolve(fileTimestamp + logName + INTRAPROCESS_LOG_POSTFIX);
-
-         // Make sure we can create a file in logFolder
          FileTools.ensureDirectoryExists(logFolder);
 
          Path tempFile = logFolder.resolve(".temp");

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/logging/IntraprocessYoVariableLogger.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/logging/IntraprocessYoVariableLogger.java
@@ -98,7 +98,6 @@ public class IntraprocessYoVariableLogger
          DateFormat dateFormat = new SimpleDateFormat("yyyyMMdd_HHmmssSSS");
          String fileTimestamp = dateFormat.format(Calendar.getInstance().getTime());
          logFolder = DEFAULT_INCOMING_LOGS_DIRECTORY.resolve(fileTimestamp + logName + INTRAPROCESS_LOG_POSTFIX);
-         logFolder.toFile().mkdirs();
 
          // Make sure we can create a file in logFolder
          FileTools.ensureDirectoryExists(logFolder);
@@ -109,7 +108,7 @@ public class IntraprocessYoVariableLogger
          {
             // If we failed to create a temp file, try the backup logs dir
             logFolder = BACKUP_INCOMING_LOGS_DIRECTORY;
-            logFolder.toFile().mkdirs();
+            FileTools.ensureDirectoryExists(logFolder);
 
             if (!tempFile.toFile().createNewFile())
             {

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXVRHandControl.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXVRHandControl.java
@@ -126,7 +126,7 @@ public class RDXVRHandControl
                            float newThumbOpposition = thumbOpposition.get(side) + side.negateIfRightSide(1.0f) * Math.signum(lateralJoystick) * THUMB_OPPOSITION_JOYSTICK_INCREMENT;
                            newThumbOpposition = Math.max(0.0f, Math.min(newThumbOpposition, 1.0f));
                            thumbOpposition.put(side, newThumbOpposition);
-                           handManager.getHand(side).sendFingerPosition(5, thumbOpposition.get(side));
+                           handManager.getHand(side).sendFingerPosition(5, 120.0f * thumbOpposition.get(side));
                         }
                      }
 

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXVRHandControl.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/vr/RDXVRHandControl.java
@@ -126,7 +126,7 @@ public class RDXVRHandControl
                            float newThumbOpposition = thumbOpposition.get(side) + side.negateIfRightSide(1.0f) * Math.signum(lateralJoystick) * THUMB_OPPOSITION_JOYSTICK_INCREMENT;
                            newThumbOpposition = Math.max(0.0f, Math.min(newThumbOpposition, 1.0f));
                            thumbOpposition.put(side, newThumbOpposition);
-                           handManager.getHand(side).sendFingerPosition(5, 120.0f * thumbOpposition.get(side));
+                           handManager.getHand(side).sendFingerPosition(5, thumbOpposition.get(side));
                         }
                      }
 


### PR DESCRIPTION
- Make sure the logging directory is usable and provide a backup if not
- Catch any IOException that may happen in the compression thread and stop the logger