### PR TITLE
Buf fix in calculation of terrain traversability

### DIFF
--- a/ihmc-perception/src/main/resources/us/ihmc/perception/gpuMapping/TerrainMapExtractor.cu
+++ b/ihmc-perception/src/main/resources/us/ihmc/perception/gpuMapping/TerrainMapExtractor.cu
@@ -192,7 +192,7 @@ __global__ void computeTerrainData(float *heightMap, size_t pitchHeightMap,
 
         // Roughness check
         float squaredErrorThreshold = params[SQUARED_ERROR_THRESHOLD];
-        squared_error_traversability = clamp((1.0f - squared_error) / squaredErrorThreshold, 0.0f, 1.0f);
+        squared_error_traversability = clamp(1.0f - squared_error / squaredErrorThreshold, 0.0f, 1.0f);
         if (squared_error > squaredErrorThreshold)
         {
             traversability_result = SQUARED_ERROR;


### PR DESCRIPTION
Full traversability being calculated normally on step-ups

<img width="1436" height="944" alt="TerrainMapBug" src="https://github.com/user-attachments/assets/e7c80cee-133d-4779-9d2a-2cb3022ade1b" />

With bugfix

<img width="1092" height="888" alt="TerrainMapBugFix" src="https://github.com/user-attachments/assets/4d08d0ea-2375-460c-bcfd-bc422587f5d2" />
