### PR TITLE
[Feature] Faster RawImage Synchronization in getC/GpuImageMat Methods

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/RawImage.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/RawImage.java
@@ -9,12 +9,14 @@ import us.ihmc.euclid.orientation.interfaces.Orientation3DReadOnly;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.euclid.tuple3D.interfaces.Tuple3DReadOnly;
-import us.ihmc.sensors.CameraIntrinsics;
 import us.ihmc.perception.imageMessage.PixelFormat;
+import us.ihmc.sensors.CameraIntrinsics;
 
 import javax.annotation.Nullable;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * <p>
@@ -48,10 +50,10 @@ public class RawImage
     */
    @Nullable
    private Mat cpuImageMat = null;
-   private final Object cpuImageMutex = new Object();
+   private final Lock cpuImageLock = new ReentrantLock();
    @Nullable
    private GpuMat gpuImageMat = null;
-   private final Object gpuImageMutex = new Object();
+   private final Lock gpuImageLock = new ReentrantLock();
    private final PixelFormat pixelFormat;
    private final CameraIntrinsics cameraIntrinsics;
    private final CameraModel cameraModel;
@@ -283,13 +285,18 @@ public class RawImage
     */
    public Mat getCpuImageMat()
    {
-      synchronized (cpuImageMutex)
+      cpuImageLock.lock();
+      try
       {
-         if (cpuImageMat == null && !gpuImageMat.isNull())
+         if (cpuImageMat == null)
          {
             cpuImageMat = new Mat(gpuImageMat.size(), gpuImageMat.type());
             gpuImageMat.download(cpuImageMat);
          }
+      }
+      finally
+      {
+         cpuImageLock.unlock();
       }
 
       return cpuImageMat;
@@ -308,13 +315,18 @@ public class RawImage
     */
    public GpuMat getGpuImageMat()
    {
-      synchronized (gpuImageMutex)
+      gpuImageLock.lock();
+      try
       {
          if (gpuImageMat == null)
          {
             gpuImageMat = new GpuMat(cpuImageMat.size(), cpuImageMat.type());
             gpuImageMat.upload(cpuImageMat);
          }
+      }
+      finally
+      {
+         gpuImageLock.unlock();
       }
 
       return gpuImageMat;

--- a/ihmc-perception/src/test/java/us/ihmc/perception/RawImageTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/RawImageTest.java
@@ -13,8 +13,8 @@ import us.ihmc.euclid.tools.EuclidCoreTestTools;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.tuple3D.Vector3D;
 import us.ihmc.euclid.yawPitchRoll.YawPitchRoll;
-import us.ihmc.sensors.CameraIntrinsics;
 import us.ihmc.perception.imageMessage.PixelFormat;
+import us.ihmc.sensors.CameraIntrinsics;
 
 import java.time.Instant;
 import java.util.Random;
@@ -189,6 +189,53 @@ public class RawImageTest
       assertFalse(sensorTransform.geometricallyEquals(image.getTransformToWorld(), 1E-7));
 
       image.release();
+   }
+
+   @Test // @RepeatedTest(10)
+   public void testReadBandwidth() throws InterruptedException
+   {
+      RawImage testImage = createRawImage(mat8UC1);
+
+      int numThreads = 300;
+      int readsPerThread = 30000;
+      Thread[] threads = new Thread[numThreads];
+
+      // Make sure the image is initialized once so first-use overhead is gone
+      assertNotNull(testImage.getCpuImageMat());
+      assertNotNull(testImage.getGpuImageMat());
+
+      long startNanos = System.nanoTime();
+
+      for (int i = 0; i < numThreads; ++i)
+      {
+         threads[i] = new Thread(() ->
+         {
+            // Each thread repeatedly reads the image
+            for (int j = 0; j < readsPerThread; j++)
+            {
+               Mat cpu = testImage.getCpuImageMat();
+               GpuMat gpu = testImage.getGpuImageMat();
+
+               // Touch something so JIT cannot trivially dead‑code eliminate
+               assertTrue(cpu != null && !cpu.isNull());
+               assertTrue(gpu != null && !gpu.isNull());
+            }
+         }, "RawImageReader-" + i);
+
+         threads[i].start();
+      }
+
+      for (int i = 0; i < numThreads; ++i)
+         threads[i].join();
+
+      long endNanos = System.nanoTime();
+      long totalReads = (long) numThreads * readsPerThread;
+      double seconds = (endNanos - startNanos) / 1e9;
+      double readsPerSecond = totalReads / seconds;
+
+      System.out.printf("Read bandwidth: %.2f Mops/s (%d reads in %.3f s with %d threads)%n", readsPerSecond / 1e6, totalReads, seconds, numThreads);
+
+      testImage.release();
    }
 
    private boolean dataEquals(BytePointer dataA, BytePointer dataB)


### PR DESCRIPTION
synchronized block (before):
```
Read bandwidth: 8.35 Mops/s (9000000 reads in 1.078 s with 300 threads)
Read bandwidth: 9.26 Mops/s (9000000 reads in 0.972 s with 300 threads)
Read bandwidth: 6.21 Mops/s (9000000 reads in 1.448 s with 300 threads)
Read bandwidth: 7.64 Mops/s (9000000 reads in 1.178 s with 300 threads)
Read bandwidth: 8.21 Mops/s (9000000 reads in 1.096 s with 300 threads)
Read bandwidth: 8.40 Mops/s (9000000 reads in 1.072 s with 300 threads)
Read bandwidth: 8.33 Mops/s (9000000 reads in 1.081 s with 300 threads)
Read bandwidth: 6.78 Mops/s (9000000 reads in 1.327 s with 300 threads)
Read bandwidth: 7.66 Mops/s (9000000 reads in 1.174 s with 300 threads)
Read bandwidth: 6.63 Mops/s (9000000 reads in 1.357 s with 300 threads)
```

ReentrantLock (after):
```Read bandwidth: 23.97 Mops/s (9000000 reads in 0.376 s with 300 threads)
Read bandwidth: 21.76 Mops/s (9000000 reads in 0.414 s with 300 threads)
Read bandwidth: 34.23 Mops/s (9000000 reads in 0.263 s with 300 threads)
Read bandwidth: 29.23 Mops/s (9000000 reads in 0.308 s with 300 threads)
Read bandwidth: 18.74 Mops/s (9000000 reads in 0.480 s with 300 threads)
Read bandwidth: 26.85 Mops/s (9000000 reads in 0.335 s with 300 threads)
Read bandwidth: 33.97 Mops/s (9000000 reads in 0.265 s with 300 threads)
Read bandwidth: 19.88 Mops/s (9000000 reads in 0.453 s with 300 threads)
Read bandwidth: 30.89 Mops/s (9000000 reads in 0.291 s with 300 threads)
Read bandwidth: 27.69 Mops/s (9000000 reads in 0.325 s with 300 threads)
```