### PR TITLE
[Feature] ControllerAPI Low Frequency Topics

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/ROS2SyncedRobotModel.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/drcRobot/ROS2SyncedRobotModel.java
@@ -47,7 +47,7 @@ public class ROS2SyncedRobotModel extends CommunicationsSyncedRobotModel
       robotConfigurationDataInput.addCallback(message -> resetDataReceptionTimer());
       capturabilityBasedStatusInput = new ROS2Input<>(ros2Node,
                                                       CapturabilityBasedStatus.class,
-                                                      HumanoidControllerAPI.getTopic(CapturabilityBasedStatus.class, robotModel.getSimpleRobotName()));
+                                                      HumanoidControllerAPI.getLowFrequencyTopic(CapturabilityBasedStatus.class, robotModel.getSimpleRobotName()));
 
       for (RobotSide robotSide : RobotSide.values)
       {

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/ros2/ROS2ControllerHelper.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/ros2/ROS2ControllerHelper.java
@@ -63,6 +63,11 @@ public class ROS2ControllerHelper extends ROS2Helper
       return subscribe(HumanoidControllerAPI.getTopic(messageClass, simpleRobotName));
    }
 
+   public <T> ROS2Input<T> subscribeToControllerLowFrequency(Class<T> messageClass)
+   {
+      return subscribe(HumanoidControllerAPI.getLowFrequencyTopic(messageClass, simpleRobotName));
+   }
+
    public ROS2Input<RobotConfigurationData> subscribeToRobotConfigurationData()
    {
       return subscribe(StateEstimatorAPI.getRobotConfigurationDataTopic(getRobotName()));

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/controllerAPI/input/ControllerNetworkSubscriber.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/controllerAPI/input/ControllerNetworkSubscriber.java
@@ -4,6 +4,7 @@ import controller_msgs.msg.dds.InvalidPacketNotificationPacket;
 import ihmc_common_msgs.msg.dds.MessageCollection;
 import ihmc_common_msgs.msg.dds.MessageCollectionNotification;
 import us.ihmc.commonWalkingControlModules.controllerAPI.input.MessageCollector.MessageIDExtractor;
+import us.ihmc.commons.thread.Throttler;
 import us.ihmc.communication.controllerAPI.CommandInputManager;
 import us.ihmc.communication.controllerAPI.ControllerAPI;
 import us.ihmc.communication.controllerAPI.MessageUnpackingTools.MessageUnpacker;
@@ -34,6 +35,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public class ControllerNetworkSubscriber
 {
+   private static final double LOW_FREQUENCY_PUBLISH_RATE = 50.0;
    private static final boolean DEBUG = false;
 
    /** The input API to which the received messages should be submitted. */
@@ -58,6 +60,7 @@ public class ControllerNetworkSubscriber
     * communication thread.
     */
    private final Map<Class<? extends Settable<?>>, ROS2Publisher<?>> statusMessagePublisherMap = new HashMap<>();
+   private final Map<Class<? extends Settable<?>>, ThrottledROS2Publisher<?>> lowFrequencyStatusMessagePublisherMap = new HashMap<>();
 
    private final ROS2Node ros2Node;
 
@@ -204,6 +207,7 @@ public class ControllerNetworkSubscriber
       {
          Class<T> messageClass = (Class<T>) listOfSupportedStatusMessages.get(i);
          statusMessagePublisherMap.put(messageClass, createPublisher(messageClass));
+         lowFrequencyStatusMessagePublisherMap.put(messageClass, createLowFrequencyPublisher(messageClass));
       }
 
       for (int i = 0; i < listOfSupportedControlMessages.size(); i++)
@@ -222,6 +226,11 @@ public class ControllerNetworkSubscriber
    private <T extends Settable<T>> ROS2Publisher<T> createPublisher(Class<T> messageClass)
    {
       return ros2Node.createPublisher(ControllerAPI.getTopic(outputTopic, messageClass));
+   }
+
+   private <T extends Settable<T>> ThrottledROS2Publisher<T> createLowFrequencyPublisher(Class<T> messageClass)
+   {
+      return new ThrottledROS2Publisher<>(ros2Node.createPublisher(ControllerAPI.getLowFrequencyTopic(outputTopic, messageClass)), LOW_FREQUENCY_PUBLISH_RATE);
    }
 
    @SuppressWarnings("unchecked")
@@ -295,6 +304,9 @@ public class ControllerNetworkSubscriber
    {
       ROS2Publisher<T> publisher = (ROS2Publisher<T>) statusMessagePublisherMap.get(message.getClass());
       publisher.publish(message);
+
+      ThrottledROS2Publisher<T> throttledPublisher = (ThrottledROS2Publisher<T>) lowFrequencyStatusMessagePublisherMap.get(message.getClass());
+      throttledPublisher.publish(message);
    }
 
    public static interface MessageFilter
@@ -305,5 +317,23 @@ public class ControllerNetworkSubscriber
    public static interface MessageValidator
    {
       String validate(Object message);
+   }
+
+   private static class ThrottledROS2Publisher<T>
+   {
+      private final ROS2Publisher<T> publisher;
+      private final Throttler throttler = new Throttler();
+
+      public ThrottledROS2Publisher(ROS2Publisher<T> publisher, double maxPublishFrequency)
+      {
+         this.publisher = publisher;
+         throttler.setFrequency(maxPublishFrequency);
+      }
+
+      public void publish(T message)
+      {
+         if (throttler.run())
+            publisher.publish(message);
+      }
    }
 }

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/plugin/HumanoidSteppingPluginFactory.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/plugin/HumanoidSteppingPluginFactory.java
@@ -39,7 +39,7 @@ public interface HumanoidSteppingPluginFactory extends HighLevelHumanoidControll
 
    default void createStepGeneratorNetworkSubscriber(String robotName, RealtimeROS2Node realtimeROS2Node)
    {
-      ROS2Topic<?> baseTopic = ControllerAPI.getBaseTopic(HumanoidControllerAPI.HUMANOID_CONTROL_MODULE_NAME, robotName);
+      ROS2Topic<?> baseTopic = HumanoidControllerAPI.getBaseTopic(robotName);
       StepGeneratorNetworkSubscriber stepGeneratorNetworkSubscriber = new StepGeneratorNetworkSubscriber(baseTopic,
                                                                                                          getStepGeneratorCommandInputManager().getCommandInputManager(),
                                                                                                          getStepGeneratorStatusMessageOutputManager(),

--- a/ihmc-communication/src/main/java/us/ihmc/communication/HumanoidControllerAPI.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/HumanoidControllerAPI.java
@@ -32,4 +32,9 @@ public final class HumanoidControllerAPI
    {
       return ControllerAPI.getTopic(getBaseTopic(robotName), messageClass);
    }
+
+   public static <T> ROS2Topic<T> getLowFrequencyTopic(Class<T> messageClass, String robotName)
+   {
+      return ControllerAPI.getLowFrequencyTopic(getBaseTopic(robotName), messageClass);
+   }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/HumanoidControllerAPI.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/HumanoidControllerAPI.java
@@ -10,22 +10,26 @@ public final class HumanoidControllerAPI
    public static final String HUMANOID_KINEMATICS_CONTROLLER_NODE_NAME = "kinematics_ihmc_controller";
    public static final String HUMANOID_CONTROL_MODULE_NAME = "humanoid_control";
 
-   public static final ROS2Topic<?> HUMANOID_CONTROLLER = ROS2Tools.IHMC_ROOT.withModule(HUMANOID_CONTROL_MODULE_NAME);
    public static final ROS2Topic<TextToSpeechPacket> TEXT_STATUS = ROS2Tools.IHMC_ROOT.withTypeName(TextToSpeechPacket.class);
+
+   public static ROS2Topic<?> getBaseTopic(String robotName)
+   {
+      return ControllerAPI.getBaseTopic(HUMANOID_CONTROL_MODULE_NAME, robotName);
+   }
 
    public static ROS2Topic<?> getOutputTopic(String robotName)
    {
-      return HUMANOID_CONTROLLER.withRobot(robotName).withOutput();
+      return getBaseTopic(robotName).withOutput();
    }
 
    public static ROS2Topic<?> getInputTopic(String robotName)
    {
-      return HUMANOID_CONTROLLER.withRobot(robotName).withInput();
+      return getBaseTopic(robotName).withInput();
    }
 
    /** Applies only for the humanoid controller. */
    public static <T> ROS2Topic<T> getTopic(Class<T> messageClass, String robotName)
    {
-      return ControllerAPI.getTopic(ControllerAPI.getBaseTopic(HUMANOID_CONTROL_MODULE_NAME, robotName), messageClass);
+      return ControllerAPI.getTopic(getBaseTopic(robotName), messageClass);
    }
 }

--- a/ihmc-communication/src/main/java/us/ihmc/communication/controllerAPI/ControllerAPI.java
+++ b/ihmc-communication/src/main/java/us/ihmc/communication/controllerAPI/ControllerAPI.java
@@ -163,6 +163,11 @@ public final class ControllerAPI
          return baseTopic.withTypeName(messageClass).withQoS(getQoS(messageClass));
    }
 
+   public static <T> ROS2Topic<T> getLowFrequencyTopic(ROS2Topic<?> baseTopic, Class<T> messageClass)
+   {
+      return getTopic(baseTopic, messageClass).withSuffix("lf");
+   }
+
    public static ROS2QosProfile getQoS(Class<?> messageClass)
    {
       if (inputMessageClasses.contains(messageClass))

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXContinuousHikingPanel.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/perception/RDXContinuousHikingPanel.java
@@ -66,6 +66,7 @@ import java.util.ArrayList;
 import java.util.EnumMap;
 import java.util.List;
 
+import static us.ihmc.communication.HumanoidControllerAPI.getLowFrequencyTopic;
 import static us.ihmc.communication.HumanoidControllerAPI.getTopic;
 
 public class RDXContinuousHikingPanel extends RDXPanel implements RenderableProvider
@@ -131,7 +132,7 @@ public class RDXContinuousHikingPanel extends RDXPanel implements RenderableProv
       footstepStatusMessagePublisher = ros2Node.createPublisher(getTopic(FootstepStatusMessage.class, robotModel.getSimpleRobotName()));
       walkingControllerFailureStatusPublisher = ros2Node.createPublisher(getTopic(WalkingControllerFailureStatusMessage.class,
                                                                                   robotModel.getSimpleRobotName()));
-      planOffsetStatusPublisher = ros2Node.createPublisher(getTopic(PlanOffsetStatus.class, robotModel.getSimpleRobotName()));
+      planOffsetStatusPublisher = ros2Node.createPublisher(getLowFrequencyTopic(PlanOffsetStatus.class, robotModel.getSimpleRobotName()));
       clearGoalFootstepsPublisher = ros2Node.createPublisher(ContinuousHikingAPI.CLEAR_GOAL_FOOTSTEPS);
       resetStateMachinePublisher = ros2Node.createPublisher(ContinuousHikingAPI.RESET_STATE_MACHINE);
 

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/RDXJoystickBasedStepping.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/ui/RDXJoystickBasedStepping.java
@@ -124,7 +124,7 @@ public class RDXJoystickBasedStepping
    {
       this.controllerHelper = controllerHelper;
       this.syncedRobot = syncedRobot;
-      capturabilityBasedStatusInput = controllerHelper.subscribeToController(CapturabilityBasedStatus.class);
+      capturabilityBasedStatusInput = controllerHelper.subscribeToControllerLowFrequency(CapturabilityBasedStatus.class);
       controllerHelper.subscribeToControllerViaCallback(FootstepStatusMessage.class, footstepStatus ->
       {
          queuedTasksToProcess.add(() ->

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/tools/RemoteHumanoidRobotInterface.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/tools/RemoteHumanoidRobotInterface.java
@@ -82,7 +82,7 @@ public class RemoteHumanoidRobotInterface
       this.robotModel = robotModel;
       robotName = robotModel.getSimpleRobotName();
       jointMap = robotModel.getJointMap();
-      topicName = HumanoidControllerAPI.HUMANOID_CONTROLLER.withRobot(robotName);
+      topicName = HumanoidControllerAPI.getBaseTopic(robotName);
 
       controllerPublisherMap = new ROS2ControllerPublisherMap(ros2Node, robotName);
       publisherMap = new ROS2PublisherMap(ros2Node);

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/tools/walkingController/ControllerStatusTracker.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/tools/walkingController/ControllerStatusTracker.java
@@ -21,6 +21,7 @@ import us.ihmc.tools.Timer;
 import java.util.ArrayList;
 import java.util.List;
 
+import static us.ihmc.communication.HumanoidControllerAPI.getLowFrequencyTopic;
 import static us.ihmc.communication.HumanoidControllerAPI.getTopic;
 
 /**
@@ -60,9 +61,9 @@ public class ControllerStatusTracker
       robotModel.addRobotConfigurationDataReceivedCallback(this::acceptRobotConfigurationData);
       ros2Node.createSubscription2(getTopic(HighLevelStateChangeStatusMessage.class, robotName), this::acceptHighLevelStateChangeStatusMessage);
       ros2Node.createSubscription2(getTopic(WalkingControllerFailureStatusMessage.class, robotName), this::acceptWalkingControllerFailureStatusMessage);
-      ros2Node.createSubscription2(getTopic(PlanOffsetStatus.class, robotName), this::acceptPlanOffsetStatus);
+      ros2Node.createSubscription2(getLowFrequencyTopic(PlanOffsetStatus.class, robotName), this::acceptPlanOffsetStatus);
       ros2Node.createSubscription2(getTopic(ControllerCrashNotificationPacket.class, robotName), this::acceptControllerCrashNotificationPacket);
-      ros2Node.createSubscription2(getTopic(CapturabilityBasedStatus.class, robotName), this::acceptCapturabilityBasedStatus);
+      ros2Node.createSubscription2(getLowFrequencyTopic(CapturabilityBasedStatus.class, robotName), this::acceptCapturabilityBasedStatus);
       ros2Node.createSubscription2(getTopic(WalkingStatusMessage.class, robotName), this::acceptWalkingStatusMessage);
    }
 

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/tools/walkingController/WalkingFootstepTracker.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/tools/walkingController/WalkingFootstepTracker.java
@@ -18,6 +18,7 @@ import us.ihmc.ros2.ROS2Subscription;
 import java.util.ArrayList;
 import java.util.List;
 
+import static us.ihmc.communication.HumanoidControllerAPI.getLowFrequencyTopic;
 import static us.ihmc.communication.HumanoidControllerAPI.getTopic;
 import static us.ihmc.tools.string.StringTools.format;
 
@@ -48,7 +49,7 @@ public class WalkingFootstepTracker
                                                                 this::interceptFootstepDataListMessage);
       footstepStatusSubscriber = ros2Node.createSubscription2(getTopic(FootstepStatusMessage.class, robotName),
                                                               this::acceptFootstepStatusMessage);
-      footstepQueueStatusSubscriber = ros2Node.createSubscription2(getTopic(FootstepQueueStatusMessage.class, robotName),
+      footstepQueueStatusSubscriber = ros2Node.createSubscription2(getLowFrequencyTopic(FootstepQueueStatusMessage.class, robotName),
                                                                    this::acceptFootstepQueueStatusMessage);
    }
 

--- a/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/ControllerFootstepQueueMonitor.java
+++ b/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/ControllerFootstepQueueMonitor.java
@@ -8,7 +8,6 @@ import controller_msgs.msg.dds.QueuedFootstepStatusMessage;
 import controller_msgs.msg.dds.WalkingControllerFailureStatusMessage;
 import controller_msgs.msg.dds.WalkingStatusMessage;
 import ihmc_common_msgs.msg.dds.QueueableMessage;
-import us.ihmc.communication.HumanoidControllerAPI;
 import us.ihmc.euclid.referenceFrame.FramePose3D;
 import us.ihmc.euclid.referenceFrame.interfaces.FramePose3DReadOnly;
 import us.ihmc.humanoidRobotics.communication.packets.walking.WalkingStatus;
@@ -20,6 +19,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static us.ihmc.communication.HumanoidControllerAPI.getLowFrequencyTopic;
 import static us.ihmc.communication.HumanoidControllerAPI.getTopic;
 
 public class ControllerFootstepQueueMonitor
@@ -37,9 +37,9 @@ public class ControllerFootstepQueueMonitor
 
    public ControllerFootstepQueueMonitor(ROS2Node ros2Node, String simpleRobotName)
    {
-      ros2Node.createSubscription2(HumanoidControllerAPI.getTopic(FootstepQueueStatusMessage.class, simpleRobotName), this::footstepQueueStatusReceived);
-      ros2Node.createSubscription2(HumanoidControllerAPI.getTopic(FootstepStatusMessage.class, simpleRobotName), this::footstepStatusReceived);
-      ros2Node.createSubscription2(getTopic(PlanOffsetStatus.class, simpleRobotName), this::acceptPlanOffsetStatus);
+      ros2Node.createSubscription2(getLowFrequencyTopic(FootstepQueueStatusMessage.class, simpleRobotName), this::footstepQueueStatusReceived);
+      ros2Node.createSubscription2(getTopic(FootstepStatusMessage.class, simpleRobotName), this::footstepStatusReceived);
+      ros2Node.createSubscription2(getLowFrequencyTopic(PlanOffsetStatus.class, simpleRobotName), this::acceptPlanOffsetStatus);
       ros2Node.createSubscription2(getTopic(WalkingStatusMessage.class, simpleRobotName), this::acceptWalkingStatusMessage);
       ros2Node.createSubscription2(getTopic(WalkingControllerFailureStatusMessage.class, simpleRobotName), this::acceptWalkingControllerFailureStatusMessage);
       ros2Node.createSubscription2(getTopic(FootstepDataListMessage.class, simpleRobotName), this::interceptFootstepDataListMessage);


### PR DESCRIPTION
Add low frequency output topics to the ControllerAPI. Each controller output now has two topics: a normal unthrottled topic and a throttled low frequency topic. 

The low frequency topics are simply the normal topic with `/lf` appended. For example, the normal topic
`/ihmc/alex/humanoid_control/output/footstep_queue_status`
has its low frequency alternative as 
`/ihmc/alex/humanoid_control/output/footstep_queue_status/lf`. 

Currently I set an arbitrary publish frequency limit to 50hz (matching RCD publish frequency). Let me know if you'd like to see a different number/have it parametrized somehow.

Tested this on the robot using the shakeout behavior, a tiny bit of continuous hiking, and control ring walking. 