### PR TITLE
[Bugfix] YOLO Cropping Top & Bottom of Detections

### DIFF
--- a/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXYOLOv8PipelineDemo.java
+++ b/ihmc-high-level-behaviors/src/test/java/us/ihmc/rdx/perception/RDXYOLOv8PipelineDemo.java
@@ -53,14 +53,14 @@ import java.util.concurrent.TimeUnit;
 
 public class RDXYOLOv8PipelineDemo
 {
-   private static final String SVO_FILE = System.getProperty("user.home") + "/Downloads/20251217_151953_H1NewModelTest.svo2";
+   private static final String SVO_FILE = "/opt/ihmc/LogData/UserFolders/TomaszFolder/20251020_ZEDXMini_DoorChargeBarrierBottle.svo2";
 
    private static final String SAVE_DIRECTORY = System.getProperty("user.home") + File.separator + "Documents" + File.separator;
 
    private final ROS2Node ros2Node = new ROS2NodeBuilder().build(RDXYOLOv8PipelineDemo.class.getSimpleName());
    private final ROS2Helper ros2Helper = new ROS2Helper(ros2Node);
 
-   private final ROS2ZEDSVOPlaybackSensor zedPlaybackSensor = new ROS2ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, zed.SL_DEPTH_MODE_PERFORMANCE, SVO_FILE);
+   private final ROS2ZEDSVOPlaybackSensor zedPlaybackSensor = new ROS2ZEDSVOPlaybackSensor(ros2Helper, 0, ZEDModelData.ZED_2, zed.SL_DEPTH_MODE_NEURAL, SVO_FILE);
    private RawImage colorImage;
    private final RDXImageVisualizer colorImageVisualizer = new RDXImageVisualizer("ZED Color", "ZED Color", false);
    private RawImage depthImage;

--- a/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8Model.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8Model.java
@@ -14,6 +14,7 @@ import org.bytedeco.opencv.opencv_core.Rect;
 import org.bytedeco.opencv.opencv_core.Scalar;
 import org.bytedeco.opencv.opencv_core.Size;
 import org.bytedeco.opencv.opencv_core.StringVector;
+import org.bytedeco.opencv.opencv_dnn.Image2BlobParams;
 import org.bytedeco.opencv.opencv_dnn.Net;
 import org.yaml.snakeyaml.Yaml;
 import us.ihmc.perception.CameraModel;
@@ -41,8 +42,15 @@ import static org.bytedeco.cuda.global.cudart.*;
 
 public class YOLOv8Model
 {
-   private static final double SCALE_FACTOR = 1.0 / 255.0;
    private static final Size DETECTION_SIZE = new Size(1280, 736);
+   private static final Image2BlobParams IMAGE_TO_BLOB_PARAMS = new Image2BlobParams(Scalar.all(1.0 / 255.0),
+                                                                                     DETECTION_SIZE,
+                                                                                     new Scalar(),
+                                                                                     true,
+                                                                                     opencv_core.CV_32F,
+                                                                                     opencv_dnn.DNN_LAYOUT_NCHW,
+                                                                                     opencv_dnn.DNN_PMODE_LETTERBOX,
+                                                                                     new Scalar());
 
    private static final int FILTERED_FLOATS_PER_ROW = 38;
    private static final int FLOATS_PER_BOX = 5;
@@ -91,8 +99,7 @@ public class YOLOv8Model
       URL classNamesFileURL = YOLOv8Tools.getClassNamesFile(modelBaseDirectory);
       URL onnxFileURL = YOLOv8Tools.getONNXFile(modelBaseDirectory);
 
-      try (InputStream classNamesFile = classNamesFileURL.openStream();
-           InputStream onnxFile = onnxFileURL.openStream())
+      try (InputStream classNamesFile = classNamesFileURL.openStream(); InputStream onnxFile = onnxFileURL.openStream())
       {
          // Parse class_names.yaml
          Yaml yaml = new Yaml();
@@ -289,7 +296,7 @@ public class YOLOv8Model
       }
 
       // Run the net
-      Mat blob = opencv_dnn.blobFromImage(bgrInputImage.getCpuImageMat(), SCALE_FACTOR, DETECTION_SIZE, new Scalar(), true, true, opencv_core.CV_32F);
+      Mat blob = opencv_dnn.blobFromImageWithParams(bgrInputImage.getCpuImageMat(), IMAGE_TO_BLOB_PARAMS);
       yoloNet.setInput(blob);
       yoloNet.forward(outputBlobs, outputNames);
       blob.close();
@@ -336,11 +343,9 @@ public class YOLOv8Model
        * mskWht32 |   |   |   |   |   |   |   |   |   | . |   |
        *          +------------------------------------ . ----+
        */
-      try (Mat output0Blob = outputBlobs.get(0);
-           Mat output1Blob = outputBlobs.get(1);
+      try (Mat output0Blob = outputBlobs.get(0); Mat output1Blob = outputBlobs.get(1);
 
-           dim3 blockDims = new dim3();
-           dim3 gridDims = new dim3())
+           dim3 blockDims = new dim3(); dim3 gridDims = new dim3())
       {
          updateCUDAMemoryAllocation(output0Blob, output1Blob);
 
@@ -415,7 +420,7 @@ public class YOLOv8Model
          CameraIntrinsics maskIntrinsics = computeMaskIntrinsics(bgrInputImage);
          float widthScale = (float) bgrInputImage.getWidth() / DETECTION_SIZE.width();
          float heightScale = (float) bgrInputImage.getHeight() / DETECTION_SIZE.height();
-         float scaleFactor = Math.min(widthScale, heightScale);
+         float scaleFactor = Math.max(widthScale, heightScale);
          float scaledDetectionWidth = DETECTION_SIZE.width() * scaleFactor;
          float scaledDetectionHeight = DETECTION_SIZE.height() * scaleFactor;
          float offsetX = 0.5f * (bgrInputImage.getWidth() - scaledDetectionWidth);
@@ -455,7 +460,7 @@ public class YOLOv8Model
       int maskHeight = outputBlobs.get(1).size(2);
       int maskWidth = outputBlobs.get(1).size(3);
 
-      float scaleFactor = Math.max((float) maskWidth / bgrInputImage.getWidth(), (float) maskHeight / bgrInputImage.getHeight());
+      float scaleFactor = Math.min((float) maskWidth / bgrInputImage.getWidth(), (float) maskHeight / bgrInputImage.getHeight());
 
       float offsetX = 0.5f * (maskWidth - scaleFactor * bgrInputImage.getWidth());
       float offsetY = 0.5f * (maskHeight - scaleFactor * bgrInputImage.getHeight());

--- a/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8Tools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8Tools.java
@@ -8,7 +8,6 @@ import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.MatVector;
 import org.bytedeco.opencv.opencv_core.Point;
 import org.bytedeco.opencv.opencv_core.Rect;
-import org.bytedeco.opencv.opencv_core.Scalar;
 import org.bytedeco.opencv.opencv_core.Size;
 import perception_msgs.msg.dds.YOLOv8ModelInfo;
 import us.ihmc.commons.MathTools;
@@ -143,6 +142,27 @@ public class YOLOv8Tools
       return centroid;
    }
 
+   public static void resizeWithCrop(Mat inputImage, Mat outputImage, Size desiredSize)
+   {
+      Mat resizedMat = new Mat();
+
+      int desiredWidth = desiredSize.width();
+      int desiredHeight = desiredSize.height();
+      double scaleFactor = Math.max((double) desiredWidth / inputImage.cols(), (double) desiredHeight / inputImage.rows());
+
+      // Use explicit target dimensions so the resized image always fully covers desiredSize
+      int resizedWidth = (int) Math.ceil(inputImage.cols() * scaleFactor);
+      int resizedHeight = (int) Math.ceil(inputImage.rows() * scaleFactor);
+      opencv_imgproc.resize(inputImage, resizedMat, new Size(resizedWidth, resizedHeight), 0.0, 0.0, opencv_imgproc.INTER_LINEAR);
+
+      int horizontalCrop = Math.max(resizedWidth - desiredWidth, 0) / 2;
+      int verticalCrop = Math.max(resizedHeight - desiredHeight, 0) / 2;
+
+      Rect roi = new Rect(horizontalCrop, verticalCrop, desiredWidth, desiredHeight);
+      resizedMat.apply(roi).copyTo(outputImage);
+      resizedMat.close();
+   }
+
    /**
     * Annotates the {@code inputImage} using the {@code detections} and puts the result in {@code annotatedImage}.
     *
@@ -186,26 +206,12 @@ public class YOLOv8Tools
          RawImage mask = detection.getObjectMask();
          Mat maskMat = mask.getCpuImageMat();
 
-         // Account for aspect ratio by scaling to match annotatedImage width
-         Size scaleSize = annotatedImage.rows() > maskMat.rows() ?
-               new Size(annotatedImage.cols(), maskMat.rows() * annotatedImage.cols() / maskMat.cols()) :
-               new Size(maskMat.cols() * annotatedImage.rows() / maskMat.rows(), annotatedImage.rows());
-         Mat scaledMask = new Mat(scaleSize, maskMat.type());
-         opencv_imgproc.resize(maskMat, scaledMask, scaleSize);
-         Scalar scalar = new Scalar(0);
-         Mat paddedMask = new Mat(annotatedImage.rows(), annotatedImage.cols(), maskMat.type(), scalar);
-         Rect roi = annotatedImage.rows() > maskMat.rows() ?
-               new Rect(0, (annotatedImage.rows() - scaledMask.rows()) / 2, scaledMask.cols(), scaledMask.rows()) :
-               new Rect((annotatedImage.cols() - scaledMask.cols()) / 2, 0, scaledMask.cols(), scaledMask.rows());
-         Mat paddedMaskCenter = new Mat(paddedMask, roi);
-         scaledMask.copyTo(paddedMaskCenter);
-         scaleSize.close();
-         paddedMaskCenter.close();
-         scalar.close();
-         roi.close();
+         // Scaling to match annotatedImage and crop away the letter box lines added to the mask during YOLO processing to match aspect ratio
+         Mat resizedMask = new Mat();
+         resizeWithCrop(maskMat, resizedMask, annotatedImage.size());
 
-         opencv_core.add(annotatedImage, greenMat, annotatedImage, paddedMask, -1);
-         paddedMask.close();
+         opencv_core.add(annotatedImage, greenMat, annotatedImage, resizedMask, -1);
+         resizedMask.close();
 
          boundingBox.close();
          textBox.close();
@@ -248,30 +254,16 @@ public class YOLOv8Tools
          RawImage mask = detection.getObjectMask();
          Mat maskMat = mask.getCpuImageMat();
 
-         // Account for aspect ratio by scaling to match annotatedImage width
-         Size scaleSize = annotatedImage.rows() > maskMat.rows() ?
-               new Size(annotatedImage.cols(), maskMat.rows() * annotatedImage.cols() / maskMat.cols()) :
-               new Size(maskMat.cols() * annotatedImage.rows() / maskMat.rows(), annotatedImage.rows());
-         Mat scaledMask = new Mat(scaleSize, maskMat.type());
-         opencv_imgproc.resize(maskMat, scaledMask, scaleSize);
-         Scalar scalar = new Scalar(0);
-         Mat paddedMask = new Mat(annotatedImage.rows(), annotatedImage.cols(), maskMat.type(), scalar);
-         Rect roi = annotatedImage.rows() > maskMat.rows() ?
-               new Rect(0, (annotatedImage.rows() - scaledMask.rows()) / 2, scaledMask.cols(), scaledMask.rows()) :
-               new Rect((annotatedImage.cols() - scaledMask.cols()) / 2, 0, scaledMask.cols(), scaledMask.rows());
-         Mat paddedMaskCenter = new Mat(paddedMask, roi);
-         scaledMask.copyTo(paddedMaskCenter);
-         scaleSize.close();
-         paddedMaskCenter.close();
-         scalar.close();
-         roi.close();
+         // Scaling to match annotatedImage and crop away the letter box lines added to the mask during YOLO processing to match aspect ratio
+         Mat resizedMask = new Mat();
+         resizeWithCrop(maskMat, resizedMask, annotatedImage.size());
 
          MatVector contours = new MatVector();
          Mat hierarchy = new Mat();
-         opencv_imgproc.findContours(paddedMask, contours, hierarchy, opencv_imgproc.RETR_TREE, opencv_imgproc.CHAIN_APPROX_SIMPLE);
+         opencv_imgproc.findContours(resizedMask, contours, hierarchy, opencv_imgproc.RETR_TREE, opencv_imgproc.CHAIN_APPROX_SIMPLE);
          opencv_imgproc.drawContours(annotatedImage, contours, -1, GREEN, 4, LINE_TYPE, hierarchy, Integer.MAX_VALUE, new Point());
 
-         paddedMask.close();
+         resizedMask.close();
       }
    }
 

--- a/ihmc-perception/src/test/java/us/ihmc/perception/detections/yolo/YOLOv8ToolsTest.java
+++ b/ihmc-perception/src/test/java/us/ihmc/perception/detections/yolo/YOLOv8ToolsTest.java
@@ -1,5 +1,8 @@
 package us.ihmc.perception.detections.yolo;
 
+import org.bytedeco.opencv.global.opencv_core;
+import org.bytedeco.opencv.opencv_core.Mat;
+import org.bytedeco.opencv.opencv_core.Size;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import us.ihmc.tools.IHMCCommonPaths;
@@ -83,5 +86,63 @@ public class YOLOv8ToolsTest
       // Getting class names file
       assertEquals(validClassNameFile.toURI().toURL(), YOLOv8Tools.getClassNamesFile(goodYoloModelDirectory.toURI().toURL()));
       assertThrows(IllegalArgumentException.class, () -> YOLOv8Tools.getClassNamesFile(badYoloModelDirectory.toURI().toURL()));
+   }
+
+   @Test
+   public void testResizeWithCropDownscaleCenterCrop()
+   {
+      Mat input = new Mat(100, 200, opencv_core.CV_8UC1);
+      Mat output = new Mat();
+
+      for (int y = 0; y < input.rows(); y++)
+      {
+         for (int x = 0; x < input.cols(); x++)
+            input.ptr(y, x).put((byte) x);
+      }
+
+      YOLOv8Tools.resizeWithCrop(input, output, new Size(100, 100));
+
+      assertEquals(100, output.cols());
+      assertEquals(100, output.rows());
+      assertEquals(50, getUnsignedByte(output, 50, 0));
+      assertEquals(100, getUnsignedByte(output, 50, 50));
+      assertEquals(149, getUnsignedByte(output, 50, 99));
+
+      input.close();
+      output.close();
+   }
+
+   @Test
+   public void testResizeWithCropUpscaleCenterCrop()
+   {
+      Mat input = new Mat(100, 50, opencv_core.CV_8UC1);
+      Mat output = new Mat();
+
+      for (int y = 0; y < input.rows(); y++)
+      {
+         for (int x = 0; x < input.cols(); x++)
+            input.ptr(y, x).put((byte) y);
+      }
+
+      YOLOv8Tools.resizeWithCrop(input, output, new Size(200, 200));
+
+      assertEquals(200, output.cols());
+      assertEquals(200, output.rows());
+
+      int topSample = getUnsignedByte(output, 0, 100);
+      int centerSample = getUnsignedByte(output, 100, 100);
+      int bottomSample = getUnsignedByte(output, 199, 100);
+
+      assertTrue(topSample < centerSample);
+      assertTrue(centerSample < bottomSample);
+      assertTrue(centerSample >= 49 && centerSample <= 51);
+
+      input.close();
+      output.close();
+   }
+
+   private static int getUnsignedByte(Mat mat, int row, int col)
+   {
+      return mat.ptr(row, col).get() & 0xFF;
    }
 }


### PR DESCRIPTION
Doesn't fix the door segmentations cutting off at the bottom though. That's some other issue.

Before: 
<img width="1920" height="1200" alt="Screenshot from 2026-03-20 15-27-01" src="https://github.com/user-attachments/assets/d4455795-5a99-4f37-9d5a-b3606874830b" />

After:
<img width="1920" height="1200" alt="Screenshot from 2026-03-20 15-24-31" src="https://github.com/user-attachments/assets/fc688de3-3044-4e45-8eaf-77c9f5466edb" />
