### PR TITLE
Set Java compile encoding to UTF-8

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,5 @@
 plugins {
    id("us.ihmc.ihmc-build")
 }
+
+apply(from = "gradle/java-compile-encoding.gradle.kts")

--- a/example-simulations/build.gradle.kts
+++ b/example-simulations/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/gradle/java-compile-encoding.gradle.kts
+++ b/gradle/java-compile-encoding.gradle.kts
@@ -1,0 +1,7 @@
+import org.gradle.api.tasks.compile.JavaCompile
+
+allprojects {
+   tasks.withType<JavaCompile>().configureEach {
+      options.encoding = "UTF-8"
+   }
+}

--- a/ihmc-avatar-interfaces/build.gradle.kts
+++ b/ihmc-avatar-interfaces/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-common-walking-control-modules/build.gradle.kts
+++ b/ihmc-common-walking-control-modules/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-communication/build.gradle.kts
+++ b/ihmc-communication/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-footstep-planning/build.gradle.kts
+++ b/ihmc-footstep-planning/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
 

--- a/ihmc-graphics/build.gradle.kts
+++ b/ihmc-graphics/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
 

--- a/ihmc-high-level-behaviors/build.gradle.kts
+++ b/ihmc-high-level-behaviors/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-humanoid-robotics/build.gradle.kts
+++ b/ihmc-humanoid-robotics/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-interfaces-jros2/build.gradle.kts
+++ b/ihmc-interfaces-jros2/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
    id("us.ihmc.jros2.generator") version "1.5.0"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
 

--- a/ihmc-java-toolkit/build.gradle.kts
+++ b/ihmc-java-toolkit/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-manipulation-planning/build.gradle.kts
+++ b/ihmc-manipulation-planning/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-model-file-loader/build.gradle.kts
+++ b/ihmc-model-file-loader/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-parameter-estimation/build.gradle.kts
+++ b/ihmc-parameter-estimation/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-parameter-optimization/build.gradle.kts
+++ b/ihmc-parameter-optimization/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-path-planning/build.gradle.kts
+++ b/ihmc-path-planning/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
 

--- a/ihmc-perception/build.gradle.kts
+++ b/ihmc-perception/build.gradle.kts
@@ -9,6 +9,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    configureDependencyResolution()

--- a/ihmc-robot-models/build.gradle.kts
+++ b/ihmc-robot-models/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
 

--- a/ihmc-robotics-toolkit/build.gradle.kts
+++ b/ihmc-robotics-toolkit/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
 

--- a/ihmc-sensor-processing/build.gradle.kts
+++ b/ihmc-sensor-processing/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-simulation-toolkit/build.gradle.kts
+++ b/ihmc-simulation-toolkit/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-state-estimation/build.gradle.kts
+++ b/ihmc-state-estimation/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-system-identification/build.gradle.kts
+++ b/ihmc-system-identification/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/ihmc-whole-body-controller/build.gradle.kts
+++ b/ihmc-whole-body-controller/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
    id("us.ihmc.scs") version "0.4"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/simulation-construction-set-tools/build.gradle.kts
+++ b/simulation-construction-set-tools/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
    id("us.ihmc.scs") version "0.4"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    

--- a/zulu/build.gradle.kts
+++ b/zulu/build.gradle.kts
@@ -4,6 +4,8 @@ plugins {
    id("us.ihmc.log-tools-plugin") version "0.6.3"
 }
 
+apply(from = "../gradle/java-compile-encoding.gradle.kts")
+
 ihmc {
    loadProductProperties("../product.properties")
    


### PR DESCRIPTION
## Summary

- Set Java compile encoding to UTF-8 through one shared Gradle convention.
- Apply that convention from the root and each included build so Gradle
  invocations launched from subproject directories do not fall back to the
  runner's platform-default charset.

## Evidence

Scheduled slow run
[`30148251430`](https://github.com/ihmcrobotics/ihmc-open-robotics-software/actions/runs/30148251430)
at `develop@f9118422` emitted `890` `US-ASCII` unmappable-character
diagnostics across `15` Java source files in six modules.

## Verification

- Exact refreshed head: `b700e10f882edc0403094e7a12913c566ca18b36`.
- Diff against current `develop`: `27` files, `59` additions, `0` deletions.
- Exact-head forced-US-ASCII `ihmc-sensor-processing clean compileJava`:
  successful in `12s`, `0` unmappable-character diagnostics.
- Exact-head forced-US-ASCII `zulu compileJava --rerun-tasks`: successful in
  `21s`, `0` unmappable-character diagnostics.
- Current-develop compatibility matrix with the replayed upstream `#1400`
  queue-ID fix plus the rough-terrain and flat-ground patches: all `15/15`
  categories passed, `134` tests, `0` failures, `0` errors, `13` skipped.
- All files changed by this PR are byte-identical in that integration head.
- `git diff --check`: passed locally and on Umbra.

## Scope

This refreshed PR is encoding-only. Current `develop` already contains the
allocation fix from `#1401`, and `#1400` is the preferred upstream artifact
for the overlapping controller queue-ID/test updates, so those changes have
been removed from this branch.
