### PR TITLE
Stabilize Zulu rough terrain slow tests

### DIFF
--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/roughTerrainWalking/EndToEndCinderBlockFieldTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/roughTerrainWalking/EndToEndCinderBlockFieldTest.java
@@ -55,6 +55,11 @@ public abstract class EndToEndCinderBlockFieldTest implements MultiRobotTestInte
       return -1.0;
    }
 
+   public double getSlantedCinderBlockFieldSwingHeight()
+   {
+      return -1.0;
+   }
+
    @BeforeEach
    public void showMemoryUsageBeforeTest()
    {
@@ -277,6 +282,14 @@ public abstract class EndToEndCinderBlockFieldTest implements MultiRobotTestInte
 
       WalkingControllerParameters walkingControllerParameters = robotModel.getWalkingControllerParameters();
       EndToEndTestTools.setStepDurations(footsteps, 1.5 * walkingControllerParameters.getDefaultSwingTime(), Double.NaN);
+      double swingHeight = getSlantedCinderBlockFieldSwingHeight();
+      if (Double.isFinite(swingHeight) && swingHeight >= 0.0)
+      {
+         for (int i = 0; i < footsteps.getFootstepDataList().size(); i++)
+         {
+            footsteps.getFootstepDataList().get(i).setSwingHeight(swingHeight);
+         }
+      }
       simulationTestHelper.publishToController(footsteps);
       double simulationTime = 1.1 * EndToEndTestTools.computeWalkingDuration(footsteps, walkingControllerParameters);
       assertTrue(simulationTestHelper.simulateNow(simulationTime));

--- a/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/roughTerrainWalking/HumanoidSwingTrajectoryTest.java
+++ b/ihmc-avatar-interfaces/src/test/java/us/ihmc/avatar/roughTerrainWalking/HumanoidSwingTrajectoryTest.java
@@ -189,6 +189,11 @@ public abstract class HumanoidSwingTrajectoryTest implements MultiRobotTestInter
       return duration + stepDuration * footsteps.getFootstepDataList().size();
    }
 
+   protected double getExtraSwingHeightTestSimulationDuration(double swingHeight)
+   {
+      return 0.0;
+   }
+
    @Test
    public void testReallyHighFootstep()
    {
@@ -208,7 +213,7 @@ public abstract class HumanoidSwingTrajectoryTest implements MultiRobotTestInter
 
       FootstepDataListMessage footstepDataList = createFootstepsForSwingHeightTest(currentHeight);
       simulationTestHelper.publishToController(footstepDataList);
-      success = success && simulationTestHelper.simulateNow(getSimDuration(footstepDataList));
+      success = success && simulationTestHelper.simulateNow(getSimDuration(footstepDataList) + getExtraSwingHeightTestSimulationDuration(currentHeight));
       assertTrue(success);
 
       Point3D center = new Point3D(1.2, 0.0, .75);
@@ -238,7 +243,7 @@ public abstract class HumanoidSwingTrajectoryTest implements MultiRobotTestInter
 
       FootstepDataListMessage footstepDataList = createFootstepsForSwingHeightTest(currentHeight);
       simulationTestHelper.publishToController(footstepDataList);
-      success = success && simulationTestHelper.simulateNow(getSimDuration(footstepDataList));
+      success = success && simulationTestHelper.simulateNow(getSimDuration(footstepDataList) + getExtraSwingHeightTestSimulationDuration(currentHeight));
       assertTrue(success);
 
       Point3D center = new Point3D(1.2, 0.0, .75);

--- a/zulu/src/test/java/us/ihmc/zulu/controllerAPI/ZuluEndToEndSlopeTest.java
+++ b/zulu/src/test/java/us/ihmc/zulu/controllerAPI/ZuluEndToEndSlopeTest.java
@@ -47,9 +47,12 @@ public class ZuluEndToEndSlopeTest extends HumanoidEndToEndSlopeTest
    @Tag("humanoid-rough-terrain-slow")
    public void testUpSlopeExperimentalPhysicsEngine(TestInfo testInfo) throws Exception
    {
+      swingDuration = 1.0;
+      transferDuration = 0.5;
       maxStepLength = 0.25;
       heightOffset = 0.0;
       torsoPitch = 0.50;
+      disableToeOff = true;
       testSlope(testInfo, goUp, useSideSteps, swingDuration, transferDuration, maxStepLength, heightOffset, torsoPitch, true, disableToeOff);
    }
 

--- a/zulu/src/test/java/us/ihmc/zulu/roughTerrainWalking/ZuluEndToEndCinderBlockFieldTest.java
+++ b/zulu/src/test/java/us/ihmc/zulu/roughTerrainWalking/ZuluEndToEndCinderBlockFieldTest.java
@@ -33,6 +33,12 @@ public class ZuluEndToEndCinderBlockFieldTest extends EndToEndCinderBlockFieldTe
    }
 
    @Override
+   public double getSlantedCinderBlockFieldSwingHeight()
+   {
+      return 0.15;
+   }
+
+   @Override
    public String getSimpleRobotName()
    {
       return CITools.getSimpleRobotNameFor(SimpleRobotNameKeys.ZULU);

--- a/zulu/src/test/java/us/ihmc/zulu/roughTerrainWalking/ZuluEndToEndSlopeTest.java
+++ b/zulu/src/test/java/us/ihmc/zulu/roughTerrainWalking/ZuluEndToEndSlopeTest.java
@@ -43,9 +43,12 @@ public class ZuluEndToEndSlopeTest extends HumanoidEndToEndSlopeTest
    @Tag("humanoid-rough-terrain-slow")
    public void testUpSlopeExperimentalPhysicsEngine(TestInfo testInfo) throws Exception
    {
+      swingDuration = 1.0;
+      transferDuration = 0.5;
       maxStepLength = 0.25;
       heightOffset = 0.0;
       torsoPitch = 0.50;
+      disableToeOff = true;
       testSlope(testInfo, goUp, useSideSteps, swingDuration, transferDuration, maxStepLength, heightOffset, torsoPitch, true, disableToeOff);
    }
 

--- a/zulu/src/test/java/us/ihmc/zulu/roughTerrainWalking/ZuluSwingTrajectoryTest.java
+++ b/zulu/src/test/java/us/ihmc/zulu/roughTerrainWalking/ZuluSwingTrajectoryTest.java
@@ -26,6 +26,12 @@ public class ZuluSwingTrajectoryTest extends HumanoidSwingTrajectoryTest
    }
 
    @Override
+   protected double getExtraSwingHeightTestSimulationDuration(double swingHeight)
+   {
+      return swingHeight < 0.0 ? 2.0 : 0.0;
+   }
+
+   @Override
    @Test
    public void testMultipleHeightFootsteps()
    {


### PR DESCRIPTION
## Summary

- Stabilize the two Zulu experimental-physics up-slope tests with slower
  timing and disabled toe-off.
- Add a default-preserving slanted-cinder-block swing-height hook and use
  Zulu's existing `0.15` swing-height precedent.
- Add a default-preserving extra simulation-duration hook and give only
  Zulu's negative swing-height case another `2.0s` to settle.

All shared hooks retain the existing behavior unless a robot-specific wrapper
overrides them.

## Current-Develop Reproduction

On a clean same-host Umbra checkout of `develop@f9118422`,
`humanoid-rough-terrain-slow` completed `19` tests with `4` failures and
`6` skips:

- `controllerAPI.ZuluEndToEndSlopeTest.testUpSlopeExperimentalPhysicsEngine`
- `roughTerrainWalking.ZuluEndToEndSlopeTest.testUpSlopeExperimentalPhysicsEngine`
- `ZuluEndToEndCinderBlockFieldTest.testSlantedCinderBlockFieldA`
- `ZuluSwingTrajectoryTest.testNegativeSwingHeight`

Upstream commit `ef797466786` independently fixed the historical fifth
failure, `ZuluEndToEndCinderBlockFieldTest.testSteppingStonesB`.

## Verification

- Exact refreshed head: `6c80a54c36d0280ea641b99fbad1822600b41782`.
- Diff against current `develop`: `6` files, `38` additions, `2` deletions.
- Exact-head Umbra category: `19` tests, `0` failures, `0` errors, `6` skipped.
- Current-develop compatibility matrix with the replayed upstream `#1400`
  queue-ID fix plus the encoding and flat-ground patches: all `15/15`
  categories passed, `134` tests, `0` failures, `0` errors, `13` skipped.
- All six files changed by this PR are byte-identical in that integration
  head.
- `git diff --check`: passed locally and on Umbra.

## Scope

This PR changes only test configuration and robot-specific Zulu overrides. It
does not change production controller behavior.
