### PR TITLE
[Bugfix] YOLO segmentation image resize in IsaacROSFoundationPoseCommunicator

### DIFF
--- a/ihmc-perception/src/main/java/us/ihmc/perception/detections/foundationPose/IsaacROSFoundationPoseCommunicator.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/detections/foundationPose/IsaacROSFoundationPoseCommunicator.java
@@ -20,6 +20,7 @@ import us.ihmc.perception.RawImage;
 import us.ihmc.perception.RawImagePublisher;
 import us.ihmc.perception.detections.InstantDetection;
 import us.ihmc.perception.detections.yolo.YOLOv8InstantDetection;
+import us.ihmc.perception.detections.yolo.YOLOv8Tools;
 import us.ihmc.perception.imageMessage.PixelFormat;
 import us.ihmc.perception.tools.RawImageTools;
 import us.ihmc.ros2.ROS2Node;
@@ -230,7 +231,9 @@ public class IsaacROSFoundationPoseCommunicator implements AutoCloseable
       depthImage.getGpuImageMat().convertTo(depth32Mat, opencv_core.CV_32FC1, depthImage.getDepthDiscretization());
       RawImage depth32FImage = depthImage.replaceImage(depth32Mat, PixelFormat.GRAY_F32);
 
-      RawImage resizedSegmentation = RawImageTools.resize(segmentation, depth32FImage.getWidth(), depth32FImage.getHeight());
+      GpuMat resizedSegmentationMat = new GpuMat();
+      YOLOv8Tools.resizeWithCrop(segmentation.getGpuImageMat(), resizedSegmentationMat, depth32Mat.size());
+      RawImage resizedSegmentation = depthImage.replaceImage(resizedSegmentationMat, PixelFormat.GRAY8);
 
       // Update the sensor frame (publishes TFMessage so FoundationPose gets the frame)
       synchronized (sensorFrame)

--- a/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8Tools.java
+++ b/ihmc-perception/src/main/java/us/ihmc/perception/detections/yolo/YOLOv8Tools.java
@@ -3,7 +3,9 @@ package us.ihmc.perception.detections.yolo;
 import org.apache.commons.lang3.mutable.MutableObject;
 import org.bytedeco.javacpp.IntPointer;
 import org.bytedeco.opencv.global.opencv_core;
+import org.bytedeco.opencv.global.opencv_cudawarping;
 import org.bytedeco.opencv.global.opencv_imgproc;
+import org.bytedeco.opencv.opencv_core.GpuMat;
 import org.bytedeco.opencv.opencv_core.Mat;
 import org.bytedeco.opencv.opencv_core.MatVector;
 import org.bytedeco.opencv.opencv_core.Point;
@@ -155,6 +157,27 @@ public class YOLOv8Tools
       int resizedWidth = (int) Math.ceil(inputImage.cols() * scaleFactor);
       int resizedHeight = (int) Math.ceil(inputImage.rows() * scaleFactor);
       opencv_imgproc.resize(inputImage, resizedMat, new Size(resizedWidth, resizedHeight), 0.0, 0.0, opencv_imgproc.INTER_LINEAR);
+
+      int horizontalCrop = Math.max(resizedWidth - desiredWidth, 0) / 2;
+      int verticalCrop = Math.max(resizedHeight - desiredHeight, 0) / 2;
+
+      Rect roi = new Rect(horizontalCrop, verticalCrop, desiredWidth, desiredHeight);
+      resizedMat.apply(roi).copyTo(outputImage);
+      resizedMat.close();
+   }
+
+   public static void resizeWithCrop(GpuMat inputImage, GpuMat outputImage, Size desiredSize)
+   {
+      GpuMat resizedMat = new GpuMat();
+
+      int desiredWidth = desiredSize.width();
+      int desiredHeight = desiredSize.height();
+      double scaleFactor = Math.max((double) desiredWidth / inputImage.cols(), (double) desiredHeight / inputImage.rows());
+
+      // Use explicit target dimensions so the resized image always fully covers desiredSize
+      int resizedWidth = (int) Math.ceil(inputImage.cols() * scaleFactor);
+      int resizedHeight = (int) Math.ceil(inputImage.rows() * scaleFactor);
+      opencv_cudawarping.resize(inputImage, resizedMat, new Size(resizedWidth, resizedHeight), 0.0, 0.0, opencv_imgproc.INTER_LINEAR, null);
 
       int horizontalCrop = Math.max(resizedWidth - desiredWidth, 0) / 2;
       int verticalCrop = Math.max(resizedHeight - desiredHeight, 0) / 2;


### PR DESCRIPTION
The YOLO segmentation was being resized without cropping to the correct aspect ratio so masks sent to FoundationPose were stretched out, causing bad initial pose estimates. 