### PR TITLE
CI: Trigger dependent fast workflows on develop push.

### DIFF
--- a/.github/workflows/trigger-dependents.yml
+++ b/.github/workflows/trigger-dependents.yml
@@ -1,0 +1,13 @@
+name: Trigger dependent CI
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  trigger:
+    uses: ihmcrobotics/ihmc-actions/.github/workflows/trigger-dependents.yml@main
+    secrets:
+      ROSIE_PERSONAL_ACCESS_TOKEN: ${{ secrets.ROSIE_PERSONAL_ACCESS_TOKEN }}
+    with:
+      source-repo: ihmc-open-robotics-software


### PR DESCRIPTION
Adds a workflow that calls ihmc-actions trigger-dependents when develop moves, so alex and unitree-h1 re-run fast CI against current IORS develop without waiting for their own develop push.

Depends on ihmc-actions main (dependency-graph.json and trigger-dependents.yml already merged).