### PR TITLE
Don't use nominal object pose for composite frames.

### DIFF
--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/behaviorTree/actions/RDXSceneAction.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/behaviorTree/actions/RDXSceneAction.java
@@ -141,9 +141,11 @@ public class RDXSceneAction extends RDXActionNode<SceneActionState, SceneActionD
    {
       super.update();
 
-      nominalObjectPoseGizmo.getPoseGizmo().setParentFrame(scene.findFrameByName("Walking"));
-
-      RDXCRDTTools.syncGizmoWithBidirectionalField(nominalObjectPoseGizmo.getPoseGizmo(), definition.getNominalObjectPose(), definition);
+      if (definition.usesNominalObjectPose())
+      {
+         nominalObjectPoseGizmo.getPoseGizmo().setParentFrame(scene.findFrameByName("Walking"));
+         RDXCRDTTools.syncGizmoWithBidirectionalField(nominalObjectPoseGizmo.getPoseGizmo(), definition.getNominalObjectPose(), definition);
+      }
 
       for (RDXROS2YOLOv8ModelSettings settings : yoloModelSettings)
          settings.update(definition);
@@ -255,7 +257,8 @@ public class RDXSceneAction extends RDXActionNode<SceneActionState, SceneActionD
             ImGui.pushItemWidth(100.0f);
             timeoutWidget.renderImGuiWidget();
             minHistorySizeWidget.renderImGuiWidget();
-            ImGui.checkbox(labels.get("Adjust Nominal Object Pose"), nominalObjectPoseGizmo.getSelected());
+            if (definition.usesNominalObjectPose())
+               ImGui.checkbox(labels.get("Adjust Nominal Object Pose"), nominalObjectPoseGizmo.getSelected());
             ImGui.popItemWidth();
 
          }
@@ -346,24 +349,22 @@ public class RDXSceneAction extends RDXActionNode<SceneActionState, SceneActionD
    @Override
    public void calculate3DViewPick(ImGui3DViewInput input)
    {
-      if (getSelected())
+      if (getSelected() && definition.usesNominalObjectPose())
          nominalObjectPoseGizmo.calculate3DViewPick(input);
    }
 
    @Override
    public void process3DViewInput(ImGui3DViewInput input)
    {
-      if (getSelected())
+      if (getSelected() && definition.usesNominalObjectPose())
          nominalObjectPoseGizmo.process3DViewInput(input);
    }
 
    @Override
    public void getRenderables(Array<Renderable> renderables, Pool<Renderable> pool)
    {
-      if (getSelected())
-      {
+      if (getSelected() && definition.usesNominalObjectPose())
          nominalObjectPoseGizmo.getVirtualRenderables(renderables, pool);
-      }
    }
 
    @Override

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/action/actions/SceneActionDefinition.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/action/actions/SceneActionDefinition.java
@@ -10,6 +10,7 @@ import perception_msgs.msg.dds.YOLOv8ModelInfo;
 import us.ihmc.behaviors.behaviorTree.BehaviorTreeRootNodeDefinition;
 import us.ihmc.behaviors.behaviorTree.action.ActionNodeDefinition;
 import us.ihmc.behaviors.behaviorTree.scene.BehaviorTreeSceneObjectDefinition;
+import us.ihmc.behaviors.behaviorTree.scene.BehaviorTreeSceneObjectType;
 import us.ihmc.commons.exception.DefaultExceptionHandler;
 import us.ihmc.communication.crdt.CRDTBidirectionalEnumField;
 import us.ihmc.communication.crdt.CRDTBidirectionalFloat;
@@ -131,7 +132,8 @@ public class SceneActionDefinition extends ActionNodeDefinition
             {
                jsonNode.put("timeout", timeout.getValue());
                jsonNode.put("minimumHistorySize", minimumHistorySize.getValue());
-               JSONTools.toJSON(jsonNode.putObject("nominalObjectPose"), nominalObjectPose.getValueReadOnly());
+               if (usesNominalObjectPose())
+                  JSONTools.toJSON(jsonNode.putObject("nominalObjectPose"), nominalObjectPose.getValueReadOnly());
             }
          }
          case CONFIGURE_PERSISTENT_DETECTIONS ->
@@ -176,7 +178,7 @@ public class SceneActionDefinition extends ActionNodeDefinition
             {
                timeout.setValue((float) jsonNode.get("timeout").asDouble());
                minimumHistorySize.setValue(jsonNode.get("minimumHistorySize").asInt());
-               if (jsonNode.get("nominalObjectPose") instanceof ObjectNode nominalObjectPoseNode)
+               if (usesNominalObjectPose() && jsonNode.get("nominalObjectPose") instanceof ObjectNode nominalObjectPoseNode)
                   JSONTools.toEuclid(nominalObjectPoseNode, nominalObjectPose.getValueAndModify());
             }
          }
@@ -382,6 +384,12 @@ public class SceneActionDefinition extends ActionNodeDefinition
    public CRDTBidirectionalRigidBodyTransform getNominalObjectPose()
    {
       return nominalObjectPose;
+   }
+
+   public boolean usesNominalObjectPose()
+   {
+      return sceneActionType.getValue() == SceneActionType.SETUP_OBJECT
+             && sceneObjectDefinition.getObjectType() != BehaviorTreeSceneObjectType.COMPOSITE_FRAME;
    }
 
    public float getPoseFilterAlpha()

--- a/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/action/actions/SceneActionExecutor.java
+++ b/ihmc-high-level-behaviors/src/main/java/us/ihmc/behaviors/behaviorTree/action/actions/SceneActionExecutor.java
@@ -168,6 +168,12 @@ public class SceneActionExecutor extends ActionNodeExecutor<SceneActionState, Sc
 
       if (rootNode.getState().getPreviewModeEnabled())
       {
+         if (definition.getSceneObjectDefinition().getObjectType() == BehaviorTreeSceneObjectType.COMPOSITE_FRAME)
+         {
+            setupCompositeFrameDetection();
+            return;
+         }
+
          state.getLogger().info("Preview mode enabled. Adding nominal object pose for: {}", definition.getSceneObjectDefinition().getName());
 
          BehaviorTreeSceneObjectState target = null;


### PR DESCRIPTION
Composite frame scene actions don't use a nominal object pose, but preview mode was still applying one and the editor kept syncing the gizmo. This adds usesNominalObjectPose() checks across the executor, definition serialization, and RDX UI so composite frames use setupCompositeFrameDetection in preview instead.