### PR TITLE
Fix JointLevelKF ~1e18 divergence: per-joint encoder gating

### DIFF
--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFPreFilter.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFPreFilter.java
@@ -588,6 +588,45 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
    }
 
    /**
+    * Rebuilds (Henc, zEnc, Renc) each tick over ONLY the joints whose encoder reads finite, one measurement
+    * row per good encoder, and returns the number of rows. This is the per-joint gate that replaces the old
+    * all-or-nothing skip: one intermittent encoder no longer unpins every joint (see {@link #computeJointState}).
+    *
+    * <p>Row r observes joint state index i with H[r,i] = 1, z[r] = q_i, R[r,r] = ENCODER_VAR. The scratch is
+    * grown to its full (n) size first, filled, then shrunk to the valid-row count — reshaping to a size no
+    * larger than the pre-allocated capacity never allocates, so this stays allocation-free on the estimator
+    * thread. When every encoder is finite this reproduces the previous full-rank identity encoder update
+    * exactly. Returns 0 when no encoder is finite (caller skips the update, as before).</p>
+    */
+   private int buildValidEncoderUpdate()
+   {
+      Henc.reshape(n, dim);
+      Henc.zero();
+      zEnc.reshape(n, 1);
+      int r = 0;
+      for (var e : jointToIndex.entrySet())
+      {
+         double q = sensorMap.getOneDoFJointOutput(e.getKey()).getPosition();
+         if (!Double.isFinite(q))
+         {
+            if (!warnedNonFiniteInput)
+               warnNonFiniteInputOnce("joint position of " + e.getKey().getName());
+            continue;
+         }
+         Henc.set(r, e.getValue(), 1.0); // this measurement row pins the joint at its state index
+         zEnc.set(r, 0, q);
+         r++;
+      }
+      Henc.reshape(r, dim);
+      zEnc.reshape(r, 1);
+      Renc.reshape(r, r);
+      Renc.zero();
+      for (int i = 0; i < r; i++)
+         Renc.set(i, i, ENCODER_VAR);
+      return r;
+   }
+
+   /**
     * Installs the optional on-ground gate: while {@code onGround} does not read true, {@link #initialize()}
     * stays deferred (the filter exports NaN joint states and zero bias, so consumers fall back to the raw
     * sensors). Pass {@code null} to disable gating (the default — initialize as soon as boot data is finite).
@@ -672,21 +711,17 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
       predict();
       warnIfNonFiniteState("predict", -1);
 
-      // update encoder states; skipped wholesale if any encoder reads non-finite (boot transient)
-      int row = 0;
-      boolean encodersValid = true;
-      for (OneDoFJointBasics j : jointToIndex.keySet())
-      {
-         double q = sensorMap.getOneDoFJointOutput(j).getPosition();
-         if (!Double.isFinite(q))
-         {
-            encodersValid = false;
-            if (!warnedNonFiniteInput)
-               warnNonFiniteInputOnce("joint position of " + j.getName());
-         }
-         zEnc.set(row++, 0, q);
-      }
-      if (encodersValid)
+      // Encoder update, gated PER JOINT (not all-or-nothing). Alex's encoders are intermittent, so a single
+      // non-finite reading used to drop the WHOLE encoder update — unpinning every joint's position for that
+      // tick. With the position pin gone, q integrates q̇ (which the pair-gyro/stance-anchor updates only
+      // loosely constrain, and the anchor can bias) with no correction, so q ramps without bound and, on the
+      // mass-matrix path, P grows without bound too — the divergence that drove the joint estimates to ~1e18.
+      // Fix: build the encoder measurement over only the joints whose encoder is finite this tick, so every
+      // good encoder keeps pinning its joint while just the bad one is skipped. When all are finite (the common
+      // case) this is exactly the previous full-rank update; the reduced matrices reuse the pre-sized scratch
+      // (reshape to a smaller size never allocates), so it stays allocation-free on the estimator thread.
+      int validEncoderCount = buildValidEncoderUpdate();
+      if (validEncoderCount > 0)
       {
          josephUpdate(Henc, zEnc, Renc, "encoder");
          warnIfNonFiniteState("encoderUpdate", -1);
@@ -712,6 +747,7 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
       CommonOps_DDRM.mult(F, P, Ptmp);
       CommonOps_DDRM.multTransB(Ptmp, F, P); // FPF^T term
       CommonOps_DDRM.addEquals(P, Q);
+      symmetrize(P); // FPF^T + Q is symmetric in exact arithmetic; force it so round-off can't drift P (matches the reference)
    }
 
    private void pairGyroUpdate(Pair p)
@@ -900,6 +936,7 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
       KR.reshape(dim, k);
       CommonOps_DDRM.mult(K, Rm, KR);
       CommonOps_DDRM.multAddTransB(KR, K, P); // + K R K^T
+      symmetrize(P); // Joseph form is symmetric by construction; force it so round-off can't accumulate asymmetry
 
       if (containsNonFinite(x) || containsNonFinite(P))
       {
@@ -967,6 +1004,27 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
       for (int i = 0; i < src.getNumRows(); i++)
          for (int j = 0; j < src.getNumCols(); j++)
             dst.set(row0 + i, col0 + j, scale * src.get(i,j));
+   }
+
+   /**
+    * In-place symmetrization P <- 0.5 (P + P^T). The predict and Joseph-form covariance updates are symmetric
+    * in exact arithmetic, but floating-point round-off leaves a tiny asymmetry each tick that a long hardware
+    * run can accumulate; forcing symmetry keeps P on the symmetric-PSD manifold the Kalman gain assumes (the
+    * same LΣL^T covariance discipline the JAX reference applies after every predict/update). Allocation-free;
+    * O(dim^2), negligible next to the O(dim^3) matrix products already in the step.
+    */
+   private static void symmetrize(DMatrixRMaj mat)
+   {
+      int rows = mat.getNumRows();
+      for (int i = 0; i < rows; i++)
+      {
+         for (int j = i + 1; j < rows; j++)
+         {
+            double avg = 0.5 * (mat.get(i, j) + mat.get(j, i));
+            mat.set(i, j, avg);
+            mat.set(j, i, avg);
+         }
+      }
    }
 
    /** True if any entry of the matrix is NaN or infinite. Allocation-free; O(elements). */

--- a/ihmc-state-estimation/src/test/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFTrajectoryTest.java
+++ b/ihmc-state-estimation/src/test/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFTrajectoryTest.java
@@ -296,6 +296,49 @@ public class JointLevelKFTrajectoryTest
          assertTrue(Math.abs(p1.get(i, n + i)) > 1.0e-6, "within-joint q-qdot coupling persists, joint " + i);
    }
 
+   /**
+    * Regression for the intermittent-encoder divergence: a single joint's encoder reads non-finite every tick
+    * (Alex's encoders are intermittent) while the legs move and the phase-2 stance anchor runs every tick
+    * (double support). The encoder update must be gated PER JOINT, so the joints whose encoders are still good
+    * stay pinned to their trajectory; a single bad encoder must not drop the whole update and unpin every joint.
+    *
+    * <p>Before per-joint gating this diverged hard: the whole encoder update was skipped, so every joint's
+    * position integrated a stance-anchor-biased velocity with no correction and ran away (tens of radians here,
+    * ~1e18 over a full hardware run). With gating, the good-encoder joints track to encoder precision and only
+    * the genuinely unmeasured joint drifts.</p>
+    */
+   @Test
+   public void testIntermittentEncoderWithStanceAnchorKeepsGoodJointsPinned()
+   {
+      JointLevelKFTestFixture f = JointLevelKFTestFixture.singlePair(9108L, 8, 1, 7);
+      int n = f.n;
+      double[] q = new double[n];
+      double[] qd = new double[n];
+
+      for (int k = 0; k < 500; k++) // clean warm-up: all encoders good, filter converges
+      {
+         trajectory(k, n, q, qd);
+         f.applyConsistentMotion(q, qd);
+         f.filter.computeJointState();
+         f.filter.computeImuBiases(f.feet);
+      }
+      for (int k = 500; k < 8000; k++) // joint 0's encoder is dead every tick while the legs move + anchor runs
+      {
+         trajectory(k, n, q, qd);
+         f.applyConsistentMotion(q, qd);
+         f.sensorMap.setPosition(f.filteredJoints.get(0), Double.NaN);
+         f.filter.computeJointState();
+         f.filter.computeImuBiases(f.feet);
+      }
+
+      DMatrixRMaj x = f.filter.getStateVector();
+      assertAllFinite(x, "state stays finite with a dead encoder and the stance anchor active");
+      trajectory(7999, n, q, qd);
+      for (int i = 1; i < n; i++) // every joint whose encoder is still good must remain pinned to its trajectory
+         assertEquals(q[i], x.get(i, 0), 5.0e-3,
+                      "good-encoder joint stays pinned despite joint 0's dead encoder (per-joint gating), joint " + i);
+   }
+
    private static void assertAllFinite(DMatrixRMaj matrix, String message)
    {
       for (int i = 0; i < matrix.getNumElements(); i++)


### PR DESCRIPTION
## Problem
The `JointLevelKFPreFilter` joint estimates blew up to ~10^18 during double support.

## Root cause
The encoder measurement update was **all-or-nothing**: a single non-finite encoder reading (Alex's encoders are documented as intermittent) skipped the **entire** encoder update, unpinning **every** joint's position for that tick. With the position pin gone, each joint's position integrates its velocity estimate — only loosely constrained by the pair-gyro updates, and biased by the phase-2 stance anchor whose non-rotating-foot assumption is violated while the legs move during double support — with no correction. So positions ramp without bound, and on the mass-matrix process-noise path the covariance grows without bound too. Over a multi-minute hardware run this reaches ~10^18. Every existing safety net only checks for NaN/Inf, so a **finite-but-exploding** state went undetected.

## Fix
1. **Per-joint encoder gating** (primary): each tick build the encoder measurement over only the joints whose encoder reads finite, so every good encoder keeps pinning its joint while just the bad one is skipped. When all encoders are finite this is exactly the previous full-rank update; the reduced matrices reuse the pre-sized scratch (reshape to a smaller size never allocates), so it stays allocation-free on the estimator thread.
2. **Covariance symmetrization** `P <- 0.5(P + Pᵀ)` after predict and after the Joseph update, matching the JAX reference's LΣLᵀ discipline — cheap defense against round-off asymmetry accumulating over a long run.

## Verification
- Reproduced via a new regression test (`testIntermittentEncoderWithStanceAnchorKeepsGoodJointsPinned`): moving legs + stance anchor active + one dead encoder. **Before** the fix the good-encoder joints diverge to ~41 rad after 7.5k ticks (and keep climbing); **after** the fix they track to encoder precision (~1e-3 rad) and only the genuinely unmeasured joint drifts. The test fails on the old code, passes on the new.
- All 63 existing `jointLevel` unit tests pass, including the allocation test (confirms the per-tick reshape stays allocation-free).

## Note / follow-up
A joint whose encoder is dead **permanently** still slowly drifts (no absolute position sensor + a slightly stance-anchor-biased velocity). That's inherent, not a regression, and vastly smaller than before (~15 rad vs ~660 rad over 60k ticks in the mass-matrix repro). Consider innovation (NIS) gating on the stance anchor so its inconsistency under leg motion stops biasing the velocity — but that touches the anchor's design and is left out of this focused fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)