### PR TITLE
Docs: Compiling and run-main scripts

### DIFF
--- a/docs/Compiling.md
+++ b/docs/Compiling.md
@@ -1,0 +1,75 @@
+# Compiling with Gradle
+
+Use `compileJava` to compile main sources without running tests.
+
+## Entire repo group (composite)
+
+From a group-of-projects root (for example `~/dev/primary`), run the same task across this build and all included composite builds:
+
+```bash
+gradle compositeTask -PtaskName=compileJava
+```
+
+`compositeCompileJava` is equivalent:
+
+```bash
+gradle compositeCompileJava
+```
+
+You can pass multiple task names:
+
+```bash
+gradle compositeTask -PtaskName=compileJava,compileTestJava
+```
+
+## Single repository
+
+`cd` into the repository (for example `ihmc-open-robotics-software`), then compile everything in that build:
+
+```bash
+cd ihmc-open-robotics-software
+gradle compileJava
+```
+
+Or from the group root, target that included build:
+
+```bash
+gradle :ihmc-open-robotics-software:compileJava
+```
+
+## Single subproject
+
+`cd` into the subproject directory, then run `gradle compileJava`.
+
+Examples below use `ihmc-java-toolkit`. Replace it with any subproject name, such as `zulu` or `ihmc-avatar-interfaces`.
+
+```bash
+cd ihmc-java-toolkit
+gradle compileJava
+```
+
+From the repository or group root, use the project path:
+
+```bash
+gradle :ihmc-java-toolkit:compileJava
+```
+
+Extra source sets get their own project path. For example, the libgdx sources of `ihmc-high-level-behaviors`:
+
+```bash
+gradle :ihmc-high-level-behaviors:ihmc-high-level-behaviors-libgdx:compileJava
+```
+
+From a group root, include the repository name:
+
+```bash
+gradle :ihmc-open-robotics-software:ihmc-high-level-behaviors:ihmc-high-level-behaviors-libgdx:compileJava
+```
+
+## Seeing what ran
+
+Add `--info` if you want per-project compile output:
+
+```bash
+gradle compositeTask -PtaskName=compileJava --info
+```

--- a/docs/Running Main Classes.md
+++ b/docs/Running Main Classes.md
@@ -2,37 +2,37 @@
 
 Prefer [`scripts/run-main`](../scripts/run-main): Gradle compiles and writes the classpath, then `exec`s `java` like IntelliJ. Ctrl+C goes to the app, not a Gradle `run` wrapper.
 
-Extra source sets are separate Gradle projects. `AlexRDXBehaviorTestFacilitator` lives under `src/test`, so its project is `alex-test` (not `alex`). The script also sets the working directory to the repository root (IntelliJ-style), not `src/test`.
+Extra source sets are separate Gradle projects. `RDXUIDemo` lives under `src/test`, so its project is `ihmc-high-level-behaviors-test` (not `ihmc-high-level-behaviors`). The script also sets the working directory to the repository root (IntelliJ-style), not `src/test`.
 
-## Example: Alex behavior facilitator
+## Example: RDX UI demo
 
-From the `alex` repository:
+From `ihmc-high-level-behaviors`:
 
 ```bash
-cd alex
-../ihmc-open-robotics-software/scripts/run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+cd ihmc-high-level-behaviors
+../scripts/run-main :ihmc-high-level-behaviors-test us.ihmc.rdx.RDXUIDemo
 ```
 
 From a group-of-projects root (for example `~/dev/primary`):
 
 ```bash
-ihmc-open-robotics-software/scripts/run-main :alex:alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+ihmc-open-robotics-software/scripts/run-main :ihmc-open-robotics-software:ihmc-high-level-behaviors:ihmc-high-level-behaviors-test us.ihmc.rdx.RDXUIDemo
 ```
 
 ## Other projects / source sets
 
-Main sources in `alex`:
+Main sources in `example-simulations`:
 
 ```bash
-cd alex
-../ihmc-open-robotics-software/scripts/run-main :alex us.ihmc.alex.simulation.AlexRLSimulation
+cd example-simulations
+../scripts/run-main :example-simulations us.ihmc.exampleSimulations.simplePendulum.SimplePendulumSimulation
 ```
 
-RDX sources in `alex` (`src/rdx` → `alex-rdx`):
+Libgdx sources in `ihmc-high-level-behaviors` (`src/libgdx` → `ihmc-high-level-behaviors-libgdx`):
 
 ```bash
-cd alex
-../ihmc-open-robotics-software/scripts/run-main :alex-rdx us.ihmc.alex.rdx.apps.AlexRDXTeleoperationUI
+cd ihmc-high-level-behaviors
+../scripts/run-main :ihmc-high-level-behaviors-libgdx us.ihmc.rdx.simulation.environment.RDXEnvironmentBuilderUI
 ```
 
 ## Program arguments
@@ -40,22 +40,22 @@ cd alex
 Pass them after the main class:
 
 ```bash
-../ihmc-open-robotics-software/scripts/run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator arg1 arg2
+../scripts/run-main :ihmc-high-level-behaviors-test us.ihmc.rdx.RDXUIDemo arg1 arg2
 ```
 
 ## JVM options
 
 ```bash
-JAVA_TOOL_OPTIONS='-Xmx4g' ../ihmc-open-robotics-software/scripts/run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+JAVA_TOOL_OPTIONS='-Xmx4g' ../scripts/run-main :ihmc-high-level-behaviors-test us.ihmc.rdx.RDXUIDemo
 ```
 
 ## Alternative: `gradle run`
 
-You can still use the Application plugin `run` task with [`scripts/run-main.init.gradle.kts`](../scripts/run-main.init.gradle.kts). This keeps Gradle attached for the whole process, so Ctrl+C / shutdown is less reliable than `run-main`, and the working directory is the extra-source-set folder (for example `alex/src/test`).
+You can still use the Application plugin `run` task with [`scripts/run-main.init.gradle.kts`](../scripts/run-main.init.gradle.kts). This keeps Gradle attached for the whole process, so Ctrl+C / shutdown is less reliable than `run-main`, and the working directory is the extra-source-set folder (for example `ihmc-high-level-behaviors/src/test`).
 
 ```bash
-cd alex
-gradle :alex-test:run \
-  -PmainClass=us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator \
-  --init-script ../ihmc-open-robotics-software/scripts/run-main.init.gradle.kts
+cd ihmc-high-level-behaviors
+gradle :ihmc-high-level-behaviors-test:run \
+  -PmainClass=us.ihmc.rdx.RDXUIDemo \
+  --init-script ../scripts/run-main.init.gradle.kts
 ```

--- a/docs/Running Main Classes.md
+++ b/docs/Running Main Classes.md
@@ -1,0 +1,61 @@
+# Running Main Classes
+
+Prefer [`scripts/run-main`](../scripts/run-main): Gradle compiles and writes the classpath, then `exec`s `java` like IntelliJ. Ctrl+C goes to the app, not a Gradle `run` wrapper.
+
+Extra source sets are separate Gradle projects. `AlexRDXBehaviorTestFacilitator` lives under `src/test`, so its project is `alex-test` (not `alex`). The script also sets the working directory to the repository root (IntelliJ-style), not `src/test`.
+
+## Example: Alex behavior facilitator
+
+From the `alex` repository:
+
+```bash
+cd alex
+../ihmc-open-robotics-software/scripts/run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+```
+
+From a group-of-projects root (for example `~/dev/primary`):
+
+```bash
+ihmc-open-robotics-software/scripts/run-main :alex:alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+```
+
+## Other projects / source sets
+
+Main sources in `alex`:
+
+```bash
+cd alex
+../ihmc-open-robotics-software/scripts/run-main :alex us.ihmc.alex.simulation.AlexRLSimulation
+```
+
+RDX sources in `alex` (`src/rdx` → `alex-rdx`):
+
+```bash
+cd alex
+../ihmc-open-robotics-software/scripts/run-main :alex-rdx us.ihmc.alex.rdx.apps.AlexRDXTeleoperationUI
+```
+
+## Program arguments
+
+Pass them after the main class:
+
+```bash
+../ihmc-open-robotics-software/scripts/run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator arg1 arg2
+```
+
+## JVM options
+
+```bash
+JAVA_TOOL_OPTIONS='-Xmx4g' ../ihmc-open-robotics-software/scripts/run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+```
+
+## Alternative: `gradle run`
+
+You can still use the Application plugin `run` task with [`scripts/run-main.init.gradle.kts`](../scripts/run-main.init.gradle.kts). This keeps Gradle attached for the whole process, so Ctrl+C / shutdown is less reliable than `run-main`, and the working directory is the extra-source-set folder (for example `alex/src/test`).
+
+```bash
+cd alex
+gradle :alex-test:run \
+  -PmainClass=us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator \
+  --init-script ../ihmc-open-robotics-software/scripts/run-main.init.gradle.kts
+```

--- a/scripts/run-main
+++ b/scripts/run-main
@@ -5,11 +5,11 @@
 # Usage:
 #   run-main <gradle-project> <main-class> [args...]
 #
-# Examples (from alex/):
-#   ../ihmc-open-robotics-software/scripts/run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+# Examples (from ihmc-high-level-behaviors/):
+#   ../scripts/run-main :ihmc-high-level-behaviors-test us.ihmc.rdx.RDXUIDemo
 #
-# Examples (from primary/):
-#   ihmc-open-robotics-software/scripts/run-main :alex:alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+# Examples (from a group-of-projects root):
+#   ihmc-open-robotics-software/scripts/run-main :ihmc-open-robotics-software:ihmc-high-level-behaviors:ihmc-high-level-behaviors-test us.ihmc.rdx.RDXUIDemo
 
 set -euo pipefail
 
@@ -18,7 +18,7 @@ INIT_SCRIPT="$SCRIPT_DIR/run-main.init.gradle.kts"
 
 if [[ $# -lt 2 ]]; then
    echo "Usage: run-main <gradle-project> <main-class> [args...]" >&2
-   echo "Example: run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator" >&2
+   echo "Example: run-main :ihmc-high-level-behaviors-test us.ihmc.rdx.RDXUIDemo" >&2
    exit 1
 fi
 

--- a/scripts/run-main
+++ b/scripts/run-main
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Build with Gradle, then run the main class with java (IntelliJ-style).
+# Ctrl+C goes to the JVM, not a Gradle daemon wrapper.
+#
+# Usage:
+#   run-main <gradle-project> <main-class> [args...]
+#
+# Examples (from alex/):
+#   ../ihmc-open-robotics-software/scripts/run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+#
+# Examples (from primary/):
+#   ihmc-open-robotics-software/scripts/run-main :alex:alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+INIT_SCRIPT="$SCRIPT_DIR/run-main.init.gradle.kts"
+
+if [[ $# -lt 2 ]]; then
+   echo "Usage: run-main <gradle-project> <main-class> [args...]" >&2
+   echo "Example: run-main :alex-test us.ihmc.alex.rdx.AlexRDXBehaviorTestFacilitator" >&2
+   exit 1
+fi
+
+PROJECT=$1
+MAIN=$2
+shift 2
+
+[[ $PROJECT == :* ]] || PROJECT=":$PROJECT"
+
+OUT_DIR=$(mktemp -d "${TMPDIR:-/tmp}/ihmc-run-main.XXXXXX")
+
+gradle "${PROJECT}:writeRunMainClasspath" \
+   -PrunMainOutDir="$OUT_DIR" \
+   --init-script "$INIT_SCRIPT"
+
+WORKDIR=$(cat "$OUT_DIR/workdir")
+ARGFILE="$OUT_DIR/java.args"
+
+cd "$WORKDIR"
+# Replace this shell with the JVM so signals (Ctrl+C) match IntelliJ / java behavior
+exec java @"$ARGFILE" "$MAIN" "$@"

--- a/scripts/run-main.init.gradle.kts
+++ b/scripts/run-main.init.gradle.kts
@@ -1,0 +1,50 @@
+import org.gradle.api.tasks.JavaExec
+import org.gradle.api.tasks.SourceSetContainer
+import java.io.File
+
+allprojects {
+   afterEvaluate {
+      tasks.withType<JavaExec>().configureEach {
+         if (name == "run" && project.hasProperty("mainClass"))
+            mainClass.set(project.property("mainClass") as String)
+      }
+
+      if (project.hasProperty("runMainOutDir") && project.plugins.hasPlugin("java"))
+      {
+         tasks.register("writeRunMainClasspath") {
+            dependsOn("classes")
+            doLast {
+               val outDir = File(project.property("runMainOutDir") as String)
+               outDir.mkdirs()
+               val main = project.extensions.getByType(SourceSetContainer::class.java).getByName("main")
+               // Prefer build/classes (+ resources) over stale build/libs jars, like IntelliJ
+               val entries = ArrayList<File>()
+               val seen = HashSet<String>()
+               fun add(file: File)
+               {
+                  if (file.exists() && seen.add(file.absolutePath))
+                     entries.add(file)
+               }
+               for (file in main.runtimeClasspath.files)
+               {
+                  if (file.extension == "jar" && file.parentFile?.name == "libs")
+                  {
+                     val buildDir = file.parentFile.parentFile
+                     val classesDir = File(buildDir, "classes/java/main")
+                     if (classesDir.isDirectory)
+                     {
+                        add(classesDir)
+                        add(File(buildDir, "resources/main"))
+                        continue
+                     }
+                  }
+                  add(file)
+               }
+               File(outDir, "java.args").writeText("-cp\n${entries.joinToString(File.pathSeparator)}\n")
+               // Extra source-set projects live under src/<set>; use the repo root like IntelliJ
+               File(outDir, "workdir").writeText(project.rootProject.projectDir.absolutePath)
+            }
+         }
+      }
+   }
+}


### PR DESCRIPTION
Adds command-line docs for compiling the composite and launching main classes IntelliJ-style via a `run-main` script (Gradle builds the classpath, then `exec`s `java` so Ctrl+C hits the app).

Useful when running things like `RDXUIDemo` without the IDE.