### PR TITLE
Reset state estimator to origin, for the invariant estimator

### DIFF
--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/AvatarEstimatorThread.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/AvatarEstimatorThread.java
@@ -155,6 +155,18 @@ public class AvatarEstimatorThread extends ModularRobotController implements SCS
       }
    }
 
+   public void requestReinitializeEstimator()
+   {
+      if (mainStateEstimator != null)
+         mainStateEstimator.requestReinitializeEstimator();
+   }
+
+   public void requestReinitializeEstimatorToWorldOrigin()
+   {
+      if (mainStateEstimator != null)
+         mainStateEstimator.requestReinitializeEstimatorToWorldOrigin();
+   }
+
    public void setupHighLevelControllerCallback(HighLevelHumanoidControllerFactory controllerFactory,
                                                 Map<HighLevelControllerName, StateEstimatorMode> stateModeMap)
    {

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/AvatarEstimatorThreadFactory.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/AvatarEstimatorThreadFactory.java
@@ -489,7 +489,11 @@ public class AvatarEstimatorThreadFactory
          asyncROS2NodeField.get().createSubscriptionSampler(inputTopicField.get().withType(ReinitializeStateEstimatorMessage.class),
                                                             sample ->
                                                             {
-                                                               if (sample.getRequestReinitialize())
+                                                               if (!sample.getRequestReinitialize())
+                                                                  return;
+                                                               if (sample.getReinitializeToWorldOrigin())
+                                                                  stateEstimator.requestReinitializeEstimatorToWorldOrigin();
+                                                               else
                                                                   stateEstimator.requestReinitializeEstimator();
                                                             });
       }

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/AvatarEstimatorThreadFactory.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/AvatarEstimatorThreadFactory.java
@@ -510,22 +510,41 @@ public class AvatarEstimatorThreadFactory
 
       if (asyncROS2NodeField.hasValue())
       {
+         // Wrist force-sensor calibration is DRC-specific, so it stays here. The reinitialize subscription
+         // is NOT: it is registered in getMainStateEstimator() so the invariant estimator gets it too.
          ForceSensorStateUpdater forceSensorStateUpdater = stateEstimator.getForceSensorStateUpdater();
          asyncROS2NodeField.get().createSubscription(inputTopicField.get().withType(RequestWristForceSensorCalibrationPacket.class),
                                      subscriber -> forceSensorStateUpdater.requestWristForceSensorCalibrationAtomic());
-         asyncROS2NodeField.get().createSubscriptionSampler(inputTopicField.get().withType(ReinitializeStateEstimatorMessage.class),
-                                                            sample ->
-                                                            {
-                                                               if (!sample.getRequestReinitialize())
-                                                                  return;
-                                                               if (sample.getReinitializeToWorldOrigin())
-                                                                  stateEstimator.requestReinitializeEstimatorToWorldOrigin();
-                                                               else
-                                                                  stateEstimator.requestReinitializeEstimator();
-                                                            });
       }
 
       return stateEstimator;
+   }
+
+   /**
+    * Subscribes the given main estimator to {@link ReinitializeStateEstimatorMessage}.
+    *
+    * <p>This lives here, on the {@link StateEstimatorController} interface, rather than inside
+    * {@link #createDRCKinematicsStateEstimator()} where it used to: otherwise the message is a silent no-op
+    * whenever the invariant estimator is the main one.</p>
+    *
+    * <p>Known gap (pre-existing): an estimator injected via {@link #setMainStateEstimator} bypasses
+    * {@link #getMainStateEstimator()}'s create path and so is not subscribed.</p>
+    */
+   private void registerReinitializeStateEstimatorSubscription(StateEstimatorController stateEstimator)
+   {
+      if (stateEstimator == null || !asyncROS2NodeField.hasValue())
+         return;
+
+      asyncROS2NodeField.get().createSubscriptionSampler(inputTopicField.get().withType(ReinitializeStateEstimatorMessage.class),
+                                                         sample ->
+                                                         {
+                                                            if (!sample.getRequestReinitialize())
+                                                               return;
+                                                            if (sample.getReinitializeToWorldOrigin())
+                                                               stateEstimator.requestReinitializeEstimatorToWorldOrigin();
+                                                            else
+                                                               stateEstimator.requestReinitializeEstimator();
+                                                         });
    }
 
    /** Selects the invariant InEKF as the main estimator (built by {@link #createInvariantStateEstimator()}). */
@@ -953,6 +972,8 @@ public class AvatarEstimatorThreadFactory
             mainStateEstimatorField.set(createInvariantStateEstimator());
          else
             mainStateEstimatorField.set(createDRCKinematicsStateEstimator());
+
+         registerReinitializeStateEstimatorSubscription(mainStateEstimatorField.get());
       }
       return mainStateEstimatorField.get();
    }

--- a/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/scs2/SCS2AvatarSimulation.java
+++ b/ihmc-avatar-interfaces/src/main/java/us/ihmc/avatar/scs2/SCS2AvatarSimulation.java
@@ -109,6 +109,34 @@ public class SCS2AvatarSimulation
          simulationConstructionSet.waitUntilVisualizerFullyUp();
    }
 
+   /**
+    * Reinitializes the state estimator with legacy behavior (restore last stored / provided root pose).
+    */
+   public void reinitializeStateEstimatorFromRobot()
+   {
+      if (estimatorThread == null)
+      {
+         LogTools.warn("Cannot reinitialize state estimator: estimator thread is not available.");
+         return;
+      }
+
+      estimatorThread.requestReinitializeEstimator();
+   }
+
+   /**
+    * Reinitializes the state estimator so mid-feet is at the world origin (translation only).
+    */
+   public void reinitializeStateEstimatorToWorldOrigin()
+   {
+      if (estimatorThread == null)
+      {
+         LogTools.warn("Cannot reinitialize state estimator to world origin: estimator thread is not available.");
+         return;
+      }
+
+      estimatorThread.requestReinitializeEstimatorToWorldOrigin();
+   }
+
    public void destroy()
    {
       if (hasBeenDestroyed)

--- a/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/simulation/scs2/RDXSCS2HumanoidSimulationManager.java
+++ b/ihmc-high-level-behaviors/src/libgdx/java/us/ihmc/rdx/simulation/scs2/RDXSCS2HumanoidSimulationManager.java
@@ -1,7 +1,5 @@
 package us.ihmc.rdx.simulation.scs2;
 
-import gnu.trove.map.TObjectDoubleMap;
-import gnu.trove.map.hash.TObjectDoubleHashMap;
 import imgui.ImGui;
 import us.ihmc.avatar.drcRobot.DRCRobotModel;
 import us.ihmc.avatar.initialSetup.RobotInitialSetup;
@@ -9,15 +7,11 @@ import us.ihmc.avatar.scs2.SCS2AvatarSimulation;
 import us.ihmc.avatar.scs2.SCS2AvatarSimulationFactory;
 import us.ihmc.commonWalkingControlModules.desiredFootStep.footstepGenerator.HeadingAndVelocityEvaluationScriptParameters;
 import us.ihmc.jros2.AsyncROS2Node;
-import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
-import us.ihmc.mecano.multiBodySystem.iterators.SubtreeStreams;
 import us.ihmc.rdx.imgui.ImGuiUniqueLabelMap;
 import us.ihmc.rdx.ui.RDXBaseUI;
 import us.ihmc.scs2.definition.robot.RobotDefinition;
 import us.ihmc.scs2.definition.terrain.TerrainObjectDefinition;
 import us.ihmc.scs2.simulation.SimulationSession;
-import us.ihmc.scs2.simulation.bullet.physicsEngine.BulletPhysicsEngine;
-import us.ihmc.scs2.simulation.bullet.physicsEngine.BulletRobot;
 import us.ihmc.scs2.simulation.robot.Robot;
 import us.ihmc.simulationConstructionSetTools.util.HumanoidFloatingRootJointRobot;
 
@@ -101,20 +95,11 @@ public class RDXSCS2HumanoidSimulationManager extends RDXSCS2RestartableSimulati
       {
          if (ImGui.button(labels.get("Reinitialize State Estimator")))
          {
-            if (getSession().getPhysicsEngine() instanceof BulletPhysicsEngine bulletPhysicsEngine)
-            {
-               for (BulletRobot bulletRobot : bulletPhysicsEngine.getBulletRobots())
-               {
-                  if (bulletRobot.getName().equalsIgnoreCase(robotModel.getSimpleRobotName()))
-                  {
-                     TObjectDoubleMap<String> jointPositions = new TObjectDoubleHashMap<>();
-                     SubtreeStreams.fromChildren(OneDoFJointBasics.class,
-                                                 bulletRobot.getRootBody()).forEach(joint -> jointPositions.put(joint.getName(), joint.getQ()));
-                     avatarSimulation.getEstimatorThread().initializeStateEstimators(bulletRobot.getFloatingRootJoint().getFrameAfterJoint()
-                                                                                                .getTransformToParent(), jointPositions);
-                  }
-               }
-            }
+            avatarSimulation.reinitializeStateEstimatorFromRobot();
+         }
+         if (ImGui.button(labels.get("Reinitialize State Estimator to World Origin")))
+         {
+            avatarSimulation.reinitializeStateEstimatorToWorldOrigin();
          }
       });
 

--- a/ihmc-interfaces-jros2/messages/ihmc_interfaces/controller_msgs/msg/ReinitializeStateEstimatorMessage.msg
+++ b/ihmc-interfaces-jros2/messages/ihmc_interfaces/controller_msgs/msg/ReinitializeStateEstimatorMessage.msg
@@ -2,3 +2,6 @@
 # This message is used to request an initialization fo the state estimator.
 
 bool request_reinitialize
+# When true (with request_reinitialize), reinitialize so mid-feet is at world origin.
+# Corresponds to the reinitializeStateEstimatorToWorldOrigin YoVariable.
+bool reinitialize_to_world_origin

--- a/ihmc-interfaces-jros2/src/main/java/controller_msgs/ReinitializeStateEstimatorMessage.java
+++ b/ihmc-interfaces-jros2/src/main/java/controller_msgs/ReinitializeStateEstimatorMessage.java
@@ -16,17 +16,22 @@ This message is used to request an initialization fo the state estimator.
 # This message is part of the IHMC whole-body controller API.
 # This message is used to request an initialization fo the state estimator.
 
-bool request_reinitialize}</pre>
+bool request_reinitialize
+# When true (with request_reinitialize), reinitialize so mid-feet is at world origin.
+# Corresponds to the reinitializeStateEstimatorToWorldOrigin YoVariable.
+bool reinitialize_to_world_origin}</pre>
 */
 public class ReinitializeStateEstimatorMessage implements ROS2Message<ReinitializeStateEstimatorMessage>
 {
    public static final java.lang.String name = "controller_msgs::msg::dds_::ReinitializeStateEstimatorMessage_";
 
    private boolean request_reinitialize_;
+   private boolean reinitialize_to_world_origin_;
 
    public ReinitializeStateEstimatorMessage()
    {
       request_reinitialize_ = (boolean) false;
+      reinitialize_to_world_origin_ = (boolean) false;
 
    }
 
@@ -42,6 +47,7 @@ public class ReinitializeStateEstimatorMessage implements ROS2Message<Reinitiali
       int initialAlignment = currentAlignment;
 
       currentAlignment += 1 + CDRBuffer.alignment(currentAlignment, 1); // request_reinitialize_
+      currentAlignment += 1 + CDRBuffer.alignment(currentAlignment, 1); // reinitialize_to_world_origin_
 
       return currentAlignment - initialAlignment;
    }
@@ -50,6 +56,7 @@ public class ReinitializeStateEstimatorMessage implements ROS2Message<Reinitiali
    public void serialize(CDRBuffer buffer)
    {
       buffer.writeBoolean(request_reinitialize_);
+      buffer.writeBoolean(reinitialize_to_world_origin_);
 
    }
 
@@ -57,6 +64,7 @@ public class ReinitializeStateEstimatorMessage implements ROS2Message<Reinitiali
    public void deserialize(CDRBuffer buffer)
    {
       request_reinitialize_ = buffer.readBoolean();
+      reinitialize_to_world_origin_ = buffer.readBoolean();
 
    }
 
@@ -64,6 +72,7 @@ public class ReinitializeStateEstimatorMessage implements ROS2Message<Reinitiali
    public void set(ReinitializeStateEstimatorMessage from)
    {
       request_reinitialize_ = from.request_reinitialize_;
+      reinitialize_to_world_origin_ = from.reinitialize_to_world_origin_;
 
    }
 
@@ -77,6 +86,16 @@ public class ReinitializeStateEstimatorMessage implements ROS2Message<Reinitiali
       this.request_reinitialize_ = request_reinitialize_;
    }
 
+   public boolean getReinitializeToWorldOrigin()
+   {
+      return reinitialize_to_world_origin_;
+   }
+
+   public void setReinitializeToWorldOrigin(boolean reinitialize_to_world_origin_)
+   {
+      this.reinitialize_to_world_origin_ = reinitialize_to_world_origin_;
+   }
+
 
    @Override
    public java.lang.String toString()
@@ -85,6 +104,9 @@ public class ReinitializeStateEstimatorMessage implements ROS2Message<Reinitiali
       builder.append("ReinitializeStateEstimatorMessage {");
       builder.append("request_reinitialize_=");
       builder.append(request_reinitialize_);
+      builder.append(", ");
+      builder.append("reinitialize_to_world_origin_=");
+      builder.append(reinitialize_to_world_origin_);
 
       builder.append("}");
       return builder.toString();

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/StateEstimatorController.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/StateEstimatorController.java
@@ -28,6 +28,22 @@ public interface StateEstimatorController extends RobotController, StateEstimato
    public void initializeEstimator(RigidBodyTransformReadOnly rootJointTransform, TObjectDoubleMap<String> jointPositions);
 
    /**
+    * Requests a reinitialization of the estimator on the next control tick (legacy behavior:
+    * restore last stored / provided root translation).
+    */
+   default void requestReinitializeEstimator()
+   {
+   }
+
+   /**
+    * Requests a reinitialization that places mid-feet at the world origin (translation only).
+    * Corresponds to the {@code reinitializeStateEstimatorToWorldOrigin} YoVariable.
+    */
+   default void requestReinitializeEstimatorToWorldOrigin()
+   {
+   }
+
+   /**
     * Initializes the root joint pose in the estimator.
     *
     * @param rootJointTransform the transform of the floating root joint that is estimated.

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/DRCKinematicsBasedStateEstimator.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/DRCKinematicsBasedStateEstimator.java
@@ -82,6 +82,7 @@ public class DRCKinematicsBasedStateEstimator implements StateEstimatorControlle
    private final List<FootSwitchInterface> footSwitchList;
 
    private final YoBoolean reinitializeStateEstimator = new YoBoolean("reinitializeStateEstimator", registry);
+   private final YoBoolean reinitializeStateEstimatorToWorldOrigin = new YoBoolean("reinitializeStateEstimatorToWorldOrigin", registry);
 
    private final FloatingJointBasics rootJoint;
    private final YoFixedFrameTwist yoRootTwist;
@@ -303,7 +304,13 @@ public class DRCKinematicsBasedStateEstimator implements StateEstimatorControlle
    @Override
    public void doControl()
    {
-      if (reinitializeStateEstimator.getBooleanValue())
+      if (reinitializeStateEstimatorToWorldOrigin.getBooleanValue())
+      {
+         reinitializeStateEstimatorToWorldOrigin.set(false);
+         pelvisLinearStateUpdater.requestInitializeToMidFeetOrigin();
+         initialize();
+      }
+      else if (reinitializeStateEstimator.getBooleanValue())
       {
          reinitializeStateEstimator.set(false);
          initialize();
@@ -400,9 +407,16 @@ public class DRCKinematicsBasedStateEstimator implements StateEstimatorControlle
       pelvisPoseHistoryCorrection.setExternalPelvisCorrectorSubscriber(externalPelvisPoseSubscriber);
    }
 
+   @Override
    public void requestReinitializeEstimator()
    {
       reinitializeStateEstimator.set(true);
+   }
+
+   @Override
+   public void requestReinitializeEstimatorToWorldOrigin()
+   {
+      reinitializeStateEstimatorToWorldOrigin.set(true);
    }
 
    @Override

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/PelvisLinearStateUpdater.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/PelvisLinearStateUpdater.java
@@ -135,10 +135,13 @@ public class PelvisLinearStateUpdater implements SCS2YoGraphicHolder
    private final FloatingJointBasics rootJoint;
 
    private boolean initializeToActual = false;
+   private boolean useProvidedRootPositionOnNextInit = false;
+   private boolean initializeToMidFeetOrigin = false;
    private final FramePoint3D initialRootJointPosition = new FramePoint3D(worldFrame);
 
    // Temporary variables
    private final FramePoint3D footPositionInWorld = new FramePoint3D();
+   private final FramePoint3D midFeetPositionInWorld = new FramePoint3D();
 
    private final BooleanProvider trustOnlyLowestFoot = new BooleanParameter("TrustOnlyLowestFoot", registry, false);
    private final IntegerProvider lowestFootWindowSize = new IntegerParameter("LowestFootWindowSize", registry, 0);
@@ -299,7 +302,18 @@ public class PelvisLinearStateUpdater implements SCS2YoGraphicHolder
 
    private void initializeRobotState()
    {
-      if (!initializeToActual)
+      if (useProvidedRootPositionOnNextInit)
+      {
+         useProvidedRootPositionOnNextInit = false;
+         initializeToMidFeetOrigin = false;
+         rootJointPosition.set(initialRootJointPosition);
+      }
+      else if (initializeToMidFeetOrigin)
+      {
+         initializeToMidFeetOrigin = false;
+         initializeRootJointPositionToMidFeetOrigin();
+      }
+      else if (!initializeToActual)
       {
          rootJointPosition.set(worldFrame, rootJoint.getJointPose().getPosition());
 
@@ -336,9 +350,47 @@ public class PelvisLinearStateUpdater implements SCS2YoGraphicHolder
       rootJointPositionEstimate.getRateEstimation().setToZero();
    }
 
+   /**
+    * Translates the estimated root so the average foot contact frame (mid-feet) is at world origin.
+    * Orientation / yaw is left unchanged.
+    */
+   private void initializeRootJointPositionToMidFeetOrigin()
+   {
+      rootJoint.updateFramesRecursively();
+
+      midFeetPositionInWorld.setToZero(worldFrame);
+      for (int i = 0; i < feet.size(); i++)
+      {
+         footPositionInWorld.setToZero(footFrames.get(feet.get(i)));
+         footPositionInWorld.changeFrame(worldFrame);
+         midFeetPositionInWorld.add(footPositionInWorld);
+      }
+      midFeetPositionInWorld.scale(1.0 / feet.size());
+
+      rootJointPosition.set(worldFrame, rootJoint.getJointPose().getPosition());
+      rootJointPosition.sub(midFeetPositionInWorld);
+
+      initialRootJointPosition.setIncludingFrame(rootJointPosition);
+      initializeToActual = true;
+
+      LogTools.info("State estimator reinitialized to mid-feet origin.%nmidFeet = %s%nroot = %s".formatted(midFeetPositionInWorld, rootJointPosition));
+   }
+
+   public void requestInitializeToMidFeetOrigin()
+   {
+      initializeToMidFeetOrigin = true;
+   }
+
+   public boolean isProvidedRootPositionPending()
+   {
+      return useProvidedRootPositionOnNextInit;
+   }
+
    public void initializeRootJointPosition(Tuple3DReadOnly rootJointPosition)
    {
       initializeToActual = true;
+      useProvidedRootPositionOnNextInit = true;
+      initializeToMidFeetOrigin = false;
       initialRootJointPosition.setIncludingFrame(worldFrame, rootJointPosition);
    }
 

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariant_estimator/ContactProbabilityProvider.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariant_estimator/ContactProbabilityProvider.java
@@ -38,4 +38,20 @@ public interface ContactProbabilityProvider
     *         contact, 0 = treat as not in contact (fully muted).
     */
    double getContactProbability(RobotSide side);
+
+   /**
+    * Discards whatever history this provider carries across ticks (finite-difference state, filters).
+    *
+    * <p>Call this after a <em>one-shot jump</em> of the estimated base pose — a gauge reset, not motion —
+    * where a tick-to-tick difference taken across the jump is meaningless. Without it, a detector that
+    * finite-differences sole position reads the jump as a velocity of {@code Δ/dt} and mistakes the reset
+    * for a foot leaving the ground.</p>
+    *
+    * <p>The default is a no-op, which is correct for stateless and force-based providers (e.g.
+    * {@link FootSwitchContactProbabilityProvider}): they read the sensors afresh each tick and never see
+    * the estimated base pose at all.</p>
+    */
+   default void reset()
+   {
+   }
 }

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariant_estimator/InvariantEKFStateEstimator.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariant_estimator/InvariantEKFStateEstimator.java
@@ -459,11 +459,6 @@ public class InvariantEKFStateEstimator implements StateEstimatorController
    }
 
    /**
-    * Re-seed the flter when resuming from a held state: base pose from the current (gyro-tracked) pelvis frame,
-    * contact anchors from current sole FK, zero velocity, covariance reset to P = initialCovariance * I.
-    * Runs only on the hold->active transition, so the allication here is not when the estimator is actively running yet.
-    */
-   /**
     * Replaces the contact FK measurement noise source (default: the constant isotropic diagonal).
     * This is the step-8 injection point for a covariance-routing provider (J Sigma_q J^T from a
     * joint-level pre-filter with {@code hasCovariance()}).
@@ -473,6 +468,18 @@ public class InvariantEKFStateEstimator implements StateEstimatorController
       this.contactMeasurementNoiseProvider = Objects.requireNonNull(contactMeasurementNoiseProvider);
    }
 
+   /**
+    * Re-seed the filter from the shared robot model: base pose from the current (gyro-tracked) pelvis frame,
+    * contact anchors from current sole FK, zero velocity, covariance reset to P = initialCovariance * I.
+    *
+    * <p>Because the base pose and every contact anchor are re-derived from the SAME model frames, the two
+    * always land in a consistent gauge -- the contact residual R^T (p_c,i - p) is preserved by construction,
+    * whatever the caller did to the root joint beforehand. That is what makes this safe to use as the
+    * back end of a base-pose reset; see {@code InvariantMainStateEstimator.reinitializeToMidFeetOrigin()}.</p>
+    *
+    * <p>Runs only on the hold->active transition (and from the one-shot
+    * {@link #reinitializeAtCurrentModelPose()}), so the allocation here is not on the running hot path.</p>
+    */
    public void reAnchor()
    {
       referenceFrames.updateFrames();
@@ -492,6 +499,21 @@ public class InvariantEKFStateEstimator implements StateEstimatorController
 
       ekf.initialize(tempRotation, new Vector3D(), basePosition, contactPositions, scaledIdentity(initialCovariance));
       updateYoVariables();
+   }
+
+   /**
+    * One-shot re-seed at the model's current base pose: {@link #reAnchor()} plus a clear of the contact
+    * provider's cross-tick history.
+    *
+    * <p>Use this (not {@code reAnchor()} directly) when the caller has just <em>translated</em> the root
+    * joint on the shared model. A provider that finite-differences sole position -- {@link
+    * KinematicContactDetector} -- would otherwise read the jump as a vertical speed of dz/dt and mute both
+    * feet for a few ticks.</p>
+    */
+   public void reinitializeAtCurrentModelPose()
+   {
+      contactProbabilityProvider.reset();
+      reAnchor();
    }
 
    @Override

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariant_estimator/InvariantMainStateEstimator.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariant_estimator/InvariantMainStateEstimator.java
@@ -3,12 +3,14 @@ package us.ihmc.stateEstimation.invariant_estimator;
 import gnu.trove.map.TObjectDoubleMap;
 
 import us.ihmc.euclid.matrix.RotationMatrix;
+import us.ihmc.euclid.referenceFrame.FramePoint3D;
 import us.ihmc.euclid.referenceFrame.FrameVector3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.interfaces.RigidBodyTransformReadOnly;
 import us.ihmc.euclid.tuple3D.Vector3D;
 import us.ihmc.humanoidRobotics.communication.packets.sensing.StateEstimatorMode;
 import us.ihmc.humanoidRobotics.frames.HumanoidReferenceFrames;
+import us.ihmc.log.LogTools;
 import us.ihmc.mecano.frames.MovingReferenceFrame;
 import us.ihmc.mecano.multiBodySystem.interfaces.FloatingJointBasics;
 import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
@@ -175,6 +177,17 @@ public class InvariantMainStateEstimator implements StateEstimatorController
    private final Vector3D angularVelocityBody = new Vector3D();
    private final FrameVector3D rootLinearVelocityWorld = new FrameVector3D();
 
+   // Operator-requested one-shot reinitializations, consumed at the top of doControl(). Same names and
+   // semantics as the DRC estimator's, so the shared ReinitializeStateEstimatorMessage plumbing and the
+   // SCS2 buttons drive whichever estimator is running.
+   private final YoBoolean reinitializeStateEstimator = new YoBoolean("reinitializeStateEstimator", registry);
+   private final YoBoolean reinitializeStateEstimatorToWorldOrigin = new YoBoolean("reinitializeStateEstimatorToWorldOrigin", registry);
+
+   // Mid-feet reinit temporaries (deliberately separate scratch from writeRootJoint's rootPosition).
+   private final FramePoint3D footPositionInWorld = new FramePoint3D();
+   private final FramePoint3D midFeetPositionInWorld = new FramePoint3D();
+   private final Vector3D reinitRootPosition = new Vector3D();
+
    /**
     * @param fullRobotModel             the estimator's full robot model (joints set here, root written here).
     * @param processedSensorOutput      processed sensor outputs (IMU + joints).
@@ -303,6 +316,21 @@ public class InvariantMainStateEstimator implements StateEstimatorController
 
       updateJoints();
       referenceFrames.updateFrames();
+
+      // One-shot operator reinits, consumed BEFORE the filter runs so the whole tick sees the new gauge.
+      // The model frames were just refreshed from the previous tick's writeRootJoint(), so the sole FK the
+      // reinit reads is the current estimate.
+      if (reinitializeStateEstimatorToWorldOrigin.getBooleanValue())
+      {
+         reinitializeStateEstimatorToWorldOrigin.set(false);
+         reinitializeStateEstimator.set(false); // world-origin subsumes the plain reinit
+         reinitializeToMidFeetOrigin();
+      }
+      else if (reinitializeStateEstimator.getBooleanValue())
+      {
+         reinitializeStateEstimator.set(false);
+         reinitializeAtCurrentPose();
+      }
 
       invariantEstimator.doControl();
 
@@ -456,6 +484,80 @@ public class InvariantMainStateEstimator implements StateEstimatorController
          yawCorrector.reset();
 
       centerOfMassUpdater.initialize();
+   }
+
+   @Override
+   public void requestReinitializeEstimator()
+   {
+      reinitializeStateEstimator.set(true);
+   }
+
+   @Override
+   public void requestReinitializeEstimatorToWorldOrigin()
+   {
+      reinitializeStateEstimatorToWorldOrigin.set(true);
+   }
+
+   /**
+    * Re-seeds the filter in place: base pose from the model's current pelvis frame, contact anchors from
+    * current sole FK, zero velocity, P = initialCovariance * I. The estimate does not move; only the
+    * accumulated covariance and the (possibly stale) contact anchors are discarded.
+    */
+   private void reinitializeAtCurrentPose()
+   {
+      invariantEstimator.reinitializeAtCurrentModelPose();
+
+      if (yawCorrector != null)
+         yawCorrector.reset();
+      centerOfMassUpdater.initialize();
+   }
+
+   /**
+    * Operator gauge reset: translates the estimated base so the average sole position lands on the world
+    * origin, leaving orientation -- and therefore yaw -- untouched.
+    *
+    * <p><b>Why this is written as a translate-then-re-seed and not as a base-position write.</b> The InEKF
+    * state carries the base position p AND every contact anchor p_c,i as absolute world positions, and the
+    * contact residual is</p>
+    *
+    * <pre>    y_i = R^T (p_c,i - p)</pre>
+    *
+    * <p>Moving p by delta without moving each p_c,i by the SAME delta injects a residual of exactly
+    * -R^T delta on both feet on the very next tick; the filter would then "correct" that by snapping the
+    * base back, and would corrupt velocity and orientation through the cross-covariance on the way. The
+    * reset must therefore be a <em>gauge shift</em>: p and every p_c,i move together.</p>
+    *
+    * <p>That is what this does. The root joint is translated on the shared model, the frames are refreshed,
+    * and the filter is re-seeded from that model -- {@link InvariantEKFStateEstimator#reAnchor()} re-derives
+    * the base from the pelvis frame and the anchors from the now-translated sole FK, so the two land in a
+    * consistent gauge by construction. Do not "simplify" this into a direct write of the base position.</p>
+    *
+    * <p>Velocity is zeroed and P is reset to initialCovariance * I, mirroring the DRC estimator's mid-feet
+    * reinit (which likewise zeroes its rate estimate).</p>
+    *
+    * <p>Assumes the caller has already refreshed the model frames for this tick.</p>
+    */
+   private void reinitializeToMidFeetOrigin()
+   {
+      midFeetPositionInWorld.setToZero(ReferenceFrame.getWorldFrame());
+      for (RobotSide side : RobotSide.values)
+      {
+         footPositionInWorld.setToZero(referenceFrames.getSoleFrame(side));
+         footPositionInWorld.changeFrame(ReferenceFrame.getWorldFrame());
+         midFeetPositionInWorld.add(footPositionInWorld);
+      }
+      midFeetPositionInWorld.scale(1.0 / RobotSide.values.length);
+
+      reinitRootPosition.set(rootJoint.getJointPose().getPosition());
+      reinitRootPosition.sub(midFeetPositionInWorld); // translation only: the orientation is left alone
+      rootJoint.setJointPosition(reinitRootPosition);
+      rootJoint.updateFramesRecursively();
+      referenceFrames.updateFrames();
+
+      reinitializeAtCurrentPose(); // p and every p_c,i now move together, off the translated model
+
+      LogTools.info("InEKF state estimator reinitialized to mid-feet origin.%nmidFeet = %s%nroot = %s".formatted(midFeetPositionInWorld,
+                                                                                                                reinitRootPosition));
    }
 
    @Override

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariant_estimator/KinematicContactDetector.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariant_estimator/KinematicContactDetector.java
@@ -124,6 +124,22 @@ public class KinematicContactDetector implements ContactProbabilityProvider
       return probability[side.ordinal()];
    }
 
+   /**
+    * Clears the finite-difference history, so the next {@link #update()} reports {@code ż = 0} instead of
+    * differencing across a discontinuity. {@code NaN} is already the "no previous sample" sentinel handled
+    * in {@link #update()}.
+    *
+    * <p>The smoothed probabilities are deliberately <em>not</em> cleared: they are still the best estimate
+    * of who is on the ground, and zeroing them would drop both feet below the estimator's contact-hold
+    * threshold for several ticks — precisely the drop-out this reset exists to prevent.</p>
+    */
+   @Override
+   public void reset()
+   {
+      for (RobotSide side : RobotSide.values)
+         previousHeight[side.ordinal()] = Double.NaN;
+   }
+
    /** @return the sole-origin height above the support plane (m), in world. */
    private double soleHeightAboveGround(RobotSide side)
    {

--- a/ihmc-state-estimation/src/test/java/us/ihmc/stateEstimation/invariant_estimator/InvariantMainStateEstimatorTest.java
+++ b/ihmc-state-estimation/src/test/java/us/ihmc/stateEstimation/invariant_estimator/InvariantMainStateEstimatorTest.java
@@ -9,21 +9,26 @@ import java.util.List;
 import java.util.Random;
 
 import org.ejml.data.DMatrixRMaj;
+import org.ejml.dense.row.factory.DecompositionFactory_DDRM;
+import org.ejml.interfaces.decomposition.EigenDecomposition_F64;
 import org.junit.jupiter.api.Test;
 
 import gnu.trove.map.hash.TObjectDoubleHashMap;
 
 import us.ihmc.euclid.matrix.RotationMatrix;
+import us.ihmc.euclid.referenceFrame.FramePoint3D;
 import us.ihmc.euclid.referenceFrame.FrameVector3D;
 import us.ihmc.euclid.referenceFrame.ReferenceFrame;
 import us.ihmc.euclid.transform.RigidBodyTransform;
 import us.ihmc.euclid.tuple3D.Vector3D;
+import us.ihmc.mecano.frames.MovingReferenceFrame;
 import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
 import us.ihmc.mecano.multiBodySystem.interfaces.RigidBodyBasics;
 import us.ihmc.mecano.tools.JointStateType;
 import us.ihmc.mecano.tools.MultiBodySystemRandomTools;
 import us.ihmc.robotModels.FullRobotModelTestTools.RandomFullHumanoidRobotModel;
 import us.ihmc.robotics.robotSide.RobotSide;
+import us.ihmc.robotics.robotSide.SideDependentList;
 import us.ihmc.sensorProcessing.stateEstimation.IMUBasedJointStateEstimatorParameters;
 import us.ihmc.sensorProcessing.stateEstimation.IMUSensorReadOnly;
 import us.ihmc.stateEstimation.jointLevel.JointLevelKFPreFilter;
@@ -248,7 +253,208 @@ public class InvariantMainStateEstimatorTest
       assertPipelineFinite(rig, "poisoned leg IMU");
    }
 
+   /**
+    * Gauge-shift correctness for {@link InvariantMainStateEstimator#requestReinitializeEstimatorToWorldOrigin()}.
+    *
+    * <p>The InEKF state carries the base position p and every contact anchor p_c,i as absolute world
+    * positions, and the contact update drives the residual y_i = R^T (p_c,i - p) to its FK prediction. A
+    * reset that moved p without moving each p_c,i by the same delta would inject a residual of -R^T delta on
+    * BOTH feet, which the filter would then "correct" by snapping the base back. So the load-bearing
+    * assertion here is not "the base moved" but "the filter's residual still agrees with forward
+    * kinematics" — which is exactly what it means for p and every p_c,i to have moved together.</p>
+    */
+   @Test
+   public void testReinitializeToWorldOriginIsAGaugeShift()
+   {
+      Rig rig = staticRigAtBasePosition(4006L, new Vector3D(1.7, -0.9, 0.35));
+
+      Vector3D midFeetBefore = midFeetInWorld(rig);
+      assertTrue(midFeetBefore.norm() > 1.0e-2,
+                 "precondition: the reset must have a non-trivial translation to make (" + midFeetBefore.norm() + ")");
+
+      RotationMatrix rotationBefore = new RotationMatrix();
+      rig.ekf.getRotation(rotationBefore);
+      SideDependentList<Vector3D> fkResidualBefore = new SideDependentList<>(forwardKinematicsContactResidual(rig, RobotSide.LEFT),
+                                                                            forwardKinematicsContactResidual(rig, RobotSide.RIGHT));
+
+      rig.main.requestReinitializeEstimatorToWorldOrigin();
+      rig.doControl();
+
+      // 1. The gauge invariant: the filter's contact residual still matches the model's forward kinematics,
+      //    i.e. the anchors travelled with the base. This is the assertion that fails loudly (by |delta|,
+      //    ~2 m here) if someone "simplifies" the reset into a direct write of the base position.
+      for (RobotSide side : RobotSide.values)
+      {
+         Vector3D mismatch = filterContactResidual(rig, side);
+         mismatch.sub(forwardKinematicsContactResidual(rig, side));
+         assertTrue(mismatch.norm() < 1.0e-6, "contact anchors moved with the base (" + side + " residual mismatch " + mismatch.norm() + ")");
+      }
+      // ...and the FK residual itself is untouched, because a rigid translation cannot change body-frame geometry.
+      for (RobotSide side : RobotSide.values)
+      {
+         Vector3D fkDrift = forwardKinematicsContactResidual(rig, side);
+         fkDrift.sub(fkResidualBefore.get(side));
+         assertTrue(fkDrift.norm() < 1.0e-9, "translation does not change the body-frame foot geometry (" + side + ")");
+      }
+
+      // 2. Mid-feet lands on the world origin.
+      assertTrue(midFeetInWorld(rig).norm() < 1.0e-5, "mid-feet at the world origin after the reset: " + midFeetInWorld(rig).norm());
+
+      // 3. Translation only: orientation, and therefore yaw, is untouched.
+      RotationMatrix rotationAfter = new RotationMatrix();
+      rig.ekf.getRotation(rotationAfter);
+      assertTrue(rotationAfter.distance(rotationBefore) < 1.0e-6, "the reset is translation only: orientation unchanged");
+      assertEquals(rotationBefore.getYaw(), rotationAfter.getYaw(), 1.0e-6, "yaw unchanged by the reset");
+
+      // 4. The covariance is still a covariance.
+      assertCovarianceSymmetricAndPSD(rig, "reinitialize to world origin");
+
+      // 5. No snap-back: a consistent gauge shift leaves the contact update nothing to correct.
+      for (int k = 0; k < 500; k++)
+         rig.doControl();
+      assertTrue(midFeetInWorld(rig).norm() < 1.0e-2, "base does not snap back after the reset: " + midFeetInWorld(rig).norm());
+      assertPipelineFinite(rig, "after reinitialize to world origin");
+   }
+
+   /** The plain reinit re-seeds in place: anchors and covariance are refreshed, the estimate does not move. */
+   @Test
+   public void testReinitializeInPlaceDoesNotMoveTheBase()
+   {
+      Rig rig = staticRigAtBasePosition(4007L, new Vector3D(1.7, -0.9, 0.35));
+
+      Vector3D positionBefore = new Vector3D();
+      rig.ekf.getBasePosition(positionBefore);
+
+      rig.main.requestReinitializeEstimator();
+      rig.doControl();
+
+      Vector3D positionDrift = new Vector3D();
+      rig.ekf.getBasePosition(positionDrift);
+      positionDrift.sub(positionBefore);
+      assertTrue(positionDrift.norm() < 1.0e-6, "the plain reinit re-seeds in place: " + positionDrift.norm());
+
+      for (RobotSide side : RobotSide.values)
+      {
+         Vector3D mismatch = filterContactResidual(rig, side);
+         mismatch.sub(forwardKinematicsContactResidual(rig, side));
+         assertTrue(mismatch.norm() < 1.0e-6, "anchors re-seeded from FK (" + side + ")");
+      }
+      assertCovarianceSymmetricAndPSD(rig, "reinitialize in place");
+   }
+
+   /**
+    * The Z half of the reset is a discontinuity, and {@link KinematicContactDetector} finite-differences sole
+    * height — so without {@link ContactProbabilityProvider#reset()} it reads the jump as a vertical speed of
+    * dz/dt and mutes both feet. A/B on the same frames and the same jump: only the reset detector survives.
+    */
+   @Test
+   public void testContactDetectorResetSuppressesTheResetJumpSpike()
+   {
+      Rig rig = buildRig(4008L, new RotationMatrix(), 1.0, false);
+      SideDependentList<MovingReferenceFrame> soleFrames = new SideDependentList<>();
+      for (RobotSide side : RobotSide.values)
+         soleFrames.put(side, rig.model.getSoleFrame(side));
+
+      // Height gate deliberately wide open (h0 = 10 m, w = 1 m) so random model geometry cannot decide the
+      // outcome: this test is about the SPEED gate, which is the one the jump trips. No smoothing, so the
+      // spike shows up on the tick it happens.
+      KinematicContactDetector withoutReset = new KinematicContactDetector(soleFrames, null, DT, 0.0, 10.0, 1.0, 0.50, 0.10, 0.0);
+      KinematicContactDetector withReset = new KinematicContactDetector(soleFrames, null, DT, 0.0, 10.0, 1.0, 0.50, 0.10, 0.0);
+
+      for (int k = 0; k < 3; k++) // settle: both feet firmly "in contact"
+      {
+         withoutReset.update();
+         withReset.update();
+      }
+      for (RobotSide side : RobotSide.values)
+         assertTrue(withReset.getContactProbability(side) > 0.99, "precondition: both feet read contact before the jump (" + side + ")");
+
+      // The reset's translation, applied to the model exactly as reinitializeToMidFeetOrigin() would.
+      Vector3D jumpedBasePosition = new Vector3D(rig.model.getRootJoint().getJointPose().getPosition());
+      jumpedBasePosition.addZ(0.05);
+      rig.model.getRootJoint().setJointPosition(jumpedBasePosition);
+      rig.model.getElevator().updateFramesRecursively();
+
+      withoutReset.update();
+      withReset.reset();
+      withReset.update();
+
+      for (RobotSide side : RobotSide.values)
+      {
+         assertTrue(withoutReset.getContactProbability(side) < 0.01,
+                    "without the reset the jump reads as 50 m/s and mutes the foot (" + side + "): " + withoutReset.getContactProbability(side));
+         assertTrue(withReset.getContactProbability(side) > 0.99,
+                    "reset() discards the history so the jump is not seen as motion (" + side + "): " + withReset.getContactProbability(side));
+      }
+   }
+
    // ---------------------------------------------------------------------------------------------------------
+
+   /** A rig re-seeded with its base at {@code basePosition}, sensors set for a stationary robot. */
+   private static Rig staticRigAtBasePosition(long seed, Vector3D basePosition)
+   {
+      Rig rig = buildRig(seed, new RotationMatrix(), 1.0, false);
+
+      RigidBodyTransform baseTransform = new RigidBodyTransform();
+      baseTransform.getTranslation().set(basePosition);
+      rig.main.initializeEstimator(baseTransform, new TObjectDoubleHashMap<>());
+
+      setGravityConsistentAccel(rig);
+      for (SettableTestIMU imu : rig.imus)
+         imu.setAngularVelocity(0.0, 0.0, 0.0);
+      return rig;
+   }
+
+   /** The average sole-origin position in world — the point the reset drives to the origin. */
+   private static Vector3D midFeetInWorld(Rig rig)
+   {
+      Vector3D midFeet = new Vector3D();
+      for (RobotSide side : RobotSide.values)
+      {
+         FramePoint3D sole = new FramePoint3D(rig.model.getSoleFrame(side));
+         sole.changeFrame(WORLD);
+         midFeet.add(sole);
+      }
+      midFeet.scale(1.0 / RobotSide.values.length);
+      return midFeet;
+   }
+
+   /** y_i = R^T (p_c,i - p), read straight out of the filter state. */
+   private static Vector3D filterContactResidual(Rig rig, RobotSide side)
+   {
+      Vector3D basePosition = new Vector3D();
+      rig.ekf.getBasePosition(basePosition);
+      Vector3D residual = new Vector3D();
+      rig.ekf.getContactPosition(side.ordinal(), residual); // CONTACT_INDICES: LEFT=0, RIGHT=1
+      residual.sub(basePosition);
+
+      RotationMatrix rotation = new RotationMatrix();
+      rig.ekf.getRotation(rotation);
+      rotation.inverseTransform(residual);
+      return residual;
+   }
+
+   /** The same quantity predicted by the model: the sole origin expressed in the pelvis frame. */
+   private static Vector3D forwardKinematicsContactResidual(Rig rig, RobotSide side)
+   {
+      FramePoint3D sole = new FramePoint3D(rig.model.getSoleFrame(side));
+      sole.changeFrame(rig.model.getPelvis().getParentJoint().getFrameAfterJoint());
+      return new Vector3D(sole);
+   }
+
+   private static void assertCovarianceSymmetricAndPSD(Rig rig, String scenario)
+   {
+      DMatrixRMaj covariance = rig.ekf.getState().getCovariance().copy();
+      for (int r = 0; r < covariance.numRows; r++)
+         for (int c = r + 1; c < covariance.numCols; c++)
+            assertEquals(covariance.get(r, c), covariance.get(c, r), 1.0e-9, "covariance symmetric (" + scenario + ")");
+
+      EigenDecomposition_F64<DMatrixRMaj> eig = DecompositionFactory_DDRM.eig(covariance.numRows, false, true);
+      assertTrue(eig.decompose(covariance), "covariance eigendecomposition succeeds (" + scenario + ")");
+      for (int i = 0; i < eig.getNumberOfEigenvalues(); i++)
+         assertTrue(eig.getEigenvalue(i).getReal() > -1.0e-9,
+                    "covariance PSD (" + scenario + "): eigenvalue " + eig.getEigenvalue(i).getReal());
+   }
 
    /** Sets every IMU's specific force to the true stationary reading at its current orientation: g_up in world. */
    private static void setGravityConsistentAccel(Rig rig)


### PR DESCRIPTION
Stacks PR #1414 (reset-to-origin for the old DRC estimator) onto the new-state-estimator branch and implements the equivalent for the InEKF, so #1413 can land with the capability on both estimators.

Draft: opened against `new-state-estimator` to get a full build/test signal before folding it into that branch.

## What's here

Two things, in two commits:

1. **A merge of `feature/reset-state` (#1414)** — unmodified. Merged clean.
2. **The invariant-estimator equivalent** + the wiring fix #1414 leaves open.

## The gauge shift (the part worth reviewing)

`InvariantMainStateEstimator.writeRootJoint()` rewrites the root joint from the filter every tick, so translating the root joint alone is erased immediately — the filter state has to move.

In `InvariantState` the base position `p` and every contact anchor `p_c,i` are **absolute world positions in the same gauge**, and the contact residual is

```
y_i = R^T (p_c,i - p)
```

Moving `p` by `Δ` without moving each `p_c,i` by the same `Δ` injects a residual of exactly `−RᵀΔ` on **both** feet on the next tick. The filter then "corrects" that by snapping the base back, corrupting velocity and orientation through the cross-covariance on the way. So the reset has to be a *gauge shift*: `p` and every `p_c,i` move together.

Rather than add new `InvariantEKF` API to do that in place, this translates the root joint on the shared model, refreshes the frames, and re-seeds from the model via the existing `reAnchor()` — which re-derives the base from the pelvis frame and the anchors from the now-translated sole FK. The two land in a consistent gauge by construction.

Semantics match #1414: full 3D translation (mid-feet ends at `(0,0,0)`), orientation and yaw untouched, velocity zeroed, `P` reset to `initialCovariance·I`.

<details>
<summary>Why not preserve P with a surgical in-place shift</summary>

Under the relabeling both `X̂` and `X` shift by the pure-translation group element `G`, so the right-invariant error transforms as `η ← Ad_G η` and `P ← Ad_G P Ad_Gᵀ`. `Ad_G` is not identity for a translation — it mixes rotation error into position error. Getting that right costs new EKF API for no operational benefit on a deliberate operator gauge reset.
</details>

## Wiring gap closed

`AvatarEstimatorThreadFactory` registered the `ReinitializeStateEstimatorMessage` subscription *inside* `createDRCKinematicsStateEstimator()`, so the message was a **silent no-op** whenever `useInvariantStateEstimator` was true. Hoisted into `getMainStateEstimator()` so it binds to whichever estimator was built. #1414's `SCS2AvatarSimulation` methods and RDX buttons then drive both estimators unchanged — no `.msg` change, no jros2 regeneration.

Known pre-existing gap, documented in the helper: an estimator injected via `setMainStateEstimator(...)` bypasses this path.

## The Z hazard

`KinematicContactDetector` finite-differences sole height, so the Z part of the translation reads as `Δz/dt` (~50 m/s for a 5 cm reset at 1 kHz) and mutes both feet via the speed gate. Added `ContactProbabilityProvider.reset()` as a `default` no-op — correct for the force-based `FootSwitchContactProbabilityProvider`, which is the `FOOT_SWITCHES` production path and immune — and clear the history from the reinit. Covered by an A/B test on the same frames and the same jump.

## Tests

Three property tests in `InvariantMainStateEstimatorTest`, on the existing `RandomFullHumanoidRobotModel` rig:

- `testReinitializeToWorldOriginIsAGaugeShift` — the load-bearing one. Asserts the filter's contact residual still matches forward kinematics after the reset (i.e. the anchors travelled with the base), plus mid-feet at origin, orientation/yaw unchanged, covariance symmetric and PSD, and no snap-back over 500 further ticks.
- `testReinitializeInPlaceDoesNotMoveTheBase` — the plain reinit re-seeds without moving the estimate.
- `testContactDetectorResetSuppressesTheResetJumpSpike` — A/B showing only the reset detector survives the jump.

The gauge assertion was checked non-vacuous by temporarily injecting a base-only 0.1 m shift; it fails at exactly 0.09999999999999998. (The real bug would show up at |Δ|, ~2 m.)

## Test status

`:ihmc-state-estimation:ihmc-state-estimation-test:test` over `jointLevel.*` + `invariant_estimator.*`: **179 tests, 1 failure**.

That failure is `FootSwitchContactProbabilityProviderTest > impactBlipIsRejectedAndRealLoadingTrustsOnce` and is **pre-existing** — it fails identically on the clean baseline with this branch's changes stashed. Untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2TQ7qjKmoV5zZFUN4uB3u