### PR TITLE
fixed a bug on resetting the pelvis linear state when frozen

### DIFF
--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/PelvisLinearStateUpdater.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/PelvisLinearStateUpdater.java
@@ -351,6 +351,10 @@ public class PelvisLinearStateUpdater implements SCS2YoGraphicHolder
       // Reset the IMU updater
       imuBasedLinearStateCalculator.initialize();
 
+      // Reset the velocity estimate from the IMU
+      mainIMULinearVelocityEstimate.getPositionEstimation().setToZero();
+      mainIMULinearVelocityEstimate.getRateEstimation().setToZero();
+
       // Set the rootJoint twist to zero.
       rootJoint.getJointTwist().setToZero();
       rootJoint.updateFramesRecursively();

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/PelvisLinearStateUpdater.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/humanoid/kinematicsBasedStateEstimation/PelvisLinearStateUpdater.java
@@ -352,7 +352,6 @@ public class PelvisLinearStateUpdater implements SCS2YoGraphicHolder
       imuBasedLinearStateCalculator.initialize();
 
       // Reset the velocity estimate from the IMU
-      mainIMULinearVelocityEstimate.getPositionEstimation().setToZero();
       mainIMULinearVelocityEstimate.getRateEstimation().setToZero();
 
       // Set the rootJoint twist to zero.


### PR DESCRIPTION
When the robot goes into the frozen state, the IMU velocity is currently not reinitialized. WHen it falls in RL, the velocity is pretty high. The acceleration m easurement isn't integrated when the estimator is frozen, but it's also not zeroed out. This can be seen here: <img width="548" height="483" alt="image" src="https://github.com/user-attachments/assets/1173bce1-2c8a-4635-b477-47f7c5b98a56" />

When the estimator is initialized, these two lines are called to zero out the imu velocity estimate. I'm adding them to the frozen state, so that it also gets zeroed there.