### PR TITLE
Use trove hash maps instead of Integer

### DIFF
--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariantEstimator/InvariantEKFStateEstimator.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/invariantEstimator/InvariantEKFStateEstimator.java
@@ -59,7 +59,17 @@ import us.ihmc.yoVariables.variable.YoInteger;
 public class InvariantEKFStateEstimator implements StateEstimatorController
 {
    private static final int NUMBER_OF_CONTACTS = 2; // left, right feet
-   private static final SideDependentList<Integer> CONTACT_INDICES = new SideDependentList<>(0, 1);
+
+   /**
+    * Contact-array index for a side. {@link RobotSide} declares LEFT then RIGHT, so this IS {@code ordinal()};
+    * it is a named method rather than a bare call so the layout contract shared by {@code contactPositions[]},
+    * {@link #NUMBER_OF_CONTACTS}, {@code InvariantState.contactTangentIndex} and {@code InvariantEKF.update}
+    * has exactly one home. Replaces a {@code SideDependentList<Integer>} that boxed on every per-tick read.
+    */
+   private static int contactIndex(RobotSide side)
+   {
+      return side.ordinal();
+   }
 
    // Filter-consistency check: each contact update is a 3-DOF position measurement, so its NIS is
    // χ²-distributed with 3 DOF. The two-sided CONSISTENCY_CONFIDENCE band gives the acceptance interval
@@ -456,7 +466,7 @@ public class InvariantEKFStateEstimator implements StateEstimatorController
       {
          contactInWorld.setToZero(soleFrames.get(side));
          contactInWorld.changeFrame(ReferenceFrame.getWorldFrame());
-         contactPositions[CONTACT_INDICES.get(side)] = new Point3D(contactInWorld);
+         contactPositions[contactIndex(side)] = new Point3D(contactInWorld);
       }
 
       ekf.initialize(tempRotation, new Vector3D(), basePosition, contactPositions, scaledIdentity(initialCovariance));
@@ -492,7 +502,7 @@ public class InvariantEKFStateEstimator implements StateEstimatorController
       {
          contactInWorld.setToZero(soleFrames.get(side));
          contactInWorld.changeFrame(ReferenceFrame.getWorldFrame());
-         contactPositions[CONTACT_INDICES.get(side)] = new Point3D(contactInWorld);
+         contactPositions[contactIndex(side)] = new Point3D(contactInWorld);
       }
 
       ekf.initialize(tempRotation, new Vector3D(), basePosition, contactPositions, scaledIdentity(initialCovariance));
@@ -512,7 +522,7 @@ public class InvariantEKFStateEstimator implements StateEstimatorController
       {
          double contactProbability = clamp(contactProbabilityProvider.getContactProbability(side));
          yoContactProbability.get(side).set(contactProbability);
-         ekf.setContactSlipVariance(CONTACT_INDICES.get(side), contactSlipVariance(contactProbability));
+         ekf.setContactSlipVariance(contactIndex(side), contactSlipVariance(contactProbability));
       }
 
       // IMU omega and a: bias-corrected in the measurement frame (where the bias is estimated),
@@ -606,7 +616,7 @@ public class InvariantEKFStateEstimator implements StateEstimatorController
          {
             if (reseedLatches.get(side).advance(contactProbability))
             {
-               yoReseedResidual.get(side).set(ekf.reseedContact(CONTACT_INDICES.get(side), contactInBody, inflatedContactCovariance));
+               yoReseedResidual.get(side).set(ekf.reseedContact(contactIndex(side), contactInBody, inflatedContactCovariance));
                yoReseedCount.get(side).increment();
             }
             yoReseedArmed.get(side).set(reseedLatches.get(side).isArmed());
@@ -615,8 +625,8 @@ public class InvariantEKFStateEstimator implements StateEstimatorController
          double inflation = measurementInflation(contactProbability);
          inflatedContactCovariance.scale(inflation);
          yoContactRInflation.get(side).set(inflation);
-         yoContactPContactTrace.get(side).set(covarianceBlockTrace(ekf.getState().contactTangentIndex(CONTACT_INDICES.get(side))));
-         ekf.update(CONTACT_INDICES.get(side), contactInBody, inflatedContactCovariance);
+         yoContactPContactTrace.get(side).set(covarianceBlockTrace(ekf.getState().contactTangentIndex(contactIndex(side))));
+         ekf.update(contactIndex(side), contactInBody, inflatedContactCovariance);
          yoContactNIS.get(side).set(ekf.getLastNormalizedInnovationSquared());
          yoContactCondSProxyLog10.get(side).set(Math.log10(ekf.getLastConditionProxy()));
          yoContactResidualNorm.get(side).set(ekf.getLastResidualNorm());

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointKFPrediction.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointKFPrediction.java
@@ -1,5 +1,7 @@
 package us.ihmc.stateEstimation.jointLevel;
 
+import gnu.trove.list.array.TDoubleArrayList;
+import gnu.trove.list.array.TIntArrayList;
 import org.ejml.data.DMatrixRMaj;
 import org.ejml.dense.row.CommonOps_DDRM;
 import org.ejml.dense.row.factory.LinearSolverFactory_DDRM;
@@ -12,6 +14,7 @@ import us.ihmc.mecano.multiBodySystem.interfaces.MultiBodySystemReadOnly;
 import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
 import us.ihmc.mecano.multiBodySystem.interfaces.RigidBodyBasics;
 import us.ihmc.mecano.tools.MultiBodySystemTools;
+import us.ihmc.sensorProcessing.stateEstimation.IMUSensorReadOnly;
 import us.ihmc.yoVariables.registry.YoRegistry;
 import us.ihmc.yoVariables.variable.YoDouble;
 import us.ihmc.yoVariables.variable.YoInteger;
@@ -119,7 +122,7 @@ final class JointKFPrediction
       // and M_bj are unavailable for the Schur complement.
       if (rootBody != null && n > 0)
       {
-         List<OneDoFJointBasics> massMatrixJoints = new ArrayList<>(state.jointToIndex.keySet());
+         List<OneDoFJointBasics> massMatrixJoints = List.of(state.jointsByIndex); // filter state order, by definition
          // The filtered joints ARE joints of the passed-in robot model; the model root is only used as a
          // sanity check here.
          RigidBodyBasics treeRoot = MultiBodySystemTools.getRootBody(massMatrixJoints.get(0).getPredecessor());
@@ -151,14 +154,15 @@ final class JointKFPrediction
             var indexProvider = massMatrixInput.getJointMatrixIndexProvider();
             // Filtered-joint columns, in filter state order.
             massMatrixColumn = new int[n];
-            for (var e : state.jointToIndex.entrySet())
-               massMatrixColumn[e.getValue()] = indexProvider.getJointDoFIndices(e.getKey())[0];
+            for (int i = 0; i < n; i++)
+               massMatrixColumn[i] = indexProvider.getJointDoFIndices(state.jointsByIndex[i])[0];
             // Nuisance = base 6-DoF columns + each gap joint's column, i.e. every considered DoF that is not a
             // filtered joint. Its parallel rotor diagonal is 0 on the base rows (a free base carries no
             // reflected rotor inertia) so a marginalized gap joint still floors M_NN.
             int[] baseColumns = indexProvider.getJointDoFIndices(baseJoint);
-            List<Integer> nuisanceColumns = new ArrayList<>();
-            List<Double> nuisanceRotor = new ArrayList<>();
+            int nuisanceCapacity = baseColumns.length + spanningJoints.size();
+            TIntArrayList nuisanceColumns = new TIntArrayList(nuisanceCapacity);
+            TDoubleArrayList nuisanceRotor = new TDoubleArrayList(nuisanceCapacity);
             for (int c : baseColumns)
             {
                nuisanceColumns.add(c);
@@ -167,7 +171,7 @@ final class JointKFPrediction
             int gapJoints = 0;
             for (JointReadOnly spanningJoint : spanningJoints)
             {
-               if (!state.jointToIndex.containsKey(spanningJoint)) // unfiltered => gap joint => marginalize it
+               if (!state.isFilteredJoint(spanningJoint)) // unfiltered => gap joint => marginalize it
                {
                   nuisanceColumns.add(indexProvider.getJointDoFIndices(spanningJoint)[0]);
                   // Gap joints take the table value or the conservative default, silently — unlike a filtered
@@ -176,13 +180,8 @@ final class JointKFPrediction
                   gapJoints++;
                }
             }
-            massMatrixNuisanceColumns = new int[nuisanceColumns.size()];
-            nuisanceRotorInertiaDiag = new double[nuisanceColumns.size()];
-            for (int i = 0; i < massMatrixNuisanceColumns.length; i++)
-            {
-               massMatrixNuisanceColumns[i] = nuisanceColumns.get(i);
-               nuisanceRotorInertiaDiag[i] = nuisanceRotor.get(i);
-            }
+            massMatrixNuisanceColumns = nuisanceColumns.toArray(); // exact-size copies; no boxed drain loop
+            nuisanceRotorInertiaDiag = nuisanceRotor.toArray();
             numberOfNuisanceDOF = massMatrixNuisanceColumns.length; // 6 + gap joints
 
             LogTools.info("Joint-level KF process noise: Schur-complement path (sigma_tau = " + parameters.sigmaTau.getValue() + " N*m) over "
@@ -213,10 +212,9 @@ final class JointKFPrediction
       sigmaTauIsFallback = new boolean[n];
       sigmaTauFallback = parameters.sigmaTau.getValue();
 
-      for (var e : state.jointToIndex.entrySet())
+      for (int idx = 0; idx < n; idx++)
       {
-         OneDoFJointBasics joint = e.getKey();
-         int idx = e.getValue();
+         OneDoFJointBasics joint = state.jointsByIndex[idx];
          String jointName = joint.getName();
 
          if (JointKFParameters.isRotorInertiaUnmatched(jointName))
@@ -260,10 +258,9 @@ final class JointKFPrediction
       int n = state.numberOfJoints;
       yoQaDiag = new YoDouble[n];
       yoQaCapBindCount = new YoInteger[n];
-      for (var e : state.jointToIndex.entrySet())
+      for (int idx = 0; idx < n; idx++)
       {
-         int idx = e.getValue();
-         String jointName = e.getKey().getName();
+         String jointName = state.jointsByIndex[idx].getName();
          yoQaDiag[idx] = new YoDouble("jointKF_QaDiag_" + jointName, registry);
          yoQaCapBindCount[idx] = new YoInteger("jointKF_QaCapBind_" + jointName + "_count", registry);
       }
@@ -342,19 +339,20 @@ final class JointKFPrediction
          Q.set(n + i, i, sa2 * dt2 / 2.0);
          Q.set(n + i, n + i, sa2 * dt);
       }
-      for (var e : state.imuToOrdinal.entrySet()) // bias random walk, per-IMU process noise
+      for (int o = 0; o < state.numberOfIMUs; o++) // bias random walk, per-IMU process noise
       {
-         e.getKey().getAngularVelocityBiasProcessNoiseCovariance(Rimu);
+         IMUSensorReadOnly imu = state.imusByOrdinal[o];
+         imu.getAngularVelocityBiasProcessNoiseCovariance(Rimu);
          // Do not let a non-finite covariance (e.g. an IMU still booting at construction) poison Q: a single
          // NaN here spreads to P on the first predict and never recovers. Skip this IMU's bias random-walk
          // instead, and name it so the offender is obvious in the log.
          if (JointLevelKFPreFilter.containsNonFinite(Rimu))
          {
-            LogTools.error("Non-finite angular-velocity bias process-noise covariance from IMU " + e.getKey().getSensorName()
+            LogTools.error("Non-finite angular-velocity bias process-noise covariance from IMU " + imu.getSensorName()
                            + " at construction; skipping its Q contribution (its bias random-walk is disabled) so Q stays finite.");
             continue;
          }
-         int col = 2 * n + 3 * e.getValue();
+         int col = 2 * n + 3 * o;
          for (int i = 0; i < 3; i++)
             for (int j = 0; j < 3; j++)
                Q.set(col + i, col + j, Q.get(col + i, col + j) + dt * Rimu.get(i, j));

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointKFState.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointKFState.java
@@ -1,9 +1,12 @@
 package us.ihmc.stateEstimation.jointLevel;
 
+import gnu.trove.impl.Constants;
+import gnu.trove.map.hash.TObjectIntHashMap;
 import org.ejml.data.DMatrixRMaj;
 import us.ihmc.euclid.tuple3D.interfaces.Vector3DReadOnly;
 import us.ihmc.log.LogTools;
 import us.ihmc.mecano.algorithms.GeometricJacobianCalculator;
+import us.ihmc.mecano.multiBodySystem.interfaces.JointReadOnly;
 import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
 import us.ihmc.mecano.multiBodySystem.interfaces.RigidBodyBasics;
 import us.ihmc.mecano.tools.MultiBodySystemTools;
@@ -16,7 +19,6 @@ import us.ihmc.yoVariables.variable.YoInteger;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.function.ToDoubleFunction;
 
@@ -26,7 +28,11 @@ import java.util.function.ToDoubleFunction;
  * <pre>
  *   x = [ q(0..n-1) ; q̇(n..2n-1) ; b_omega(2n..2n+3m-1) ] ,  dim = 2n + 3m
  * </pre>
- * Joint state index and IMU ordinal are the insertion orders of {@code jointToIndex} / {@code imuToOrdinal};
+ * Joint state index and IMU ordinal are the POSITIONS in {@link #jointsByIndex} / {@link #imusByOrdinal},
+ * assigned in first-encounter order as the IMU-pair chains are resolved. Those two arrays ARE the state order.
+ * {@code jointToIndex} / {@code imuToOrdinal} are the inverse lookup ONLY and are private for one reason: they
+ * are hash maps, so their iteration order is bucket order and has nothing to do with the state layout, and
+ * every iterator they hand out allocates. Loop over joints and IMUs by index, never over a map.
  * IMU {@code o}'s bias occupies columns {@code [2n+3o, 2n+3o+3)}; the stacked gyro measurement lays pair
  * {@code e} on rows {@code [3e, 3e+3)} with the active anchors trailing.
  *
@@ -42,11 +48,26 @@ final class JointKFState
    final SensorOutputMapReadOnly sensorMap;
    final double dt;
 
-   final LinkedHashMap<OneDoFJointBasics, Integer> jointToIndex = new LinkedHashMap<>();
-   //TODO: look at JointIndexHandler and use that here, rather than using unsafe Integer hashmap
-   final LinkedHashMap<IMUSensorReadOnly, Integer> imuToOrdinal = new LinkedHashMap<>();
+   /**
+    * Returned by {@link #jointIndex} / {@link #imuOrdinal} for a key that is NOT part of the filter state.
+    * Trove's DEFAULT no-entry value is 0, which is a valid joint index and a valid IMU ordinal — the -1 passed
+    * to both constructors below is therefore mandatory, not stylistic, and every lookup must test against it.
+    */
+   static final int NOT_IN_STATE = -1;
+
+   /**
+    * Inverse lookup ONLY, and private so nothing can iterate them (see the class javadoc) or write to them
+    * after construction. Deliberately NOT {@code JointIndexHandler}: that stores a
+    * {@code LinkedHashMap<JointReadOnly, int[]>}, so it is neither unboxed nor iteration-free; it hands back
+    * full-multibody DoF column blocks rather than this filter's dense 0..n-1 state indices; and it has no
+    * IMU-ordinal equivalent at all. {@link #jointsByIndex} IS this filter's index handler.
+    */
+   private final TObjectIntHashMap<OneDoFJointBasics> jointToIndex;
+   private final TObjectIntHashMap<IMUSensorReadOnly> imuToOrdinal;
    final List<Pair> pairs = new ArrayList<>();
    final List<FootAnchor> footAnchors = new ArrayList<>();
+   /** state index -> joint. THE definition of state order: x[i] is the position of {@code jointsByIndex[i]}. */
+   OneDoFJointBasics[] jointsByIndex;
    /** ordinal -> IMU, so a per-tick loop over IMUs is an index loop (no map-iterator allocation). */
    IMUSensorReadOnly[] imusByOrdinal;
    IMUSensorReadOnly baseIMU;
@@ -102,6 +123,12 @@ final class JointKFState
       this.dt = estimatorDT;
       this.parameters = parameters;
 
+      // Capacities only; both maps are filled exactly once, in the pass below, and never written again. The IMU
+      // count is bounded exactly at 2 per pair; the joint count is not known until the chains are resolved, so
+      // this is a generous guess whose only cost is one boot-time rehash. NOT_IN_STATE is the no-entry value.
+      jointToIndex = new TObjectIntHashMap<>(64, Constants.DEFAULT_LOAD_FACTOR, NOT_IN_STATE);
+      imuToOrdinal = new TObjectIntHashMap<>(Math.max(1, 2 * pairParameters.size()), Constants.DEFAULT_LOAD_FACTOR, NOT_IN_STATE);
+
       // 1)  Resolve all pairs of IMUs, collect distinct joints and IMUs into the state layout
       for (IMUBasedJointStateEstimatorParameters pp : pairParameters)
       {
@@ -138,6 +165,19 @@ final class JointKFState
       numberOfIMUs = imuToOrdinal.size();
       dim = 2 * numberOfJoints + 3 * numberOfIMUs;
 
+      // index -> key inverses, built ONCE, here, before anything reads them. Built by re-walking `pairs` — the
+      // same source that populated the maps — so not even construction has to iterate a hash map. Writes are
+      // idempotent for a joint that appears on two chains.
+      jointsByIndex = new OneDoFJointBasics[numberOfJoints];
+      imusByOrdinal = new IMUSensorReadOnly[numberOfIMUs];
+      for (Pair p : pairs)
+      {
+         for (OneDoFJointBasics j : p.chainJoints)
+            jointsByIndex[jointToIndex.get(j)] = j;
+         imusByOrdinal[imuToOrdinal.get(p.parent)] = p.parent;
+         imusByOrdinal[imuToOrdinal.get(p.child)] = p.child;
+      }
+
       // Acyclicity assert (Part B item 6): with the exact R_g, a cycle's telescoping row-combination has zero H,
       // zero z and zero noise, so S is singular BY CONSTRUCTION (SPEC §5.3). The used IMU graph MUST be a tree.
       assertAcyclicIMUGraph();
@@ -149,15 +189,24 @@ final class JointKFState
          p.Jang.reshape(3, dof); // Jang is allocated blank at construction in the chain, only reshaped once full DoF are known
          p.qdCols = new int[dof];
          for (int c = 0; c < dof; c++)
-            p.qdCols[c] = numberOfJoints + jointToIndex.get(p.chainJoints[c]); // this int[] is the selector matrix of the path S_ab, but in sparse form as all joints are not related directly
-         p.parentBias = 2 * numberOfJoints + 3 * imuToOrdinal.get(p.parent);
-         p.childBias = 2 * numberOfJoints + 3 * imuToOrdinal.get(p.child);
+         {
+            // Fail loud rather than let a sentinel through: numberOfJoints + (-1) is an IN-RANGE column, so a
+            // missing chain joint would silently alias another joint's q̇ instead of throwing. Unreachable —
+            // the first pass inserted every chain joint of every pair.
+            int idx = jointToIndex.get(p.chainJoints[c]);
+            if (idx == NOT_IN_STATE)
+               throw new IllegalStateException("JointLevelKFPreFilter: chain joint " + p.chainJoints[c].getName() + " of pair "
+                     + p.parent.getSensorName() + "->" + p.child.getSensorName() + " is not a filter state.");
+            p.qdCols[c] = numberOfJoints + idx; // this int[] is the selector matrix of the path S_ab, but in sparse form as all joints are not related directly
+         }
+         p.parentBias = 2 * numberOfJoints + 3 * requireImuOrdinal(p.parent);
+         p.childBias = 2 * numberOfJoints + 3 * requireImuOrdinal(p.child);
       }
 
       // 3) Base IMU = root of the tree + first pair parent.
       //WARNING: Need to configure if the root differs.
       baseIMU = pairs.isEmpty() ? null : pairs.get(0).parent;
-      baseBiasCol = baseIMU == null ? -1 : 2 * numberOfJoints + 3 * imuToOrdinal.get(baseIMU);
+      baseBiasCol = baseIMU == null ? -1 : 2 * numberOfJoints + 3 * requireImuOrdinal(baseIMU);
       if (baseIMU == null)
          throw new RuntimeException("Base IMU is null, check the kinematic tree.");
       LogTools.info("Base IMU initialized as " + baseIMU.getSensorName());
@@ -189,8 +238,8 @@ final class JointKFState
             int unfiltered = 0;
             for (int c = 0; c < fa.legJoints.length; c++)
             {
-               Integer idx = jointToIndex.get(fa.legJoints[c]);
-               if (idx == null)
+               int idx = jointToIndex.get(fa.legJoints[c]);
+               if (idx == NOT_IN_STATE)
                {
                   fa.qdCols[c] = -1; // unfiltered: contributes J_U * qd^meas to z', no H column
                   unfiltered++;
@@ -228,9 +277,6 @@ final class JointKFState
 
       x.reshape(dim, 1);
       P.reshape(dim, dim);
-      imusByOrdinal = new IMUSensorReadOnly[numberOfIMUs];
-      for (var e : imuToOrdinal.entrySet()) // construction-time only; the hot path indexes this array
-         imusByOrdinal[e.getValue()] = e.getKey();
 
       yoStateDimension = new YoInteger("jointKFStateDimension", registry);
       yoNumberOfFilteredJoints = new YoInteger("jointKFNumberOfFilteredJoints", registry);
@@ -239,6 +285,36 @@ final class JointKFState
       yoNumberOfFilteredJoints.set(numberOfJoints);
       yoNumberOfIMUs.set(numberOfIMUs);
       createJointYoVariables(registry);
+   }
+
+   /** Filter state index of {@code joint}'s position entry (its velocity entry is this + n), or {@link #NOT_IN_STATE}. */
+   int jointIndex(OneDoFJointBasics joint)
+   {
+      return jointToIndex.get(joint);
+   }
+
+   /** Whether {@code joint} is an estimated filter state. Takes the supertype for the spanning-joint walk. */
+   boolean isFilteredJoint(JointReadOnly joint)
+   {
+      return jointToIndex.containsKey(joint);
+   }
+
+   /** Bias-block ordinal of {@code imu}, or {@link #NOT_IN_STATE}. */
+   int imuOrdinal(IMUSensorReadOnly imu)
+   {
+      return imuToOrdinal.get(imu);
+   }
+
+   /**
+    * Ordinal of an IMU that MUST be in the state. Fails loud rather than returning a -1 that would index three
+    * columns backwards out of the bias block and into the q̇ block — an in-range, silently wrong answer.
+    */
+   int requireImuOrdinal(IMUSensorReadOnly imu)
+   {
+      int ordinal = imuToOrdinal.get(imu);
+      if (ordinal == NOT_IN_STATE)
+         throw new IllegalArgumentException("JointLevelKFPreFilter: IMU '" + imu.getSensorName() + "' is not part of the filter state.");
+      return ordinal;
    }
 
    /** One set per filtered joint, indexed by state index so the per-tick update is a straight array write. */
@@ -250,10 +326,9 @@ final class JointKFState
       yoJointPositionLowerBound = new YoDouble[numberOfJoints];
       yoJointVelocityUpperBound = new YoDouble[numberOfJoints];
       yoJointVelocityLowerBound = new YoDouble[numberOfJoints];
-      for (var e : jointToIndex.entrySet())
+      for (int idx = 0; idx < numberOfJoints; idx++)
       {
-         int idx = e.getValue();
-         String jointName = e.getKey().getName();
+         String jointName = jointsByIndex[idx].getName();
          yoJointPosition[idx] = new YoDouble("jointKF_q_" + jointName, registry);
          yoJointVelocity[idx] = new YoDouble("jointKF_qd_" + jointName, registry);
          yoJointPositionUpperBound[idx] = new YoDouble("jointKF_q_" + jointName + "_upperBound", registry);
@@ -270,17 +345,20 @@ final class JointKFState
     */
    boolean seed()
    {
-      for (var e : jointToIndex.entrySet())
+      // Index loops, not map iteration: seed() runs EVERY tick until the encoders come good, so an entry-set
+      // iterator here allocates on the estimator thread for the whole boot window. The allocation test never
+      // sees it because it calls initialize() before it starts measuring.
+      for (int i = 0; i < numberOfJoints; i++)
       {
-         if (!Double.isFinite(sensorMap.getOneDoFJointOutput(e.getKey()).getPosition()))
+         if (!Double.isFinite(sensorMap.getOneDoFJointOutput(jointsByIndex[i]).getPosition()))
          {
-            warnNonFiniteInputOnce("joint position of " + e.getKey().getName() + " at initialization");
+            warnNonFiniteInputOnce("joint position of " + jointsByIndex[i].getName() + " at initialization");
             return false;
          }
       }
       x.zero();
-      for (var e : jointToIndex.entrySet())
-         x.set(e.getValue(), sensorMap.getOneDoFJointOutput(e.getKey()).getPosition());
+      for (int i = 0; i < numberOfJoints; i++)
+         x.set(i, sensorMap.getOneDoFJointOutput(jointsByIndex[i]).getPosition());
       P.zero();
       for (int i = 0; i < numberOfJoints; i++) P.set(i, i, parameters.initPosVar.getValue());
       for (int i = numberOfJoints; i < 2 * numberOfJoints; i++) P.set(i, i, parameters.initVelVar.getValue());
@@ -367,10 +445,7 @@ final class JointKFState
    /** Reverse of {@code jointToIndex} for the diagnostic paths: filter-joint name at a given state index. */
    String jointNameByStateIndex(int stateIndex)
    {
-      for (var e : jointToIndex.entrySet())
-         if (e.getValue() == stateIndex)
-            return e.getKey().getName();
-      return "?idx" + stateIndex;
+      return (stateIndex >= 0 && stateIndex < numberOfJoints) ? jointsByIndex[stateIndex].getName() : "?idx" + stateIndex;
    }
 
    static String jointNamesOf(OneDoFJointBasics[] joints)
@@ -397,8 +472,8 @@ final class JointKFState
          parent[i] = i;
       for (Pair p : pairs)
       {
-         int a = find(parent, imuToOrdinal.get(p.parent));
-         int b = find(parent, imuToOrdinal.get(p.child));
+         int a = find(parent, requireImuOrdinal(p.parent));
+         int b = find(parent, requireImuOrdinal(p.child));
          if (a == b)
             throw new IllegalStateException("JointLevelKFPreFilter: the used IMU graph has a CYCLE — the pair "
                   + p.parent.getSensorName() + "->" + p.child.getSensorName() + " closes a loop. With the exact R_g a "

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointKFUpdate.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointKFUpdate.java
@@ -167,14 +167,14 @@ final class JointKFUpdate
       encVarPerJoint = new double[n];
       double encoderVarFallback = parameters.encoderVar.getValue();
       int unwiredEncoderJoints = 0;
-      for (var e : state.jointToIndex.entrySet())
+      for (int idx = 0; idx < n; idx++)
       {
-         double std = encoderPositionNoiseStd == null ? Double.NaN : encoderPositionNoiseStd.applyAsDouble(e.getKey().getName());
+         double std = encoderPositionNoiseStd == null ? Double.NaN : encoderPositionNoiseStd.applyAsDouble(state.jointsByIndex[idx].getName());
          if (Double.isFinite(std) && std > 0.0)
-            encVarPerJoint[e.getValue()] = std * std;
+            encVarPerJoint[idx] = std * std;
          else
          {
-            encVarPerJoint[e.getValue()] = encoderVarFallback;
+            encVarPerJoint[idx] = encoderVarFallback;
             unwiredEncoderJoints++;
          }
       }
@@ -194,10 +194,9 @@ final class JointKFUpdate
       qdSlewSmoothed = new double[n];
       double sigmaQdUnfiltered = parameters.sigmaQdUnfiltered.getValue();
       double qdVarFallback = sigmaQdUnfiltered * sigmaQdUnfiltered;
-      for (var e : state.jointToIndex.entrySet())
+      for (int idx = 0; idx < n; idx++)
       {
-         int idx = e.getValue();
-         String name = e.getKey().getName();
+         String name = state.jointsByIndex[idx].getName();
          double std = encoderVelocityNoiseStd == null ? Double.NaN : encoderVelocityNoiseStd.applyAsDouble(name);
          qdMeasVarPerJoint[idx] = (Double.isFinite(std) && std > 0.0) ? std * std : qdVarFallback;
          double fc = jointVelocityMeasurementBreakFrequencyHz == null ? Double.NaN : jointVelocityMeasurementBreakFrequencyHz.applyAsDouble(name);
@@ -295,10 +294,9 @@ final class JointKFUpdate
       yoQdInnov = new YoDouble[n];
       yoUseDirectVelocity = new YoBoolean("jointKFUseDirectVelocityMeasurement", registry);
       yoUseDirectVelocity.set(useDirectVelocityMeasurement);
-      for (var e : state.jointToIndex.entrySet())
+      for (int idx = 0; idx < n; idx++)
       {
-         int idx = e.getValue();
-         String jointName = e.getKey().getName();
+         String jointName = state.jointsByIndex[idx].getName();
          yoEncNIS[idx] = new YoDouble("jointKF_encNIS_" + jointName, registry);
          yoEncNIS[idx].set(Double.NaN); // no encoder update has run yet
          yoEncInnov[idx] = new YoDouble("jointKF_encInnov_" + jointName, registry);

--- a/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFPreFilter.java
+++ b/ihmc-state-estimation/src/main/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFPreFilter.java
@@ -289,14 +289,16 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
       prediction.predict();
       state.warnIfNonFiniteState("predict", -1);
 
-      // Encoder update; skipped wholesale if any encoder reads non-finite (boot transient). The z fills stay
-      // INLINE rather than moving behind a component call: their keySet() iterators only fit the allocation
-      // test's 32 B/tick budget because C2 scalar-replaces them, which depends on the allocation, the loop and
-      // the consumer inlining into one compilation unit.
-      int row = 0;
+      // Encoder update; skipped wholesale if any encoder reads non-finite (boot transient).
+      // z_enc row i IS state index i: Henc = I_n and Renc's diagonal are BOTH keyed by state index, so the row
+      // an encoder lands on must be that joint's state index and nothing else. Indexing jointsByIndex makes
+      // that identity structural — there is no iteration order left to get wrong. It also allocates nothing
+      // under any compilation state, where the old keySet() loop only fit the 32 B/tick budget as long as C2
+      // scalar-replaced the iterator. Keep the fills INLINE.
       boolean encodersValid = true;
-      for (OneDoFJointBasics j : state.jointToIndex.keySet())
+      for (int i = 0; i < state.numberOfJoints; i++)
       {
+         OneDoFJointBasics j = state.jointsByIndex[i];
          double q = state.sensorMap.getOneDoFJointOutput(j).getPosition();
          if (!Double.isFinite(q))
          {
@@ -304,7 +306,7 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
             if (!state.warnedNonFiniteInput)
                state.warnNonFiniteInputOnce("joint position of " + j.getName());
          }
-         update.zEnc.set(row++, 0, q);
+         update.zEnc.set(i, 0, q);
       }
       if (encodersValid)
       {
@@ -316,10 +318,12 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
       // adaptive lag inflation on R. Skipped wholesale on any non-finite velocity, like the encoder block.
       if (update.isDirectVelocityEnabled())
       {
-         int qdRow = 0;
+         // Same identity as the encoder block above: z_qd row i is state index i, against Hqd = [0 | I_n | 0]
+         // and an Rqd diagonal keyed by state index. prevZqd[] and qdSlewSmoothed[] are state-index-keyed too.
          boolean velocitiesValid = true;
-         for (OneDoFJointBasics j : state.jointToIndex.keySet())
+         for (int i = 0; i < state.numberOfJoints; i++)
          {
+            OneDoFJointBasics j = state.jointsByIndex[i];
             double qd = state.sensorMap.getOneDoFJointOutput(j).getVelocity();
             if (!Double.isFinite(qd))
             {
@@ -327,7 +331,7 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
                if (!state.warnedNonFiniteInput)
                   state.warnNonFiniteInputOnce("joint velocity of " + j.getName());
             }
-            update.zqd.set(qdRow++, 0, qd);
+            update.zqd.set(i, 0, qd);
          }
          if (velocitiesValid)
          {
@@ -399,21 +403,21 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
    @Override
    public boolean containsJoint(OneDoFJointBasics joint)
    {
-      return state.jointToIndex.containsKey(joint);
+      return state.isFilteredJoint(joint);
    }
 
    @Override
    public double getEstimatedJointPosition(OneDoFJointBasics joint)
    {
-      Integer idx = state.jointToIndex.get(joint);
-      return (idx == null || !state.initialized) ? Double.NaN : state.x.get(idx);
+      int idx = state.jointIndex(joint);
+      return (idx == JointKFState.NOT_IN_STATE || !state.initialized) ? Double.NaN : state.x.get(idx);
    }
 
    @Override
    public double getEstimatedJointVelocity(OneDoFJointBasics joint)
    {
-      Integer idx = state.jointToIndex.get(joint);
-      return (idx == null || !state.initialized) ? Double.NaN : state.x.get(state.numberOfJoints + idx);
+      int idx = state.jointIndex(joint);
+      return (idx == JointKFState.NOT_IN_STATE || !state.initialized) ? Double.NaN : state.x.get(state.numberOfJoints + idx);
    }
 
    @Override
@@ -441,16 +445,16 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
       toPack.zero();
       for (int a = 0; a < mm; a++)
       {
-         Integer ia = state.jointToIndex.get(joints[a]);
-         if (ia == null)
+         int ia = state.jointIndex(joints[a]);
+         if (ia == JointKFState.NOT_IN_STATE)
          {
             toPack.set(a, a, fallbackVariance);
             continue;
          }
          for (int b = 0; b < mm; b++)
          {
-            Integer ib = state.jointToIndex.get(joints[b]);
-            if (ib != null)
+            int ib = state.jointIndex(joints[b]);
+            if (ib != JointKFState.NOT_IN_STATE)
                toPack.set(a, b, state.P.get(blockOffset + ia, blockOffset + ib)); // adding the off diagonals for the cross-covariances
          }
       }
@@ -459,12 +463,15 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
    @Override
    public FrameVector3DReadOnly getAngularVelocityBiasInIMUFrame(IMUSensorReadOnly imu)
    {
-      Integer ord = state.imuToOrdinal.get(imu);
-      if (ord == null || !state.initialized)
+      int ord = state.imuOrdinal(imu);
+      if (ord == JointKFState.NOT_IN_STATE || !state.initialized)
       {
-         // IMU not in the filter's state (e.g. the primary pelvis IMU when it isn't a pair member),
-         // or the filter hasn't initialized yet: report zero bias. MUST return here — falling through
-         // would unbox a null ord in "3 * ord" and NPE every tick on the estimator thread.
+         // IMU not in the filter's state (e.g. the primary pelvis IMU when it isn't a pair member), or the
+         // filter hasn't initialized yet: report zero bias. MUST return here, and the reason is now STRONGER
+         // than it was: this used to guard an NPE on unboxing a null ord in "3 * ord". With the -1 sentinel
+         // the fall-through is worse than a crash — 2n + 3*(-1) = 2n-3 is a VALID index into x, so it would
+         // silently export three JOINT VELOCITIES as this IMU's gyro bias, straight into the InEKF's predict.
+         // No exception, no NaN, just a wrong robot.
          biasOut.setToZero(imu.getMeasurementFrame());
          return biasOut;
       }
@@ -518,8 +525,14 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
    int getNumberOfPairs()           { return state.pairs.size(); }
 
    /** State index of the given joint's position entry (its velocity entry is this + n); -1 if not filtered. */
-   int getJointStateIndex(OneDoFJointBasics joint) { Integer i = state.jointToIndex.get(joint); return i == null ? -1 : i; }
-   List<OneDoFJointBasics> getFilteredJointsInStateOrder() { return new ArrayList<>(state.jointToIndex.keySet()); }
+   int getJointStateIndex(OneDoFJointBasics joint) { return state.jointIndex(joint); }
+   /** Immutable snapshot: jointsByIndex IS the filter's state order and must not escape as a mutable array. */
+   List<OneDoFJointBasics> getFilteredJointsInStateOrder() { return List.of(state.jointsByIndex); }
+
+   /** This tick's encoder measurement vector; row i must be the joint at state index i. */
+   DMatrixRMaj getEncoderMeasurementForTest()        { return update.zEnc.copy(); }
+   /** This tick's direct-velocity measurement vector; row i must be the joint at state index i. */
+   DMatrixRMaj getDirectVelocityMeasurementForTest() { return update.zqd.copy(); }
 
    DMatrixRMaj getStateVector()      { return state.x.copy(); }     // x = [q ; q_dot ; b_omega]
    DMatrixRMaj getCovariance()       { return state.P.copy(); }
@@ -565,8 +578,10 @@ public class JointLevelKFPreFilter implements ProprioceptivePreFilter
    DMatrixRMaj getStackedMeasurementNoise()    { return biasUpdate.Rg.copy(); }  // R_g (3(E+K) x 3(E+K))
    DMatrixRMaj getMixingOperator()             { return biasUpdate.Lmix.copy(); } // L (3(E+K) x 3m); H_g bias columns == this
    int getStackedRowForPair(int pairIndex)     { return 3 * pairIndex; }      // pair e occupies rows [3e, 3e+3)
-   int getBiasBlockColumn(IMUSensorReadOnly imu) { return 2 * state.numberOfJoints + 3 * state.imuToOrdinal.get(imu); } // state col of imu's bias
-   int getImuOrdinal(IMUSensorReadOnly imu)    { return state.imuToOrdinal.get(imu); }
+   int getBiasBlockColumn(IMUSensorReadOnly imu) { return 2 * state.numberOfJoints + 3 * state.requireImuOrdinal(imu); } // state col of imu's bias
+   int getImuOrdinal(IMUSensorReadOnly imu)    { return state.requireImuOrdinal(imu); }
+   /** The ORDINAL-INDEXED array side, so a test can check it against the map the way it does for joints. */
+   IMUSensorReadOnly getImuByOrdinal(int ordinal) { return state.imusByOrdinal[ordinal]; }
    IMUSensorReadOnly getBaseIMU()              { return state.baseIMU; }
    /** Anchors active on the last {@link #buildStackedMeasurementForTest}. 0 => the base-bias gauge is unfixed. */
    int getActiveAnchorCountForTest()           { return biasUpdate.getActiveAnchorCount(); }

--- a/ihmc-state-estimation/src/test/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFStateOrderPropertyTest.java
+++ b/ihmc-state-estimation/src/test/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFStateOrderPropertyTest.java
@@ -1,0 +1,266 @@
+package us.ihmc.stateEstimation.jointLevel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.ejml.data.DMatrixRMaj;
+import org.junit.jupiter.api.Test;
+
+import us.ihmc.mecano.multiBodySystem.interfaces.OneDoFJointBasics;
+import us.ihmc.yoVariables.variable.YoDouble;
+
+/**
+ * Pins the indexing algebra that ties {@code JointKFState}'s Trove inverse maps to the {@code jointsByIndex} /
+ * {@code imusByOrdinal} arrays that define the state order.
+ *
+ * <p>Before the Trove conversion the joint index was carried by a {@code LinkedHashMap} whose iteration order
+ * happened to equal its own values, because the only writer was {@code putIfAbsent(j, map.size())}. Several
+ * consumers silently leaned on that coincidence — most dangerously the encoder and direct-velocity measurement
+ * fills, which laid row {@code r} by iteration counter while {@code H = I} and {@code R}'s diagonal were keyed
+ * by state index. A permutation there routes every joint's measurement into another joint's state with no
+ * residual blow-up and NIS still ~1: the filter fuses garbage quietly. Nothing in the suite caught it.</p>
+ *
+ * <p><b>Design rule for this file:</b> every assertion compares a quantity derived from the Trove <i>map</i>
+ * against one derived from the <i>array</i>. Comparing two array-derived quantities is tautological now that
+ * both sides share a source, and would pass no matter how badly the map disagreed. Note in particular that
+ * {@code JointLevelKFEncoderNISConsistencyTest} and {@code JointLevelKFDirectVelocityMeasurementTest} DID
+ * detect a permutation before the conversion (one side came from {@code keySet()}, the other from
+ * {@code e.getValue()}) and are structurally self-consistent afterwards — which is precisely why these exist.</p>
+ *
+ * @author Lucas Libshutz
+ */
+public class JointLevelKFStateOrderPropertyTest
+{
+   /**
+    * The load-bearing invariant: the published state order and the map that resolves a joint to its state index
+    * are exact inverses of each other. Everything else in this file is a specialization of this.
+    */
+   @Test
+   public void stateIndexIsTheExactInverseOfTheStateOrderList()
+   {
+      List<JointLevelKFTestFixture> fixtures = new ArrayList<>(JointLevelKFTestFixture.shapes(9100L));
+      fixtures.add(JointLevelKFTestFixture.twoPairs(9200L, 10, 1, 5, 9));
+      fixtures.add(JointLevelKFTestFixture.singlePairFootBeyondIMUs(9300L, 10, 1, 7, 9));
+
+      for (JointLevelKFTestFixture f : fixtures)
+      {
+         List<OneDoFJointBasics> stateOrder = f.filter.getFilteredJointsInStateOrder();
+         assertEquals(f.n, stateOrder.size(), f.describe() + " state-order list length must equal n");
+
+         for (int i = 0; i < f.n; i++)
+            assertEquals(i,
+                         f.filter.getJointStateIndex(stateOrder.get(i)),
+                         f.describe() + " joint at state-order position " + i + " must report state index " + i);
+
+         // Bijection: no joint may occupy two slots, which a map/array disagreement could otherwise hide.
+         for (int i = 0; i < f.n; i++)
+            for (int j = i + 1; j < f.n; j++)
+               assertNotEquals(stateOrder.get(i),
+                               stateOrder.get(j),
+                               f.describe() + " joint repeated at state-order positions " + i + " and " + j);
+      }
+   }
+
+   /**
+    * The Trove-specific regression test. {@code TObjectIntHashMap}'s DEFAULT no-entry value is 0, which is a
+    * perfectly valid joint state index — so a map built without the explicit -1 sentinel reports "state index
+    * 0" for a joint that is not in the filter at all. This fails the day someone drops that constructor
+    * argument, and it is the reason {@code JointKFState.NOT_IN_STATE} exists.
+    */
+   @Test
+   public void unfilteredJointReportsNotInStateNotZero()
+   {
+      // The foot joint sits beyond both IMUs, so it is an anchor chain joint that is NOT a filter state.
+      JointLevelKFTestFixture f = JointLevelKFTestFixture.singlePairFootBeyondIMUs(9400L, 10, 1, 7, 9);
+      List<OneDoFJointBasics> stateOrder = f.filter.getFilteredJointsInStateOrder();
+
+      int unfilteredSeen = 0;
+      for (OneDoFJointBasics joint : f.joints)
+      {
+         if (stateOrder.contains(joint))
+            continue;
+         unfilteredSeen++;
+         assertEquals(JointKFState.NOT_IN_STATE,
+                      f.filter.getJointStateIndex(joint),
+                      f.describe() + " unfiltered joint " + joint.getName() + " must report NOT_IN_STATE, not a valid index");
+         assertFalse(f.filter.containsJoint(joint), f.describe() + " unfiltered joint " + joint.getName() + " must not be reported as filtered");
+      }
+      assertTrue(unfilteredSeen > 0, f.describe() + " fixture was supposed to leave at least one joint out of the filter state");
+   }
+
+   /**
+    * Encoder measurement row {@code i} must be the joint at state index {@code i}. Henc is the identity and
+    * Renc's diagonal is keyed by state index, so any disagreement here fuses each encoder into the wrong joint.
+    */
+   @Test
+   public void encoderMeasurementRowMatchesStateIndex()
+   {
+      for (JointLevelKFTestFixture f : JointLevelKFTestFixture.shapes(9500L))
+      {
+         // The encoder value is keyed to the JOINT, and the row it is expected on is resolved through the Trove
+         // map — never by position in the state-order list. Reading both from the list would make this
+         // tautological: the list and the fill loop share jointsByIndex, so they permute together.
+         List<OneDoFJointBasics> filtered = f.filter.getFilteredJointsInStateOrder();
+         for (OneDoFJointBasics joint : filtered)
+            f.setEncoder(joint, encoderValueFor(joint));
+
+         f.filter.initialize();
+         f.filter.computeJointState();
+
+         DMatrixRMaj zEnc = f.filter.getEncoderMeasurementForTest();
+         for (OneDoFJointBasics joint : filtered)
+         {
+            int idx = f.filter.getJointStateIndex(joint);
+            assertEquals(encoderValueFor(joint),
+                         zEnc.get(idx, 0),
+                         0.0,
+                         f.describe() + " z_enc row " + idx + " must carry the encoder of " + joint.getName());
+         }
+      }
+   }
+
+   /** Same identity for the direct-velocity channel: z_qd row i is the joint at state index i. */
+   @Test
+   public void directVelocityMeasurementRowMatchesStateIndex()
+   {
+      JointLevelKFTestFixture f = JointLevelKFTestFixture.singlePairWithDirectVelocity(9600L,
+                                                                                       10,
+                                                                                       1,
+                                                                                       9,
+                                                                                       name -> 1.0e-3,
+                                                                                       name -> 1.0e-2,
+                                                                                       name -> 20.0);
+      List<OneDoFJointBasics> filtered = f.filter.getFilteredJointsInStateOrder();
+      for (OneDoFJointBasics joint : filtered)
+         f.setMeasuredVelocity(joint, velocityValueFor(joint));
+
+      f.filter.initialize();
+      f.filter.computeJointState();
+
+      DMatrixRMaj zqd = f.filter.getDirectVelocityMeasurementForTest();
+      for (OneDoFJointBasics joint : filtered)
+      {
+         int idx = f.filter.getJointStateIndex(joint); // map-derived row, not list position
+         assertEquals(velocityValueFor(joint),
+                      zqd.get(idx, 0),
+                      0.0,
+                      f.describe() + " z_qd row " + idx + " must carry the measured velocity of " + joint.getName());
+      }
+   }
+
+   /**
+    * The per-joint YoVariables are created in one loop and written in another. If those two disagree, SCS shows
+    * every joint's estimate under a neighbour's name — invisible to any test that only checks matrices.
+    */
+   @Test
+   public void publishedPerJointYoVariablesFollowStateIndex()
+   {
+      for (JointLevelKFTestFixture f : JointLevelKFTestFixture.shapes(9700L))
+      {
+         List<OneDoFJointBasics> filtered = f.filter.getFilteredJointsInStateOrder();
+         for (OneDoFJointBasics joint : filtered)
+            f.setEncoder(joint, encoderValueFor(joint));
+
+         f.filter.initialize();
+         f.filter.computeJointState();
+
+         DMatrixRMaj x = f.filter.getStateVector();
+         for (OneDoFJointBasics joint : filtered)
+         {
+            String jointName = joint.getName();
+            int idx = f.filter.getJointStateIndex(joint); // map-derived, so a permuted array is detectable
+            YoDouble q = (YoDouble) f.registry.findVariable("jointKF_q_" + jointName);
+            YoDouble qd = (YoDouble) f.registry.findVariable("jointKF_qd_" + jointName);
+            assertTrue(q != null && qd != null, f.describe() + " missing published YoVariables for " + jointName);
+            assertEquals(x.get(idx), q.getValue(), 0.0, f.describe() + " jointKF_q_" + jointName + " must publish x[" + idx + "]");
+            assertEquals(x.get(f.n + idx),
+                         qd.getValue(),
+                         0.0,
+                         f.describe() + " jointKF_qd_" + jointName + " must publish x[" + (f.n + idx) + "]");
+         }
+      }
+   }
+
+   /**
+    * Encoder variance is resolved by joint NAME into an array indexed by STATE index. A permutation between
+    * those two gives every joint its neighbour's measurement noise — a silent mis-weighting, not a crash.
+    */
+   @Test
+   public void perJointEncoderNoiseFollowsStateIndex()
+   {
+      JointLevelKFTestFixture f = JointLevelKFTestFixture.singlePairWithEncoderNoise(9800L, 10, 1, 9, JointLevelKFStateOrderPropertyTest::uniqueSigmaForName);
+      List<OneDoFJointBasics> filtered = f.filter.getFilteredJointsInStateOrder();
+      f.filter.initialize();
+
+      DMatrixRMaj rEnc = f.filter.getEncoderNoise();
+      for (OneDoFJointBasics joint : filtered)
+      {
+         int idx = f.filter.getJointStateIndex(joint); // map-derived row against name-derived variance
+         double sigma = uniqueSigmaForName(joint.getName());
+         assertEquals(sigma * sigma,
+                      rEnc.get(idx, idx),
+                      1.0e-18,
+                      f.describe() + " Renc(" + idx + "," + idx + ") must be the wired variance of " + joint.getName());
+      }
+   }
+
+   /**
+    * IMU-side analogue of {@link #stateIndexIsTheExactInverseOfTheStateOrderList}: ordinals form a bijection
+    * onto [0, m) and the bias block column is exactly 2n + 3o. A wrong ordinal here aims the gyro-bias export
+    * at the wrong three columns, which under the -1 sentinel can land inside the q̇ block and stay in range.
+    */
+   @Test
+   public void imuOrdinalIsTheInverseOfTheBiasBlockLayout()
+   {
+      List<JointLevelKFTestFixture> fixtures = new ArrayList<>(JointLevelKFTestFixture.shapes(9900L));
+      fixtures.add(JointLevelKFTestFixture.twoPairs(9950L, 10, 1, 5, 9));
+
+      for (JointLevelKFTestFixture f : fixtures)
+      {
+         boolean[] ordinalSeen = new boolean[f.m];
+         for (JointLevelKFTestFixture.TestIMU imu : f.imus)
+         {
+            int ordinal = f.filter.getImuOrdinal(imu); // map-derived
+            assertTrue(ordinal >= 0 && ordinal < f.m, f.describe() + " ordinal of " + imu.getSensorName() + " out of range: " + ordinal);
+            assertFalse(ordinalSeen[ordinal], f.describe() + " ordinal " + ordinal + " assigned to two IMUs");
+            ordinalSeen[ordinal] = true;
+
+            // The inverse leg: the ORDINAL-INDEXED array must hand back the same IMU the map sent us to.
+            // Without this the assertions here would be map-against-map and blind to a permuted array.
+            assertEquals(imu,
+                         f.filter.getImuByOrdinal(ordinal),
+                         f.describe() + " imusByOrdinal[" + ordinal + "] must be " + imu.getSensorName());
+
+            assertEquals(2 * f.n + 3 * ordinal,
+                         f.filter.getBiasBlockColumn(imu),
+                         f.describe() + " bias block column of " + imu.getSensorName() + " must be 2n + 3*ordinal");
+         }
+         for (int o = 0; o < f.m; o++)
+            assertTrue(ordinalSeen[o], f.describe() + " no IMU claimed ordinal " + o);
+      }
+   }
+
+   // Per-JOINT values, keyed by identity rather than by state position. That is what lets the assertions above
+   // resolve the expected row through the Trove map and still know what value belongs there.
+
+   private static double encoderValueFor(OneDoFJointBasics joint)
+   {
+      return 1.0 + 0.37 * (1 + Math.floorMod(joint.getName().hashCode(), 89));
+   }
+
+   private static double velocityValueFor(OneDoFJointBasics joint)
+   {
+      return -2.0 - 0.11 * (1 + Math.floorMod(joint.getName().hashCode(), 83));
+   }
+
+   /** Distinct, deterministic per-joint encoder sigma so a permuted wiring cannot coincidentally match. */
+   private static double uniqueSigmaForName(String jointName)
+   {
+      return 1.0e-4 * (1 + Math.floorMod(jointName.hashCode(), 97));
+   }
+}

--- a/ihmc-state-estimation/src/test/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFTestFixture.java
+++ b/ihmc-state-estimation/src/test/java/us/ihmc/stateEstimation/jointLevel/JointLevelKFTestFixture.java
@@ -351,6 +351,12 @@ final class JointLevelKFTestFixture
       sensorMap.setPosition(joint, q);
    }
 
+   /** Firmware-reported joint velocity, i.e. the direct-velocity channel's raw measurement. */
+   void setMeasuredVelocity(OneDoFJointBasics joint, double qd)
+   {
+      sensorMap.setVelocity(joint, qd);
+   }
+
    /**
     * Applies one tick of a self-consistent simulated motion: sets each filtered joint's true {@code q}/{@code q̇}
     * on the live mecano chain and its encoder to the true {@code q}, refreshes the frames, then sets every IMU's
@@ -624,6 +630,11 @@ final class JointLevelKFTestFixture
       void setPosition(OneDoFJointBasics joint, double q)
       {
          states.get(joint).position = q;
+      }
+
+      void setVelocity(OneDoFJointBasics joint, double qd)
+      {
+         states.get(joint).velocity = qd;
       }
 
       @Override


### PR DESCRIPTION
This pull request refactors the state and index management in the joint-level Kalman filter code, replacing boxed and allocation-heavy data structures with more efficient, array-based and primitive collections. It also clarifies the contract for state ordering and index lookup, ensuring that iteration and lookup are allocation-free and consistent with the filter's state layout. These changes improve performance, reduce memory allocations, and make the code easier to reason about and maintain.

**State and Index Management Improvements:**

* Replaced `SideDependentList<Integer>` with a static `contactIndex(RobotSide side)` method in `InvariantEKFStateEstimator`, eliminating per-tick boxing and clarifying the contract for contact array indices. [[1]](diffhunk://#diff-65f7ccb97cf77448272f7c6907223b8af2d18d2c9cc79590a969bdd37d2128a4L62-R72) [[2]](diffhunk://#diff-65f7ccb97cf77448272f7c6907223b8af2d18d2c9cc79590a969bdd37d2128a4L459-R469) [[3]](diffhunk://#diff-65f7ccb97cf77448272f7c6907223b8af2d18d2c9cc79590a969bdd37d2128a4L495-R505) [[4]](diffhunk://#diff-65f7ccb97cf77448272f7c6907223b8af2d18d2c9cc79590a969bdd37d2128a4L515-R525) [[5]](diffhunk://#diff-65f7ccb97cf77448272f7c6907223b8af2d18d2c9cc79590a969bdd37d2128a4L609-R619) [[6]](diffhunk://#diff-65f7ccb97cf77448272f7c6907223b8af2d18d2c9cc79590a969bdd37d2128a4L618-R629)
* Replaced `LinkedHashMap` state index maps in `JointKFState` with Trove's primitive `TObjectIntHashMap`, and made these maps private to prevent accidental allocation-heavy iteration. Added explicit `NOT_IN_STATE` sentinel value for robust lookup. [[1]](diffhunk://#diff-a69b9b4ab9837420039c58a2d663033a974cc76ff9a5de66989918f1720de358L45-R70) [[2]](diffhunk://#diff-a69b9b4ab9837420039c58a2d663033a974cc76ff9a5de66989918f1720de358R126-R131)
* Added `jointsByIndex` and `imusByOrdinal` arrays to `JointKFState` as the authoritative state order, and updated all relevant code to iterate and access state by index rather than by map entry. [[1]](diffhunk://#diff-a69b9b4ab9837420039c58a2d663033a974cc76ff9a5de66989918f1720de358L29-R35) [[2]](diffhunk://#diff-a69b9b4ab9837420039c58a2d663033a974cc76ff9a5de66989918f1720de358R168-R180)

**Performance and Allocation Optimizations:**

* Switched from boxed `ArrayList` to Trove's `TIntArrayList` and `TDoubleArrayList` for nuisance columns and rotor inertia in `JointKFPrediction`, eliminating unnecessary boxing and allocation. [[1]](diffhunk://#diff-8129eef35135ad3fe896b38557e8ba673da32528eea344c660b26c5e0e9424d7L154-R165) [[2]](diffhunk://#diff-8129eef35135ad3fe896b38557e8ba673da32528eea344c660b26c5e0e9424d7L179-R184)
* Updated loops and access patterns throughout `JointKFPrediction` and `JointKFState` to use array indices, ensuring allocation-free iteration and lookup. [[1]](diffhunk://#diff-8129eef35135ad3fe896b38557e8ba673da32528eea344c660b26c5e0e9424d7L122-R125) [[2]](diffhunk://#diff-8129eef35135ad3fe896b38557e8ba673da32528eea344c660b26c5e0e9424d7L170-R174) [[3]](diffhunk://#diff-8129eef35135ad3fe896b38557e8ba673da32528eea344c660b26c5e0e9424d7L216-R217) [[4]](diffhunk://#diff-8129eef35135ad3fe896b38557e8ba673da32528eea344c660b26c5e0e9424d7L263-R263) [[5]](diffhunk://#diff-8129eef35135ad3fe896b38557e8ba673da32528eea344c660b26c5e0e9424d7L345-R355)

**Documentation and Contract Clarification:**

* Expanded and clarified class and field documentation in `JointKFState` to make the state layout and index contract explicit, and to warn against iteration over hash maps for state order. [[1]](diffhunk://#diff-a69b9b4ab9837420039c58a2d663033a974cc76ff9a5de66989918f1720de358L29-R35) [[2]](diffhunk://#diff-a69b9b4ab9837420039c58a2d663033a974cc76ff9a5de66989918f1720de358L45-R70)

These changes collectively improve efficiency, robustness, and clarity in the joint-level Kalman filter state management and related estimator code.