### PR TITLE
Fix the HeightMapCommand to use the unbounded messages that jros2 supports

### DIFF
--- a/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/controllerAPI/command/HeightMapCommand.java
+++ b/ihmc-humanoid-robotics/src/main/java/us/ihmc/humanoidRobotics/communication/controllerAPI/command/HeightMapCommand.java
@@ -8,13 +8,10 @@ import us.ihmc.euclid.tuple2D.Point2D;
 
 public class HeightMapCommand implements Command<HeightMapCommand, HeightMapMessageForController>
 {
-   /* By default, use the capacity defined in HeightMapMessage.msg */
-   private static final int DEFAULT_CAPACITY = new HeightMapMessageForController().getHeights().capacity();
-
    private long sequenceId;
 
    /* List of heights indexed by key. See HeightMapTools for definition of key */
-   private final TFloatArrayList heights = new TFloatArrayList(DEFAULT_CAPACITY);
+   private final TFloatArrayList heights = new TFloatArrayList();
    /* Zero-indexed key corresponding to the center of the height map */
    private int centerIndex;
    /* Number of cells along each axis of the height map */
@@ -27,14 +24,6 @@ public class HeightMapCommand implements Command<HeightMapCommand, HeightMapMess
    private final Point2D gridCenter = new Point2D();
    /* Convenience fields for the height map dimensions */
    private double minX, maxX, minY, maxY;
-
-   public HeightMapCommand()
-   {
-      for (int i = 0; i < DEFAULT_CAPACITY; i++)
-      {
-         heights.add(0.0f);
-      }
-   }
 
    @Override
    public void clear()
@@ -51,11 +40,10 @@ public class HeightMapCommand implements Command<HeightMapCommand, HeightMapMess
       this.mapSize = message.getWidthInMeters();
       this.gridCenter.set(message.getGridCenterX(), message.getGridCenterY());
 
+      heights.resetQuick();
       for (int i = 0; i < message.getHeights().size(); i++)
       {
-         // Calculate cell height
-         float cellHeight = message.getHeights().get(i);
-         heights.set(i, cellHeight);
+         heights.add(message.getHeights().get(i));
       }
 
       updateGridDimensions();

--- a/ihmc-interfaces-jros2/messages/ihmc_interfaces/perception_msgs/msg/HeightMapMessageForController.msg
+++ b/ihmc-interfaces-jros2/messages/ihmc_interfaces/perception_msgs/msg/HeightMapMessageForController.msg
@@ -19,5 +19,5 @@ float64 cell_size_in_meters
 int32 cells_per_axis
 
 # List of heights, which correspond to the list of keys
-float32[<=255000] heights
+float32[] heights
 

--- a/ihmc-interfaces-jros2/src/main/java/perception_msgs/HeightMapMessageForController.java
+++ b/ihmc-interfaces-jros2/src/main/java/perception_msgs/HeightMapMessageForController.java
@@ -33,7 +33,7 @@ float64 cell_size_in_meters
 int32 cells_per_axis
 
 # List of heights, which correspond to the list of keys
-float32[<=255000] heights
+float32[] heights
 
 }</pre>
 */
@@ -74,7 +74,7 @@ public class HeightMapMessageForController implements ROS2Message<HeightMapMessa
    {
       grid_center_x_ = (double) 0.0;
       grid_center_y_ = (double) 0.0;
-      heights_ = new IDLFloatSequence(0, 255000);
+      heights_ = new IDLFloatSequence();
 
    }
 


### PR DESCRIPTION
Exception on develop:
```
java.lang.ArrayIndexOutOfBoundsException: Array index out of range: 0
	at gnu.trove.list.array.TFloatArrayList.set(TFloatArrayList.java:298)
	at us.ihmc.humanoidRobotics.communication.controllerAPI.command.HeightMapCommand.setFromMessage(HeightMapCommand.java:58)
	at us.ihmc.humanoidRobotics.communication.controllerAPI.command.HeightMapCommand.setFromMessage(HeightMapCommand.java:9)
	at us.ihmc.communication.controllerAPI.CommandInputManager.submitMessageInternal(CommandInputManager.java:234)
	at us.ihmc.communication.controllerAPI.CommandInputManager.submitMessage(CommandInputManager.java:187)
	at us.ihmc.commonWalkingControlModules.highLevelHumanoidControl.plugin.StepGeneratorNetworkSubscriber.receivedMessage(StepGeneratorNetworkSubscriber.java:212)
	at us.ihmc.commonWalkingControlModules.highLevelHumanoidControl.plugin.StepGeneratorNetworkSubscriber.lambda$createSubscribersForSupportedMessages$4(StepGeneratorNetworkSubscriber.java:172)
	at us.ihmc.jros2.ROS2Subscription.onDataAvailable(ROS2Subscription.java:254)
```

This needed to be updated to use jros2 where it has the ability to use unbounded messages