### PR TITLE
Add configurable staged falling behavior

### DIFF
--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/controlModules/WalkingFailureDetectionControlModule.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/controlModules/WalkingFailureDetectionControlModule.java
@@ -36,6 +36,7 @@ public class WalkingFailureDetectionControlModule
 
    private final YoBoolean isUsingNextFootstep;
    private final YoBoolean isFallDetectionActivated;
+   private final YoBoolean forceFallingState;
    private final YoDouble icpDistanceFromFootPolygon;
    private final DoubleProvider icpDistanceFromFootPolygonThreshold;
    private final YoBoolean isRobotFalling;
@@ -66,6 +67,8 @@ public class WalkingFailureDetectionControlModule
 
       isFallDetectionActivated = new YoBoolean("isFallDetectionActivated", registry);
       isFallDetectionActivated.set(true);
+
+      forceFallingState = new YoBoolean("forceFallingState", registry);
 
       icpDistanceFromFootPolygonThreshold = new DoubleParameter("icpDistanceFromFootPolygonThreshold", registry, 0.15);
       icpDistanceFromFootPolygon = new YoDouble("icpDistanceFromFootPolygon", registry);
@@ -122,6 +125,10 @@ public class WalkingFailureDetectionControlModule
 
    public void checkIfRobotIsFalling(FramePoint2DReadOnly capturePoint2d, FramePoint2DReadOnly desiredCapturePoint2d)
    {
+      // Consume the UI request so it triggers exactly one state transition.
+      boolean forceFalling = forceFallingState.getBooleanValue();
+      forceFallingState.set(false);
+
       updateCombinedPolygon();
 
       if (isUsingNextFootstep.getBooleanValue())
@@ -133,7 +140,9 @@ public class WalkingFailureDetectionControlModule
       boolean isCapturePointCloseToFootPolygon = icpDistanceFromFootPolygon.getDoubleValue() < icpDistanceFromFootPolygonThreshold.getValue();
       boolean isCapturePointCloseToDesiredCapturePoint = desiredCapturePoint2d.distance(capturePoint2d) < icpDistanceFromFootPolygonThreshold.getValue();
 
-      isRobotFalling.set(fallWasReported.getAndSet(false) || (!isCapturePointCloseToFootPolygon && !isCapturePointCloseToDesiredCapturePoint));
+      boolean detectorReportsFalling = fallWasReported.getAndSet(false)
+                                       || (!isCapturePointCloseToFootPolygon && !isCapturePointCloseToDesiredCapturePoint);
+      isRobotFalling.set(forceFalling || (isFallDetectionActivated.getBooleanValue() && detectorReportsFalling));
 
       if (isRobotFalling.getBooleanValue())
       {
@@ -153,9 +162,6 @@ public class WalkingFailureDetectionControlModule
 
    public boolean isRobotFalling()
    {
-      if (!isFallDetectionActivated.getBooleanValue())
-         return false;
-
       return isRobotFalling.getBooleanValue();
    }
 

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
@@ -49,7 +49,7 @@ public class FallingControllerState extends HighLevelControllerState
    private final double[] capturedJointVelocities;
    private final double[] initialJointStiffnesses;
    private final double[] initialJointDampings;
-   private final boolean[] verticalLoweringJoints;
+   private final boolean[] firstStageJoints;
    private final WholeBodySetpointParameters fallingSetpoints;
 
    public FallingControllerState(CommandInputManager commandInputManager,
@@ -116,10 +116,10 @@ public class FallingControllerState extends HighLevelControllerState
       capturedJointVelocities = new double[controlledJoints.length];
       initialJointStiffnesses = new double[controlledJoints.length];
       initialJointDampings = new double[controlledJoints.length];
-      verticalLoweringJoints = new boolean[controlledJoints.length];
+      firstStageJoints = new boolean[controlledJoints.length];
       for (int i = 0; i < controlledJoints.length; i++)
       {
-         verticalLoweringJoints[i] = isVerticalLoweringJoint(controlledJoints[i].getName());
+         firstStageJoints[i] = isFirstStageJoint(controlledJoints[i].getName());
       }
       this.fallingSetpoints = fallingSetpoints;
       fallingTrialConfiguration.set(FallingTrialConfiguration.DEFAULT);
@@ -263,7 +263,7 @@ public class FallingControllerState extends HighLevelControllerState
             capturedJointVelocities[i] = controlledJoints[i].getQd();
          }
 
-         loweringJointPositions[i] = verticalLoweringJoints[i] ? capturedJointPositions[i] : initialJointPositions[i];
+         loweringJointPositions[i] = firstStageJoints[i] ? capturedJointPositions[i] : initialJointPositions[i];
 
          JointDesiredOutputReadOnly previousJointData = highLevelControllerOutput != null ? highLevelControllerOutput.getJointDesiredOutput(controlledJoints[i]) : null;
          JointDesiredOutputReadOnly fallingJointData = fallingJointSettings.getJointDesiredOutput(controlledJoints[i]);
@@ -312,14 +312,25 @@ public class FallingControllerState extends HighLevelControllerState
       return (1.0 - alpha) * start + alpha * end;
    }
 
-   private static boolean isVerticalLoweringJoint(String jointName)
+   private static boolean isFirstStageJoint(String jointName)
    {
       String lowerCaseJointName = jointName.toLowerCase();
+      return isVerticalLoweringJoint(lowerCaseJointName) || isArmOrHeadJoint(lowerCaseJointName);
+   }
+
+   private static boolean isVerticalLoweringJoint(String lowerCaseJointName)
+   {
       boolean legJoint = lowerCaseJointName.contains("hip") || lowerCaseJointName.contains("knee") || lowerCaseJointName.contains("ankle");
       boolean pitchJoint = lowerCaseJointName.contains("pitch") || lowerCaseJointName.endsWith("_y") || lowerCaseJointName.endsWith("y");
       boolean yawOrRollJoint = lowerCaseJointName.contains("yaw") || lowerCaseJointName.contains("roll") || lowerCaseJointName.endsWith("_x")
                                || lowerCaseJointName.endsWith("_z");
 
       return legJoint && pitchJoint && !yawOrRollJoint;
+   }
+
+   private static boolean isArmOrHeadJoint(String lowerCaseJointName)
+   {
+      return lowerCaseJointName.contains("shoulder") || lowerCaseJointName.contains("elbow") || lowerCaseJointName.contains("wrist")
+             || lowerCaseJointName.contains("neck") || lowerCaseJointName.contains("head");
    }
 }

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
@@ -320,6 +320,16 @@ public class FallingControllerState extends HighLevelControllerState
       return lowLevelOneDoFJointDesiredDataHolder;
    }
 
+   public void setFallingTrialConfiguration(FallingTrialConfiguration fallingTrialConfiguration)
+   {
+      this.fallingTrialConfiguration.set(fallingTrialConfiguration);
+   }
+
+   public FallingTrialConfiguration getFallingTrialConfiguration()
+   {
+      return fallingTrialConfiguration.getEnumValue();
+   }
+
    private double getTotalTransitionDuration()
    {
       return Math.max(1.0e-3, fallTransitionDuration.getDoubleValue());

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
@@ -25,6 +25,7 @@ public class FallingControllerState extends HighLevelControllerState
    private static final HighLevelControllerName controllerState = HighLevelControllerName.FALLING_STATE;
    private final YoDouble fallTransitionDuration;
    private final YoDouble fallVerticalLoweringDuration;
+   private final YoDouble fallArmConfigurationDuration;
    private final YoDouble fallGainInterpolationDuration;
    private final YoDouble fallGainInterpolationAlpha;
    private final YoBoolean fallGainInterpolationActive;
@@ -33,8 +34,10 @@ public class FallingControllerState extends HighLevelControllerState
    private final JointDesiredOutputListReadOnly highLevelControllerOutput;
    private final YoPolynomial trajectory = new YoPolynomial("fallingTrajectory", 4, registry);
    private final YoPolynomial loweringTrajectory = new YoPolynomial("fallingLoweringTrajectory", 4, registry);
+   private final YoPolynomial armConfigurationTrajectory = new YoPolynomial("fallingArmConfigurationTrajectory", 4, registry);
    private final YoDouble fallingLoweringAlpha = new YoDouble("fallingLoweringAlpha", registry);
    private final YoDouble fallingConfigurationAlpha = new YoDouble("fallingConfigurationAlpha", registry);
+   private final YoDouble fallingArmConfigurationAlpha = new YoDouble("fallingArmConfigurationAlpha", registry);
    private final YoEnum<FallingTrajectoryMode> fallingTrajectoryMode = new YoEnum<>("fallingTrajectoryMode", registry, FallingTrajectoryMode.class, false);
    private final YoBoolean enableFallingDampingMode = new YoBoolean("enableFallingDampingMode", registry);
    private final YoBoolean fallingDampingModeActive = new YoBoolean("fallingDampingModeActive", registry);
@@ -49,7 +52,8 @@ public class FallingControllerState extends HighLevelControllerState
    private final double[] capturedJointVelocities;
    private final double[] initialJointStiffnesses;
    private final double[] initialJointDampings;
-   private final boolean[] firstStageJoints;
+   private final boolean[] verticalLoweringJoints;
+   private final boolean[] armOrHeadJoints;
    private final WholeBodySetpointParameters fallingSetpoints;
 
    public FallingControllerState(CommandInputManager commandInputManager,
@@ -101,6 +105,8 @@ public class FallingControllerState extends HighLevelControllerState
       fallTransitionDuration.set(0.75);
       fallVerticalLoweringDuration = new YoDouble("fallVerticalLoweringDuration", registry);
       fallVerticalLoweringDuration.set(0.5);
+      fallArmConfigurationDuration = new YoDouble("fallArmConfigurationDuration", registry);
+      fallArmConfigurationDuration.set(0.25);
       fallGainInterpolationDuration = new YoDouble("fallGainInterpolationDuration", registry);
       fallGainInterpolationDuration.set(0.5);
       fallGainInterpolationAlpha = new YoDouble("fallGainInterpolationAlpha", registry);
@@ -116,10 +122,13 @@ public class FallingControllerState extends HighLevelControllerState
       capturedJointVelocities = new double[controlledJoints.length];
       initialJointStiffnesses = new double[controlledJoints.length];
       initialJointDampings = new double[controlledJoints.length];
-      firstStageJoints = new boolean[controlledJoints.length];
+      verticalLoweringJoints = new boolean[controlledJoints.length];
+      armOrHeadJoints = new boolean[controlledJoints.length];
       for (int i = 0; i < controlledJoints.length; i++)
       {
-         firstStageJoints[i] = isFirstStageJoint(controlledJoints[i].getName());
+         String lowerCaseJointName = controlledJoints[i].getName().toLowerCase();
+         verticalLoweringJoints[i] = isVerticalLoweringJoint(lowerCaseJointName);
+         armOrHeadJoints[i] = isArmOrHeadJoint(lowerCaseJointName);
       }
       this.fallingSetpoints = fallingSetpoints;
       fallingTrialConfiguration.set(FallingTrialConfiguration.DEFAULT);
@@ -139,6 +148,8 @@ public class FallingControllerState extends HighLevelControllerState
       double loweringAlphaVelocity = 0.0;
       double configurationAlphaPosition = 1.0;
       double configurationAlphaVelocity = 0.0;
+      double armConfigurationAlphaPosition = 1.0;
+      double armConfigurationAlphaVelocity = 0.0;
 
       if (useStagedTrajectory && timeInState < loweringDuration)
       {
@@ -168,8 +179,26 @@ public class FallingControllerState extends HighLevelControllerState
          configurationAlphaVelocity = loweringAlphaVelocity;
       }
 
+      if (useStagedTrajectory)
+      {
+         double armConfigurationDuration = getArmConfigurationDuration();
+         if (armConfigurationDuration > 1.0e-3)
+         {
+            double timeInArmConfiguration = MathTools.clamp(timeInState, 0.0, armConfigurationDuration);
+            armConfigurationTrajectory.compute(timeInArmConfiguration);
+            armConfigurationAlphaPosition = armConfigurationTrajectory.getValue();
+            armConfigurationAlphaVelocity = armConfigurationTrajectory.getVelocity();
+         }
+      }
+      else
+      {
+         armConfigurationAlphaPosition = configurationAlphaPosition;
+         armConfigurationAlphaVelocity = configurationAlphaVelocity;
+      }
+
       fallingLoweringAlpha.set(loweringAlphaPosition);
       fallingConfigurationAlpha.set(configurationAlphaPosition);
+      fallingArmConfigurationAlpha.set(armConfigurationAlphaPosition);
 
       for (int i = 0; i < controlledJoints.length; i++)
       {
@@ -187,7 +216,12 @@ public class FallingControllerState extends HighLevelControllerState
             double desiredPosition;
             double desiredVelocity;
 
-            if (useStagedTrajectory && timeInState < loweringDuration)
+            if (useStagedTrajectory && armOrHeadJoints[i])
+            {
+               desiredPosition = interpolate(initialJointPositions[i], capturedJointPositions[i], armConfigurationAlphaPosition);
+               desiredVelocity = armConfigurationAlphaVelocity * (capturedJointPositions[i] - initialJointPositions[i]);
+            }
+            else if (useStagedTrajectory && timeInState < loweringDuration)
             {
                desiredPosition = interpolate(initialJointPositions[i], loweringJointPositions[i], loweringAlphaPosition);
                desiredVelocity = loweringAlphaVelocity * (loweringJointPositions[i] - initialJointPositions[i]);
@@ -234,10 +268,13 @@ public class FallingControllerState extends HighLevelControllerState
       double totalTransitionDuration = getTotalTransitionDuration();
       double loweringDuration = getLoweringDuration();
       double configurationDuration = totalTransitionDuration - loweringDuration;
+      double armConfigurationDuration = getArmConfigurationDuration();
       loweringTrajectory.setCubic(0.0, Math.max(1.0e-3, loweringDuration), 0.0, 0.0, 1.0, 0.0);
       trajectory.setCubic(0.0, Math.max(1.0e-3, configurationDuration), 0.0, 0.0, 1.0, 0.0);
+      armConfigurationTrajectory.setCubic(0.0, Math.max(1.0e-3, armConfigurationDuration), 0.0, 0.0, 1.0, 0.0);
       fallingLoweringAlpha.set(0.0);
       fallingConfigurationAlpha.set(0.0);
+      fallingArmConfigurationAlpha.set(0.0);
       fallingDampingModeActive.set(false);
       fallGainInterpolationActive.set(getPreviousHighLevelControllerName() == HighLevelControllerName.WALKING && highLevelControllerOutput != null);
       fallGainInterpolationAlpha.set(fallGainInterpolationActive.getBooleanValue() ? 0.0 : 1.0);
@@ -263,7 +300,7 @@ public class FallingControllerState extends HighLevelControllerState
             capturedJointVelocities[i] = controlledJoints[i].getQd();
          }
 
-         loweringJointPositions[i] = firstStageJoints[i] ? capturedJointPositions[i] : initialJointPositions[i];
+         loweringJointPositions[i] = verticalLoweringJoints[i] ? capturedJointPositions[i] : initialJointPositions[i];
 
          JointDesiredOutputReadOnly previousJointData = highLevelControllerOutput != null ? highLevelControllerOutput.getJointDesiredOutput(controlledJoints[i]) : null;
          JointDesiredOutputReadOnly fallingJointData = fallingJointSettings.getJointDesiredOutput(controlledJoints[i]);
@@ -293,6 +330,11 @@ public class FallingControllerState extends HighLevelControllerState
       return MathTools.clamp(fallVerticalLoweringDuration.getDoubleValue(), 0.0, getTotalTransitionDuration());
    }
 
+   private double getArmConfigurationDuration()
+   {
+      return MathTools.clamp(fallArmConfigurationDuration.getDoubleValue(), 0.0, getTotalTransitionDuration());
+   }
+
    private boolean isStagedFallingMode()
    {
       return fallingTrajectoryMode.getEnumValue() == FallingTrajectoryMode.LOWER_BODY_PITCH_THEN_CONFIGURATION;
@@ -310,12 +352,6 @@ public class FallingControllerState extends HighLevelControllerState
    private static double interpolate(double start, double end, double alpha)
    {
       return (1.0 - alpha) * start + alpha * end;
-   }
-
-   private static boolean isFirstStageJoint(String jointName)
-   {
-      String lowerCaseJointName = jointName.toLowerCase();
-      return isVerticalLoweringJoint(lowerCaseJointName) || isArmOrHeadJoint(lowerCaseJointName);
    }
 
    private static boolean isVerticalLoweringJoint(String lowerCaseJointName)

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
@@ -16,6 +16,7 @@ import us.ihmc.robotics.trajectories.yoVariables.YoPolynomial;
 import us.ihmc.sensorProcessing.outputData.JointDesiredOutputListReadOnly;
 import us.ihmc.yoVariables.variable.YoBoolean;
 import us.ihmc.yoVariables.variable.YoDouble;
+import us.ihmc.yoVariables.variable.YoEnum;
 
 public class FallingControllerState extends HighLevelControllerState
 {
@@ -26,6 +27,10 @@ public class FallingControllerState extends HighLevelControllerState
    private final YoPolynomial trajectory = new YoPolynomial("fallingTrajectory", 4, registry);
    private final YoBoolean enableFallingDampingMode = new YoBoolean("enableFallingDampingMode", registry);
    private final YoBoolean fallingDampingModeActive = new YoBoolean("fallingDampingModeActive", registry);
+   private final YoEnum<FallingTrialConfiguration> fallingTrialConfiguration = new YoEnum<>("fallingTrialConfiguration",
+                                                                                           registry,
+                                                                                           FallingTrialConfiguration.class,
+                                                                                           false);
 
    private final double[] initialJointPositions;
    private final double[] capturedJointPositions;
@@ -66,6 +71,7 @@ public class FallingControllerState extends HighLevelControllerState
       capturedJointPositions = new double[controlledJoints.length];
       capturedJointVelocities = new double[controlledJoints.length];
       this.fallingSetpoints = fallingSetpoints;
+      fallingTrialConfiguration.set(FallingTrialConfiguration.DEFAULT);
    }
 
    @Override
@@ -107,6 +113,7 @@ public class FallingControllerState extends HighLevelControllerState
    {
       trajectory.setCubic(0.0, fallTransitionDuration.getDoubleValue(), 0.0, 0.0, 1.0, 0.0);
       fallingDampingModeActive.set(false);
+      FallingTrialConfiguration selectedFallingTrialConfiguration = fallingTrialConfiguration.getEnumValue();
 
       for (int i = 0; i < controlledJoints.length; i++)
       {
@@ -114,7 +121,11 @@ public class FallingControllerState extends HighLevelControllerState
 
          if (fallingSetpoints != null)
          {
-            capturedJointPositions[i] = fallingSetpoints.getSetpoint(controlledJoints[i].getName());
+            String jointName = controlledJoints[i].getName();
+            if (fallingSetpoints instanceof FallingSetpointParameters)
+               capturedJointPositions[i] = ((FallingSetpointParameters) fallingSetpoints).getSetpoint(jointName, selectedFallingTrialConfiguration);
+            else
+               capturedJointPositions[i] = fallingSetpoints.getSetpoint(jointName);
             capturedJointVelocities[i] = 0.0;
          }
          else

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
@@ -22,9 +22,14 @@ public class FallingControllerState extends HighLevelControllerState
 {
    private static final HighLevelControllerName controllerState = HighLevelControllerName.FALLING_STATE;
    private final YoDouble fallTransitionDuration;
+   private final YoDouble fallVerticalLoweringDuration;
 
    private final LowLevelOneDoFJointDesiredDataHolder lowLevelOneDoFJointDesiredDataHolder;
    private final YoPolynomial trajectory = new YoPolynomial("fallingTrajectory", 4, registry);
+   private final YoPolynomial loweringTrajectory = new YoPolynomial("fallingLoweringTrajectory", 4, registry);
+   private final YoDouble fallingLoweringAlpha = new YoDouble("fallingLoweringAlpha", registry);
+   private final YoDouble fallingConfigurationAlpha = new YoDouble("fallingConfigurationAlpha", registry);
+   private final YoBoolean enableStagedFallingConfiguration = new YoBoolean("enableStagedFallingConfiguration", registry);
    private final YoBoolean enableFallingDampingMode = new YoBoolean("enableFallingDampingMode", registry);
    private final YoBoolean fallingDampingModeActive = new YoBoolean("fallingDampingModeActive", registry);
    private final YoEnum<FallingTrialConfiguration> fallingTrialConfiguration = new YoEnum<>("fallingTrialConfiguration",
@@ -33,8 +38,10 @@ public class FallingControllerState extends HighLevelControllerState
                                                                                            false);
 
    private final double[] initialJointPositions;
+   private final double[] loweringJointPositions;
    private final double[] capturedJointPositions;
    private final double[] capturedJointVelocities;
+   private final boolean[] verticalLoweringJoints;
    private final WholeBodySetpointParameters fallingSetpoints;
 
    public FallingControllerState(CommandInputManager commandInputManager,
@@ -64,12 +71,21 @@ public class FallingControllerState extends HighLevelControllerState
       super(controllerState, highLevelControllerParameters, controllerToolbox.getControlledOneDoFJoints());
       fallTransitionDuration = new YoDouble("fallTransitionDuration", registry);
       fallTransitionDuration.set(0.5);
+      fallVerticalLoweringDuration = new YoDouble("fallVerticalLoweringDuration", registry);
+      fallVerticalLoweringDuration.set(0.25);
+      enableStagedFallingConfiguration.set(true);
       lowLevelOneDoFJointDesiredDataHolder = new LowLevelOneDoFJointDesiredDataHolder(controlledJoints.length);
       lowLevelOneDoFJointDesiredDataHolder.registerJointsWithEmptyData(controlledJoints);
 
       initialJointPositions = new double[controlledJoints.length];
+      loweringJointPositions = new double[controlledJoints.length];
       capturedJointPositions = new double[controlledJoints.length];
       capturedJointVelocities = new double[controlledJoints.length];
+      verticalLoweringJoints = new boolean[controlledJoints.length];
+      for (int i = 0; i < controlledJoints.length; i++)
+      {
+         verticalLoweringJoints[i] = isVerticalLoweringJoint(controlledJoints[i].getName());
+      }
       this.fallingSetpoints = fallingSetpoints;
       fallingTrialConfiguration.set(FallingTrialConfiguration.DEFAULT);
    }
@@ -77,12 +93,48 @@ public class FallingControllerState extends HighLevelControllerState
    @Override
    public void doAction(double timeInState)
    {
-      double timeInTrajectory = MathTools.clamp(timeInState, 0.0, fallTransitionDuration.getDoubleValue());
-      boolean useDampingMode = enableFallingDampingMode.getBooleanValue() && timeInState >= fallTransitionDuration.getDoubleValue();
+      double totalTransitionDuration = getTotalTransitionDuration();
+      double loweringDuration = getLoweringDuration();
+      double configurationDuration = totalTransitionDuration - loweringDuration;
+      boolean useStagedTrajectory = enableStagedFallingConfiguration.getBooleanValue() && loweringDuration > 1.0e-3 && configurationDuration > 1.0e-3;
+      boolean useDampingMode = enableFallingDampingMode.getBooleanValue() && timeInState >= totalTransitionDuration;
       fallingDampingModeActive.set(useDampingMode);
-      trajectory.compute(timeInTrajectory);
-      double alphaPosition = trajectory.getValue();
-      double alphaVelocity = trajectory.getVelocity();
+
+      double loweringAlphaPosition = 1.0;
+      double loweringAlphaVelocity = 0.0;
+      double configurationAlphaPosition = 1.0;
+      double configurationAlphaVelocity = 0.0;
+
+      if (useStagedTrajectory && timeInState < loweringDuration)
+      {
+         double timeInLowering = MathTools.clamp(timeInState, 0.0, loweringDuration);
+         loweringTrajectory.compute(timeInLowering);
+         loweringAlphaPosition = loweringTrajectory.getValue();
+         loweringAlphaVelocity = loweringTrajectory.getVelocity();
+         configurationAlphaPosition = 0.0;
+         configurationAlphaVelocity = 0.0;
+      }
+      else if (useStagedTrajectory)
+      {
+         double timeInConfiguration = MathTools.clamp(timeInState - loweringDuration, 0.0, configurationDuration);
+         trajectory.compute(timeInConfiguration);
+         loweringAlphaPosition = 1.0;
+         loweringAlphaVelocity = 0.0;
+         configurationAlphaPosition = trajectory.getValue();
+         configurationAlphaVelocity = trajectory.getVelocity();
+      }
+      else
+      {
+         double timeInTrajectory = MathTools.clamp(timeInState, 0.0, totalTransitionDuration);
+         trajectory.compute(timeInTrajectory);
+         loweringAlphaPosition = trajectory.getValue();
+         loweringAlphaVelocity = trajectory.getVelocity();
+         configurationAlphaPosition = loweringAlphaPosition;
+         configurationAlphaVelocity = loweringAlphaVelocity;
+      }
+
+      fallingLoweringAlpha.set(loweringAlphaPosition);
+      fallingConfigurationAlpha.set(configurationAlphaPosition);
 
       for (int i = 0; i < controlledJoints.length; i++)
       {
@@ -97,8 +149,24 @@ public class FallingControllerState extends HighLevelControllerState
          }
          else
          {
-            double desiredPosition = (1.0 - alphaPosition) * initialJointPositions[i] + alphaPosition * capturedJointPositions[i];
-            double desiredVelocity = alphaVelocity * (capturedJointPositions[i] - initialJointPositions[i]);
+            double desiredPosition;
+            double desiredVelocity;
+
+            if (useStagedTrajectory && timeInState < loweringDuration)
+            {
+               desiredPosition = interpolate(initialJointPositions[i], loweringJointPositions[i], loweringAlphaPosition);
+               desiredVelocity = loweringAlphaVelocity * (loweringJointPositions[i] - initialJointPositions[i]);
+            }
+            else if (useStagedTrajectory)
+            {
+               desiredPosition = interpolate(loweringJointPositions[i], capturedJointPositions[i], configurationAlphaPosition);
+               desiredVelocity = configurationAlphaVelocity * (capturedJointPositions[i] - loweringJointPositions[i]);
+            }
+            else
+            {
+               desiredPosition = interpolate(initialJointPositions[i], capturedJointPositions[i], configurationAlphaPosition);
+               desiredVelocity = configurationAlphaVelocity * (capturedJointPositions[i] - initialJointPositions[i]);
+            }
 
             lowLevelJointData.setDesiredPosition(desiredPosition);
             lowLevelJointData.setDesiredVelocity(desiredVelocity);
@@ -111,7 +179,13 @@ public class FallingControllerState extends HighLevelControllerState
    @Override
    public void onEntry()
    {
-      trajectory.setCubic(0.0, fallTransitionDuration.getDoubleValue(), 0.0, 0.0, 1.0, 0.0);
+      double totalTransitionDuration = getTotalTransitionDuration();
+      double loweringDuration = getLoweringDuration();
+      double configurationDuration = totalTransitionDuration - loweringDuration;
+      loweringTrajectory.setCubic(0.0, Math.max(1.0e-3, loweringDuration), 0.0, 0.0, 1.0, 0.0);
+      trajectory.setCubic(0.0, Math.max(1.0e-3, configurationDuration), 0.0, 0.0, 1.0, 0.0);
+      fallingLoweringAlpha.set(0.0);
+      fallingConfigurationAlpha.set(0.0);
       fallingDampingModeActive.set(false);
       FallingTrialConfiguration selectedFallingTrialConfiguration = fallingTrialConfiguration.getEnumValue();
 
@@ -133,6 +207,8 @@ public class FallingControllerState extends HighLevelControllerState
             capturedJointPositions[i] = controlledJoints[i].getQ();
             capturedJointVelocities[i] = controlledJoints[i].getQd();
          }
+
+         loweringJointPositions[i] = verticalLoweringJoints[i] ? capturedJointPositions[i] : initialJointPositions[i];
       }
    }
 
@@ -145,5 +221,31 @@ public class FallingControllerState extends HighLevelControllerState
    public JointDesiredOutputListReadOnly getOutputForLowLevelController()
    {
       return lowLevelOneDoFJointDesiredDataHolder;
+   }
+
+   private double getTotalTransitionDuration()
+   {
+      return Math.max(1.0e-3, fallTransitionDuration.getDoubleValue());
+   }
+
+   private double getLoweringDuration()
+   {
+      return MathTools.clamp(fallVerticalLoweringDuration.getDoubleValue(), 0.0, getTotalTransitionDuration());
+   }
+
+   private static double interpolate(double start, double end, double alpha)
+   {
+      return (1.0 - alpha) * start + alpha * end;
+   }
+
+   private static boolean isVerticalLoweringJoint(String jointName)
+   {
+      String lowerCaseJointName = jointName.toLowerCase();
+      boolean legJoint = lowerCaseJointName.contains("hip") || lowerCaseJointName.contains("knee") || lowerCaseJointName.contains("ankle");
+      boolean pitchJoint = lowerCaseJointName.contains("pitch") || lowerCaseJointName.endsWith("_y") || lowerCaseJointName.endsWith("y");
+      boolean yawOrRollJoint = lowerCaseJointName.contains("yaw") || lowerCaseJointName.contains("roll") || lowerCaseJointName.endsWith("_x")
+                               || lowerCaseJointName.endsWith("_z");
+
+      return legJoint && pitchJoint && !yawOrRollJoint;
    }
 }

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
@@ -9,11 +9,13 @@ import us.ihmc.commonWalkingControlModules.highLevelHumanoidControl.highLevelSta
 import us.ihmc.commons.MathTools;
 import us.ihmc.commonWalkingControlModules.momentumBasedController.HighLevelHumanoidControllerToolbox;
 import us.ihmc.communication.controllerAPI.CommandInputManager;
+import us.ihmc.euclid.tools.EuclidCoreTools;
 import us.ihmc.communication.controllerAPI.StatusMessageOutputManager;
 import us.ihmc.humanoidRobotics.communication.packets.dataobjects.HighLevelControllerName;
 import us.ihmc.sensorProcessing.outputData.JointDesiredOutputBasics;
 import us.ihmc.robotics.trajectories.yoVariables.YoPolynomial;
 import us.ihmc.sensorProcessing.outputData.JointDesiredOutputListReadOnly;
+import us.ihmc.sensorProcessing.outputData.JointDesiredOutputReadOnly;
 import us.ihmc.yoVariables.variable.YoBoolean;
 import us.ihmc.yoVariables.variable.YoDouble;
 import us.ihmc.yoVariables.variable.YoEnum;
@@ -23,8 +25,12 @@ public class FallingControllerState extends HighLevelControllerState
    private static final HighLevelControllerName controllerState = HighLevelControllerName.FALLING_STATE;
    private final YoDouble fallTransitionDuration;
    private final YoDouble fallVerticalLoweringDuration;
+   private final YoDouble fallGainInterpolationDuration;
+   private final YoDouble fallGainInterpolationAlpha;
+   private final YoBoolean fallGainInterpolationActive;
 
    private final LowLevelOneDoFJointDesiredDataHolder lowLevelOneDoFJointDesiredDataHolder;
+   private final JointDesiredOutputListReadOnly highLevelControllerOutput;
    private final YoPolynomial trajectory = new YoPolynomial("fallingTrajectory", 4, registry);
    private final YoPolynomial loweringTrajectory = new YoPolynomial("fallingLoweringTrajectory", 4, registry);
    private final YoDouble fallingLoweringAlpha = new YoDouble("fallingLoweringAlpha", registry);
@@ -41,6 +47,8 @@ public class FallingControllerState extends HighLevelControllerState
    private final double[] loweringJointPositions;
    private final double[] capturedJointPositions;
    private final double[] capturedJointVelocities;
+   private final double[] initialJointStiffnesses;
+   private final double[] initialJointDampings;
    private final boolean[] verticalLoweringJoints;
    private final WholeBodySetpointParameters fallingSetpoints;
 
@@ -57,7 +65,8 @@ public class FallingControllerState extends HighLevelControllerState
            controllerToolbox,
            highLevelControllerParameters,
            walkingControllerParameters,
-           highLevelControllerParameters.getFallingControllerParameters());
+           highLevelControllerParameters.getFallingControllerParameters(),
+           null);
    }
 
    public FallingControllerState(CommandInputManager commandInputManager,
@@ -68,19 +77,45 @@ public class FallingControllerState extends HighLevelControllerState
                                  WalkingControllerParameters walkingControllerParameters,
                                  WholeBodySetpointParameters fallingSetpoints)
    {
+      this(commandInputManager,
+           statusOutputManager,
+           managerFactory,
+           controllerToolbox,
+           highLevelControllerParameters,
+           walkingControllerParameters,
+           fallingSetpoints,
+           null);
+   }
+
+   public FallingControllerState(CommandInputManager commandInputManager,
+                                 StatusMessageOutputManager statusOutputManager,
+                                 HighLevelControlManagerFactory managerFactory,
+                                 HighLevelHumanoidControllerToolbox controllerToolbox,
+                                 HighLevelControllerParameters highLevelControllerParameters,
+                                 WalkingControllerParameters walkingControllerParameters,
+                                 WholeBodySetpointParameters fallingSetpoints,
+                                 JointDesiredOutputListReadOnly highLevelControllerOutput)
+   {
       super(controllerState, highLevelControllerParameters, controllerToolbox.getControlledOneDoFJoints());
       fallTransitionDuration = new YoDouble("fallTransitionDuration", registry);
       fallTransitionDuration.set(0.5);
       fallVerticalLoweringDuration = new YoDouble("fallVerticalLoweringDuration", registry);
       fallVerticalLoweringDuration.set(0.25);
+      fallGainInterpolationDuration = new YoDouble("fallGainInterpolationDuration", registry);
+      fallGainInterpolationDuration.set(0.5);
+      fallGainInterpolationAlpha = new YoDouble("fallGainInterpolationAlpha", registry);
+      fallGainInterpolationActive = new YoBoolean("fallGainInterpolationActive", registry);
       fallingTrajectoryMode.set(FallingTrajectoryMode.LOWER_BODY_PITCH_THEN_CONFIGURATION);
       lowLevelOneDoFJointDesiredDataHolder = new LowLevelOneDoFJointDesiredDataHolder(controlledJoints.length);
       lowLevelOneDoFJointDesiredDataHolder.registerJointsWithEmptyData(controlledJoints);
+      this.highLevelControllerOutput = highLevelControllerOutput;
 
       initialJointPositions = new double[controlledJoints.length];
       loweringJointPositions = new double[controlledJoints.length];
       capturedJointPositions = new double[controlledJoints.length];
       capturedJointVelocities = new double[controlledJoints.length];
+      initialJointStiffnesses = new double[controlledJoints.length];
+      initialJointDampings = new double[controlledJoints.length];
       verticalLoweringJoints = new boolean[controlledJoints.length];
       for (int i = 0; i < controlledJoints.length; i++)
       {
@@ -173,7 +208,24 @@ public class FallingControllerState extends HighLevelControllerState
          }
       }
 
-      lowLevelOneDoFJointDesiredDataHolder.completeWith(getStateSpecificJointSettings());
+      JointDesiredOutputListReadOnly fallingJointSettings = getStateSpecificJointSettings();
+      lowLevelOneDoFJointDesiredDataHolder.completeWith(fallingJointSettings);
+
+      double gainInterpolationAlpha = computeGainInterpolationAlpha(timeInState);
+      fallGainInterpolationAlpha.set(gainInterpolationAlpha);
+      if (fallGainInterpolationActive.getBooleanValue())
+      {
+         for (int i = 0; i < controlledJoints.length; i++)
+         {
+            JointDesiredOutputBasics lowLevelJointData = lowLevelOneDoFJointDesiredDataHolder.getJointDesiredOutput(controlledJoints[i]);
+            JointDesiredOutputReadOnly fallingJointData = fallingJointSettings.getJointDesiredOutput(controlledJoints[i]);
+
+            if (fallingJointData.hasStiffness())
+               lowLevelJointData.setStiffness(EuclidCoreTools.interpolate(initialJointStiffnesses[i], fallingJointData.getStiffness(), gainInterpolationAlpha));
+            if (fallingJointData.hasDamping())
+               lowLevelJointData.setDamping(EuclidCoreTools.interpolate(initialJointDampings[i], fallingJointData.getDamping(), gainInterpolationAlpha));
+         }
+      }
    }
 
    @Override
@@ -187,7 +239,10 @@ public class FallingControllerState extends HighLevelControllerState
       fallingLoweringAlpha.set(0.0);
       fallingConfigurationAlpha.set(0.0);
       fallingDampingModeActive.set(false);
+      fallGainInterpolationActive.set(getPreviousHighLevelControllerName() == HighLevelControllerName.WALKING && highLevelControllerOutput != null);
+      fallGainInterpolationAlpha.set(fallGainInterpolationActive.getBooleanValue() ? 0.0 : 1.0);
       FallingTrialConfiguration selectedFallingTrialConfiguration = fallingTrialConfiguration.getEnumValue();
+      JointDesiredOutputListReadOnly fallingJointSettings = getStateSpecificJointSettings();
 
       for (int i = 0; i < controlledJoints.length; i++)
       {
@@ -209,6 +264,11 @@ public class FallingControllerState extends HighLevelControllerState
          }
 
          loweringJointPositions[i] = verticalLoweringJoints[i] ? capturedJointPositions[i] : initialJointPositions[i];
+
+         JointDesiredOutputReadOnly previousJointData = highLevelControllerOutput != null ? highLevelControllerOutput.getJointDesiredOutput(controlledJoints[i]) : null;
+         JointDesiredOutputReadOnly fallingJointData = fallingJointSettings.getJointDesiredOutput(controlledJoints[i]);
+         initialJointStiffnesses[i] = previousJointData != null && previousJointData.hasStiffness() ? previousJointData.getStiffness() : fallingJointData.getStiffness();
+         initialJointDampings[i] = previousJointData != null && previousJointData.hasDamping() ? previousJointData.getDamping() : fallingJointData.getDamping();
       }
    }
 
@@ -236,6 +296,15 @@ public class FallingControllerState extends HighLevelControllerState
    private boolean isStagedFallingMode()
    {
       return fallingTrajectoryMode.getEnumValue() == FallingTrajectoryMode.LOWER_BODY_PITCH_THEN_CONFIGURATION;
+   }
+
+   private double computeGainInterpolationAlpha(double timeInState)
+   {
+      if (!fallGainInterpolationActive.getBooleanValue())
+         return 1.0;
+
+      double interpolationDuration = fallGainInterpolationDuration.getDoubleValue();
+      return interpolationDuration <= 0.0 ? 1.0 : MathTools.clamp(timeInState / interpolationDuration, 0.0, 1.0);
    }
 
    private static double interpolate(double start, double end, double alpha)

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
@@ -29,7 +29,7 @@ public class FallingControllerState extends HighLevelControllerState
    private final YoPolynomial loweringTrajectory = new YoPolynomial("fallingLoweringTrajectory", 4, registry);
    private final YoDouble fallingLoweringAlpha = new YoDouble("fallingLoweringAlpha", registry);
    private final YoDouble fallingConfigurationAlpha = new YoDouble("fallingConfigurationAlpha", registry);
-   private final YoBoolean enableStagedFallingConfiguration = new YoBoolean("enableStagedFallingConfiguration", registry);
+   private final YoEnum<FallingTrajectoryMode> fallingTrajectoryMode = new YoEnum<>("fallingTrajectoryMode", registry, FallingTrajectoryMode.class, false);
    private final YoBoolean enableFallingDampingMode = new YoBoolean("enableFallingDampingMode", registry);
    private final YoBoolean fallingDampingModeActive = new YoBoolean("fallingDampingModeActive", registry);
    private final YoEnum<FallingTrialConfiguration> fallingTrialConfiguration = new YoEnum<>("fallingTrialConfiguration",
@@ -73,7 +73,7 @@ public class FallingControllerState extends HighLevelControllerState
       fallTransitionDuration.set(0.5);
       fallVerticalLoweringDuration = new YoDouble("fallVerticalLoweringDuration", registry);
       fallVerticalLoweringDuration.set(0.25);
-      enableStagedFallingConfiguration.set(true);
+      fallingTrajectoryMode.set(FallingTrajectoryMode.LOWER_BODY_PITCH_THEN_CONFIGURATION);
       lowLevelOneDoFJointDesiredDataHolder = new LowLevelOneDoFJointDesiredDataHolder(controlledJoints.length);
       lowLevelOneDoFJointDesiredDataHolder.registerJointsWithEmptyData(controlledJoints);
 
@@ -96,7 +96,7 @@ public class FallingControllerState extends HighLevelControllerState
       double totalTransitionDuration = getTotalTransitionDuration();
       double loweringDuration = getLoweringDuration();
       double configurationDuration = totalTransitionDuration - loweringDuration;
-      boolean useStagedTrajectory = enableStagedFallingConfiguration.getBooleanValue() && loweringDuration > 1.0e-3 && configurationDuration > 1.0e-3;
+      boolean useStagedTrajectory = isStagedFallingMode() && loweringDuration > 1.0e-3 && configurationDuration > 1.0e-3;
       boolean useDampingMode = enableFallingDampingMode.getBooleanValue() && timeInState >= totalTransitionDuration;
       fallingDampingModeActive.set(useDampingMode);
 
@@ -231,6 +231,11 @@ public class FallingControllerState extends HighLevelControllerState
    private double getLoweringDuration()
    {
       return MathTools.clamp(fallVerticalLoweringDuration.getDoubleValue(), 0.0, getTotalTransitionDuration());
+   }
+
+   private boolean isStagedFallingMode()
+   {
+      return fallingTrajectoryMode.getEnumValue() == FallingTrajectoryMode.LOWER_BODY_PITCH_THEN_CONFIGURATION;
    }
 
    private static double interpolate(double start, double end, double alpha)

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerState.java
@@ -98,9 +98,9 @@ public class FallingControllerState extends HighLevelControllerState
    {
       super(controllerState, highLevelControllerParameters, controllerToolbox.getControlledOneDoFJoints());
       fallTransitionDuration = new YoDouble("fallTransitionDuration", registry);
-      fallTransitionDuration.set(0.5);
+      fallTransitionDuration.set(0.75);
       fallVerticalLoweringDuration = new YoDouble("fallVerticalLoweringDuration", registry);
-      fallVerticalLoweringDuration.set(0.25);
+      fallVerticalLoweringDuration.set(0.5);
       fallGainInterpolationDuration = new YoDouble("fallGainInterpolationDuration", registry);
       fallGainInterpolationDuration.set(0.5);
       fallGainInterpolationAlpha = new YoDouble("fallGainInterpolationAlpha", registry);

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerStateFactory.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingControllerStateFactory.java
@@ -19,7 +19,9 @@ public class FallingControllerStateFactory implements HighLevelControllerStateFa
                                                              controllerFactoryHelper.getManagerFactory(),
                                                              controllerFactoryHelper.getHighLevelHumanoidControllerToolbox(),
                                                              controllerFactoryHelper.getHighLevelControllerParameters(),
-                                                             controllerFactoryHelper.getWalkingControllerParameters());
+                                                             controllerFactoryHelper.getWalkingControllerParameters(),
+                                                             controllerFactoryHelper.getHighLevelControllerParameters().getFallingControllerParameters(),
+                                                             controllerFactoryHelper.getLowLevelControllerOutput());
       }
 
       return fallingControllerState;

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingSetpointParameters.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingSetpointParameters.java
@@ -1,0 +1,14 @@
+package us.ihmc.commonWalkingControlModules.falling;
+
+import us.ihmc.commonWalkingControlModules.highLevelHumanoidControl.highLevelStates.WholeBodySetpointParameters;
+
+public interface FallingSetpointParameters extends WholeBodySetpointParameters
+{
+   @Override
+   default double getSetpoint(String jointName)
+   {
+      return getSetpoint(jointName, FallingTrialConfiguration.DEFAULT);
+   }
+
+   double getSetpoint(String jointName, FallingTrialConfiguration trialConfiguration);
+}

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingTrajectoryMode.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingTrajectoryMode.java
@@ -1,0 +1,7 @@
+package us.ihmc.commonWalkingControlModules.falling;
+
+public enum FallingTrajectoryMode
+{
+   WHOLE_BODY_TO_CONFIGURATION,
+   LOWER_BODY_PITCH_THEN_CONFIGURATION
+}

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingTrialConfiguration.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingTrialConfiguration.java
@@ -1,0 +1,9 @@
+package us.ihmc.commonWalkingControlModules.falling;
+
+public enum FallingTrialConfiguration
+{
+   DEFAULT,
+   ARMS_CLOSE_CHEST,
+   ARMS_CLOSE_HEAD,
+   ARM_HEAD_ARM_CHEST
+}

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingTrialConfiguration.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/falling/FallingTrialConfiguration.java
@@ -5,5 +5,6 @@ public enum FallingTrialConfiguration
    DEFAULT,
    ARMS_CLOSE_CHEST,
    ARMS_CLOSE_HEAD,
-   ARM_HEAD_ARM_CHEST
+   ARM_HEAD_ARM_CHEST,
+   POLICY_PROTECTIVE
 }

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/factories/ControllerFailedTransitionFactory.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/factories/ControllerFailedTransitionFactory.java
@@ -17,6 +17,7 @@ public class ControllerFailedTransitionFactory implements ControllerStateTransit
 
    private final HighLevelControllerName stateToAttachEnum;
    private final HighLevelControllerName nextStateEnum;
+   private final boolean transitionToFallingWhenSupported;
 
    /**
     * This transition will transition the robot from its current state into another state if the
@@ -27,8 +28,20 @@ public class ControllerFailedTransitionFactory implements ControllerStateTransit
     */
    public ControllerFailedTransitionFactory(HighLevelControllerName stateToAttachEnum, HighLevelControllerName nextStateEnum)
    {
+      this(stateToAttachEnum, nextStateEnum, false);
+   }
+
+   /**
+    * @param transitionToFallingWhenSupported when {@code true}, a controller failure may enter
+    *                                          {@code FALLING_STATE} even while the robot has support.
+    */
+   public ControllerFailedTransitionFactory(HighLevelControllerName stateToAttachEnum,
+                                            HighLevelControllerName nextStateEnum,
+                                            boolean transitionToFallingWhenSupported)
+   {
       this.stateToAttachEnum = stateToAttachEnum;
       this.nextStateEnum = nextStateEnum;
+      this.transitionToFallingWhenSupported = transitionToFallingWhenSupported;
    }
 
    /** {@inheritDoc} */
@@ -44,7 +57,8 @@ public class ControllerFailedTransitionFactory implements ControllerStateTransit
                                                                                                                 .getControllerFailedBoolean(),
                                                                                          () -> controllerFactoryHelper.getHighLevelControllerParameters()
                                                                                                                       .getIsRobotOffSupport(),
-                                                                                         nextStateEnum);
+                                                                                         nextStateEnum,
+                                                                                         transitionToFallingWhenSupported);
       stateTransition = new StateTransition<>(nextStateEnum, stateTransitionCondition);
 
       return stateTransition;

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/factories/HighLevelHumanoidControllerFactory.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/factories/HighLevelHumanoidControllerFactory.java
@@ -364,6 +364,21 @@ public class HighLevelHumanoidControllerFactory implements CloseableAndDisposabl
          stateTransitionFactories.add(new ControllerFailedTransitionFactory(currentControlStateEnum, HighLevelControllerName.FALLING_STATE));
    }
 
+   /**
+    * Adds a controller-failure transition that prefers {@code FALLING_STATE}, including while the
+    * robot is supported. If the falling transition is not selected, the normal fallback remains available.
+    */
+   public void addSupportedControllerFailureTransitionToFalling(HighLevelControllerName currentControlStateEnum,
+                                                                 HighLevelControllerName fallbackControlStateEnum)
+   {
+      stateTransitionFactories.add(new ControllerFailedTransitionFactory(currentControlStateEnum,
+                                                                          HighLevelControllerName.FALLING_STATE,
+                                                                          true));
+
+      if (!fallbackControlStateEnum.equals(HighLevelControllerName.FALLING_STATE))
+         stateTransitionFactories.add(new ControllerFailedTransitionFactory(currentControlStateEnum, fallbackControlStateEnum));
+   }
+
    public List<ControllerStateTransitionFactory<HighLevelControllerName>> getStateTransitionFactories()
    {
       return stateTransitionFactories;

--- a/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/stateTransitions/ControllerFailedTransition.java
+++ b/ihmc-common-walking-control-modules/src/main/java/us/ihmc/commonWalkingControlModules/highLevelHumanoidControl/stateTransitions/ControllerFailedTransition.java
@@ -10,12 +10,22 @@ public class ControllerFailedTransition implements StateTransitionCondition
    private final YoBoolean controllerFailed;
    private final BooleanProvider isRobotOffSupport;
    private final HighLevelControllerName nextStateEnum;
+   private final boolean transitionToFallingWhenSupported;
 
    public ControllerFailedTransition(YoBoolean controllerFailed, BooleanProvider isRobotOffSupport, HighLevelControllerName nextStateEnum)
+   {
+      this(controllerFailed, isRobotOffSupport, nextStateEnum, false);
+   }
+
+   public ControllerFailedTransition(YoBoolean controllerFailed,
+                                     BooleanProvider isRobotOffSupport,
+                                     HighLevelControllerName nextStateEnum,
+                                     boolean transitionToFallingWhenSupported)
    {
       this.controllerFailed = controllerFailed;
       this.isRobotOffSupport = isRobotOffSupport;
       this.nextStateEnum = nextStateEnum;
+      this.transitionToFallingWhenSupported = transitionToFallingWhenSupported;
    }
 
    private boolean pollControllerFailed()
@@ -29,7 +39,7 @@ public class ControllerFailedTransition implements StateTransitionCondition
    public boolean testCondition(double timeInState)
    {
       boolean controllerFailed = this.controllerFailed.getBooleanValue();
-      boolean shouldTransition = (isRobotOffSupport.getValue() && nextStateEnum.equals(HighLevelControllerName.FALLING_STATE)) ||
+      boolean shouldTransition = ((isRobotOffSupport.getValue() || transitionToFallingWhenSupported) && nextStateEnum.equals(HighLevelControllerName.FALLING_STATE)) ||
                                  (!isRobotOffSupport.getValue() && !nextStateEnum.equals(HighLevelControllerName.FALLING_STATE));
 
       if (controllerFailed && shouldTransition)


### PR DESCRIPTION
This PR replace with PR #1435. All the updates from develop was excluded to merge to demo/xtech2026

Add configurable falling behavior through `Falling_State`.
There are two falling behaviors
1. Simple PD control for the joints with designed falling configuration
2. Using a falling policy to rotate robot's body to face the ground for diagonal and side falling

- Adds selectable falling trial configurations and trajectorymodes
- Adds robot-specific falling setpoint parameter support
- Splits the falling behavior motion
- Adds gain interpolation during the transition into the falling configuration
- Exposes the active falling configuration for custom falling controllers
- Extends controller-failure transition to suport routing through a recovery cotroller gbefore entering `FALLING_STATE`.

Falling STate can enter from RL_Control.